### PR TITLE
fix: merge trigger failing

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "include": ["src/**/*", "prisma/seed.ts"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
     "types": ["vitest/globals"],
@@ -15,7 +16,7 @@
 
     /* Modules */
     "module": "commonjs",
-    "rootDir": "./src",
+    // "rootDir": "./src",
     "outDir": "./dist",
     /* Emit */
     "sourceMap": true,
@@ -31,6 +32,8 @@
     "vitest.config.unit.ts",
     "vitest.config.ts",
     "vitest.e2e.config.ts",
-    "vitest.unit.config.ts"
-  ],
+    "vitest.unit.config.ts",
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
# Description
Specifying rootDir causes the prisma folder to be out of scope for typescript. Hence we specify the include and exclude patterns explicitly

Fixes #141 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
