### PR TITLE
feat: set default UI when no teams are present

### DIFF
--- a/app/src/components/AddTeamCard.vue
+++ b/app/src/components/AddTeamCard.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="card bg-green-100 flex justify-center items-center border">
     <div class="card-body flex justify-center items-center">
-      <h1 class="card-title">Add Team</h1>
+      <span class="font-bold">Add Team</span>
 
-      <div class="w-6 h-6 cursor-pointer" @click="emits('openAddTeamModal')">
+      <div class="w-5 h-5 cursor-pointer" @click="emits('openAddTeamModal')">
         <IconPlus />
       </div>
     </div>

--- a/app/src/components/AddTeamCard.vue
+++ b/app/src/components/AddTeamCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card w-80 bg-base-100 flex justify-center items-center">
+  <div class="card bg-green-100 flex justify-center items-center border">
     <div class="card-body flex justify-center items-center">
       <h1 class="card-title">Add Team</h1>
 

--- a/app/src/components/__tests__/AddTeamCard.spec.ts
+++ b/app/src/components/__tests__/AddTeamCard.spec.ts
@@ -13,7 +13,7 @@ describe('AddTeamCard.vue', () => {
   })
   describe('Render', () => {
     it('renders correctly', () => {
-      expect(wrapper.find('h1').text()).toBe('Add Team')
+      expect(wrapper.find('span').text()).toBe('Add Team')
     })
     it('renders icon plus', () => {
       expect(wrapper.findComponent(IconPlus).exists()).toBe(true)

--- a/app/src/views/TeamView.vue
+++ b/app/src/views/TeamView.vue
@@ -15,7 +15,10 @@
           @click="navigateToTeam(team.id)"
         />
         <div class="flex justify-center">
-          <AddTeamCard @openAddTeamModal="showAddTeamModal = !showAddTeamModal" class="w-80" />
+          <AddTeamCard
+            @openAddTeamModal="showAddTeamModal = !showAddTeamModal"
+            class="w-80 text-lg"
+          />
         </div>
       </div>
       <div class="flex flex-col items-center" v-if="teams.length == 0">
@@ -27,7 +30,10 @@
         >
 
         <div class="flex justify-center">
-          <AddTeamCard @openAddTeamModal="showAddTeamModal = !showAddTeamModal" class="w-80 h-20" />
+          <AddTeamCard
+            @openAddTeamModal="showAddTeamModal = !showAddTeamModal"
+            class="w-72 h-16 text-sm"
+          />
         </div>
       </div>
     </div>

--- a/app/src/views/TeamView.vue
+++ b/app/src/views/TeamView.vue
@@ -8,6 +8,7 @@
     <div class="pt-10" v-if="!teamsAreFetching && teams">
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-20" v-if="teams.length != 0">
         <TeamCard
+          data-test="teamcard"
           v-for="team in teams"
           :key="team.id"
           :team="team"

--- a/app/src/views/TeamView.vue
+++ b/app/src/views/TeamView.vue
@@ -17,7 +17,7 @@
         <div class="flex justify-center">
           <AddTeamCard
             @openAddTeamModal="showAddTeamModal = !showAddTeamModal"
-            class="w-80 text-lg"
+            class="w-80 text-xl"
           />
         </div>
       </div>

--- a/app/src/views/TeamView.vue
+++ b/app/src/views/TeamView.vue
@@ -1,10 +1,12 @@
 <template>
-  <div class="min-h-screen flex justify-center">
-    <span v-if="teamsAreFetching" class="loading loading-spinner loading-lg"></span>
+  <div class="min-h-screen flex flex-col items-center">
+    <div>
+      <h2 class="pt-10">Teams</h2>
+    </div>
+    <div v-if="teamsAreFetching" class="loading loading-spinner loading-lg"></div>
 
     <div class="pt-10" v-if="!teamsAreFetching && teams">
-      <h2 class="pl-5">Team</h2>
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-20">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-20" v-if="teams.length != 0">
         <TeamCard
           v-for="team in teams"
           :key="team.id"
@@ -12,19 +14,39 @@
           class="cursor-pointer"
           @click="navigateToTeam(team.id)"
         />
+        <div class="flex justify-center">
+          <AddTeamCard @openAddTeamModal="showAddTeamModal = !showAddTeamModal" class="w-80" />
+        </div>
+      </div>
+      <div class="flex flex-col items-center" v-if="teams.length == 0">
+        <img src="../assets/login-illustration.png" alt="Login illustration" width="300" />
 
-        <AddTeamCard @openAddTeamModal="showAddTeamModal = !showAddTeamModal" />
-        <ModalComponent v-model="showAddTeamModal">
-          <AddTeamForm
-            :isLoading="createTeamFetching"
-            v-model="team"
-            :users="foundUsers"
-            @searchUsers="(input) => searchUsers(input)"
-            @addTeam="executeCreateTeam"
-          />
-        </ModalComponent>
+        <span class="font-bold text-sm text-gray-500 my-4"
+          >You are currently not a part of any team, {{ useUserDataStore().name }}. Create a new
+          team now!</span
+        >
+
+        <div class="flex justify-center">
+          <AddTeamCard @openAddTeamModal="showAddTeamModal = !showAddTeamModal" class="w-80 h-20" />
+        </div>
       </div>
     </div>
+    <div class="flex flex-col items-center pt-10" v-if="teamError">
+      <img src="../assets/login-illustration.png" alt="Login illustration" width="300" />
+
+      <div class="alert alert-warning">
+        We are unable to retrieve your teams. Please try again in some time.
+      </div>
+    </div>
+    <ModalComponent v-model="showAddTeamModal">
+      <AddTeamForm
+        :isLoading="createTeamFetching"
+        v-model="team"
+        :users="foundUsers"
+        @searchUsers="(input) => searchUsers(input)"
+        @addTeam="executeCreateTeam"
+      />
+    </ModalComponent>
   </div>
 </template>
 
@@ -43,6 +65,7 @@ import { logout } from '@/utils/navBarUtil'
 import type { TeamsResponse } from '@/types'
 import AddTeamForm from '@/components/forms/AddTeamForm.vue'
 import ModalComponent from '@/components/ModalComponent.vue'
+import { useUserDataStore } from '@/stores/user'
 const router = useRouter()
 
 const { addSuccessToast } = useToastStore()

--- a/app/src/views/__tests__/TeamView.spec.ts
+++ b/app/src/views/__tests__/TeamView.spec.ts
@@ -1,22 +1,29 @@
-// TeamView.test.ts
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, beforeEach } from 'vitest'
 import { ref } from 'vue'
 import TeamView from '@/views/TeamView.vue'
 
+import { setActivePinia, createPinia } from 'pinia'
+import { useUserDataStore } from '@/stores/user'
+
 describe('TeamView.vue', () => {
   let wrapper: any
 
   beforeEach(() => {
+    setActivePinia(createPinia())
+
     wrapper = mount(TeamView, {
       setup() {
         const teamsAreFetching = ref(false)
-        const teams = ref({
-          teams: []
-        })
+        const teams = ref([])
+        const teamError = ref(null)
+        const showAddTeamModal = ref(false)
         return {
           teamsAreFetching,
-          teams
+          teams,
+          teamError,
+          showAddTeamModal,
+          useUserDataStore
         }
       }
     })
@@ -31,6 +38,21 @@ describe('TeamView.vue', () => {
       wrapper.vm.teamsAreFetching = true
       await wrapper.vm.$nextTick()
       expect(wrapper.find('.loading-spinner').exists()).toBe(true)
+    })
+
+    it('should render message when there are no teams', async () => {
+      wrapper.vm.teams = []
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('span').text()).toContain('You are currently not a part of any team')
+    })
+
+    it('should render error message when there is an error', async () => {
+      wrapper.vm.teamError = 'Unable to fetch teams'
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.alert.alert-warning').exists()).toBe(true)
+      expect(wrapper.find('.alert.alert-warning').text()).toContain(
+        'We are unable to retrieve your teams'
+      )
     })
   })
 })


### PR DESCRIPTION
# Description

Fixes #203 

Solution:

When no teams are present:
![image](https://github.com/globe-and-citizen/cnc-portal/assets/31665486/a70428dc-ad51-49ea-a8c9-0fc951d4a3c1)

When there is a backend error:
![image](https://github.com/globe-and-citizen/cnc-portal/assets/31665486/7efc367e-1b06-4a1c-9101-ba9e8ff98cad)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
