### PR TITLE
fix: rename tips action button and hide Send tip

### DIFF
--- a/app/src/components/TipsAction.vue
+++ b/app/src/components/TipsAction.vue
@@ -21,7 +21,7 @@
           className="btn btn-primary w-full text-white"
           @click="emits('pushTip', tipAmount)"
         >
-          send To Wallets
+          Send To Wallets
         </button>
         <LoadingButton v-if="sendTipLoading" color="secondary w-full min-w-24" />
         <button
@@ -29,7 +29,7 @@
           className="btn btn-secondary w-full text-white hidden"
           @click="emits('sendTip', tipAmount)"
         >
-          send To CNC Account
+          Send To CNC Account
         </button>
       </div>
     </div>

--- a/app/src/components/TipsAction.vue
+++ b/app/src/components/TipsAction.vue
@@ -29,7 +29,7 @@
           className="btn btn-secondary w-full text-white hidden"
           @click="emits('sendTip', tipAmount)"
         >
-         send To CNC Account 
+          send To CNC Account
         </button>
       </div>
     </div>

--- a/app/src/components/TipsAction.vue
+++ b/app/src/components/TipsAction.vue
@@ -21,15 +21,15 @@
           className="btn btn-primary w-full text-white"
           @click="emits('pushTip', tipAmount)"
         >
-          Push Tips
+          Split to Members Wallets
         </button>
         <LoadingButton v-if="sendTipLoading" color="secondary w-full min-w-24" />
         <button
           v-else
-          className="btn btn-secondary w-full text-white"
+          className="btn btn-secondary w-full text-white hidden"
           @click="emits('sendTip', tipAmount)"
         >
-          Send Tips
+          Split to CNC Account
         </button>
       </div>
     </div>

--- a/app/src/components/TipsAction.vue
+++ b/app/src/components/TipsAction.vue
@@ -21,7 +21,7 @@
           className="btn btn-primary w-full text-white"
           @click="emits('pushTip', tipAmount)"
         >
-          Split to Members Wallets
+          send To Wallets
         </button>
         <LoadingButton v-if="sendTipLoading" color="secondary w-full min-w-24" />
         <button
@@ -29,7 +29,7 @@
           className="btn btn-secondary w-full text-white hidden"
           @click="emits('sendTip', tipAmount)"
         >
-          Split to CNC Account
+         send To CNC Account 
         </button>
       </div>
     </div>


### PR DESCRIPTION
# Description

Need to change naming of the tips action button, and hide the send tip button for now
<img width="1005" alt="image" src="https://github.com/globe-and-citizen/cnc-portal/assets/49224826/a009711d-6c4e-48f4-8750-f2a4b0ad95c3">


Fixes # (#154)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# Checklist:

* **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)