### PR TITLE
fix: redirect user after token expiry

### DIFF
--- a/app/src/apis/authApi.ts
+++ b/app/src/apis/authApi.ts
@@ -1,5 +1,5 @@
 import { BACKEND_URL } from '@/constant/index'
-
+import { logout } from '@/utils/navBarUtil'
 export interface IAuthAPI {
   verifyPayloadAndGetToken(payload: any, methodDetails: any): Promise<string>
 }
@@ -19,6 +19,7 @@ export class AuthAPI {
       return true
     } else {
       //return false
+      logout()
       throw new Error(resObj.message)
     }
   }

--- a/app/src/apis/authApi.ts
+++ b/app/src/apis/authApi.ts
@@ -5,7 +5,7 @@ export interface IAuthAPI {
 }
 
 export class AuthAPI {
-  static async veryToken(token: string): Promise<boolean> {
+  static async verifyToken(token: string): Promise<boolean> {
     const response = await fetch(`${BACKEND_URL}/api/auth/token`, {
       method: 'GET',
       headers: {

--- a/app/src/services/authService.ts
+++ b/app/src/services/authService.ts
@@ -16,7 +16,7 @@ export class AuthService {
   static async isAuthenticated(): Promise<boolean> {
     const token = this.getToken()
 
-    if (token !== null) return await AuthAPI.veryToken(token)
+    if (token !== null) return await AuthAPI.verifyToken(token)
 
     return false
   }


### PR DESCRIPTION
# Description

Clears the token, logs the user out from the application and redirects it to /login by calling the logout method.

Fixes #55 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)



# Checklist:

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
