### PR TITLE
feat: implement notifications pagination for frontend

### DIFF
--- a/app/src/components/NavBar.vue
+++ b/app/src/components/NavBar.vue
@@ -44,52 +44,7 @@
         </ul>
       </div>
       <!--Withdraw End-->
-
-      <!--Notification Start-->
-      <div class="dropdown dropdown-end">
-        <div tabindex="0" role="button" class="">
-          <div class="btn btn-ghost btn-circle m-1">
-            <div class="indicator">
-              <IconBell />
-              <span v-if="isUnread" class="badge badge-xs badge-primary indicator-item"></span>
-            </div>
-          </div>
-        </div>
-        <ul
-          tabindex="0"
-          class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-[300px]"
-        >
-          <li v-for="notification in paginatedNotifications" :key="notification.id">
-            <a @click="updateNotification(notification.id)">
-              <div class="notification__body">
-                <span :class="{ 'font-bold': !notification.isRead }">
-                  {{ notification.message }}
-                </span>
-              </div>
-              <!--<div class="notification__footer">{{ notification.author }} {{ notification.createdAt }}</div>-->
-            </a>
-          </li>
-          <!-- Pagination Controls -->
-          <div class="flex justify-between items-center p-2">
-            <button
-              class="btn btn-sm"
-              :class="{ 'cursor-not-allowed': currentPage == 1 }"
-              @click="currentPage > 1 ? currentPage-- : currentPage"
-            >
-              Previous
-            </button>
-            <span>{{ currentPage }} / {{ totalPages }}</span>
-            <button
-              class="btn btn-sm"
-              :class="{ 'cursor-not-allowed': currentPage === totalPages }"
-              @click="currentPage < totalPages ? currentPage++ : currentPage"
-            >
-              Next
-            </button>
-          </div>
-        </ul>
-      </div>
-      <!--Notification End-->
+      <NotificationDropdown />
       <div class="dropdown dropdown-end">
         <div tabindex="0" role="button" class="avatar">
           <div class="w-10 rounded-full flex justify-center">
@@ -125,11 +80,8 @@
 <script setup lang="ts">
 import { logout } from '@/utils/navBarUtil'
 import IconHamburgerMenu from '@/components/icons/IconHamburgerMenu.vue'
-import IconBell from '@/components/icons/IconBell.vue'
 import { NETWORK } from '@/constant/index'
-import { ref, computed, watch } from 'vue'
-import { type NotificationResponse } from '@/types'
-import { useCustomFetch } from '@/composables/useCustomFetch'
+import NotificationDropdown from '@/components/NotificationDropdown.vue'
 const emits = defineEmits(['toggleSideButton', 'toggleEditUserModal', 'withdraw'])
 
 defineProps<{
@@ -137,54 +89,6 @@ defineProps<{
   balanceLoading: boolean
   balance: string
 }>()
-const currentPage = ref(1)
-const itemsPerPage = ref(4)
-const totalPages = ref(0)
-
-const updateEndPoint = ref('')
-
-const {
-  //isFetching: isNotificationsFetching,
-  //error: notificationError,
-  data: notifications,
-  execute: executeFetchNotifications
-} = useCustomFetch<NotificationResponse>('notification').json()
-
-const {
-  //isFetching: isUpdateNotificationsFetching,
-  //error: isUpdateNotificationError,
-  execute: executeUpdateNotifications
-  //data: _notifications
-} = useCustomFetch<NotificationResponse>(updateEndPoint, {
-  immediate: false
-})
-  .put()
-  .json()
-
-watch(notifications, () => {
-  totalPages.value = Math.ceil(notifications.value.data.length / itemsPerPage.value)
-})
-
-const isUnread = computed(() => {
-  const idx = notifications.value?.data.findIndex(
-    (notification: any) => notification.isRead === false
-  )
-  return idx > -1
-})
-
-const updateNotification = async (id: number | string | null) => {
-  updateEndPoint.value = `notification/${id}`
-
-  await executeUpdateNotifications()
-  await executeFetchNotifications()
-}
-
-const paginatedNotifications = computed(() => {
-  if (!notifications.value?.data) return []
-  const start = (currentPage.value - 1) * itemsPerPage.value
-  const end = start + itemsPerPage.value
-  return notifications.value.data.slice(start, end)
-})
 </script>
 
 <style scoped></style>

--- a/app/src/components/NotificationDropdown.vue
+++ b/app/src/components/NotificationDropdown.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="dropdown dropdown-end">
+    <div tabindex="0" role="button" class="">
+      <div class="btn btn-ghost btn-circle m-1">
+        <div class="indicator">
+          <IconBell />
+          <span v-if="isUnread" class="badge badge-xs badge-primary indicator-item"></span>
+        </div>
+      </div>
+    </div>
+    <ul
+      tabindex="0"
+      class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-[300px]"
+    >
+      <li v-for="notification in paginatedNotifications" :key="notification.id">
+        <a @click="updateNotification(notification.id)">
+          <div class="notification__body">
+            <span :class="{ 'font-bold': !notification.isRead }">
+              {{ notification.message }}
+            </span>
+          </div>
+          <!--<div class="notification__footer">{{ notification.author }} {{ notification.createdAt }}</div>-->
+        </a>
+      </li>
+      <!-- Pagination Controls -->
+      <div class="flex justify-between items-center p-2">
+        <button
+          class="btn btn-sm"
+          :class="{ 'cursor-not-allowed': currentPage == 1 }"
+          @click="currentPage > 1 ? currentPage-- : currentPage"
+        >
+          Previous
+        </button>
+        <span>{{ currentPage }} / {{ totalPages }}</span>
+        <button
+          class="btn btn-sm"
+          :class="{ 'cursor-not-allowed': currentPage === totalPages }"
+          @click="currentPage < totalPages ? currentPage++ : currentPage"
+        >
+          Next
+        </button>
+      </div>
+    </ul>
+  </div>
+</template>
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { type NotificationResponse } from '@/types'
+import { useCustomFetch } from '@/composables/useCustomFetch'
+import IconBell from '@/components/icons/IconBell.vue'
+
+const currentPage = ref(1)
+const itemsPerPage = ref(4)
+const totalPages = ref(0)
+
+const updateEndPoint = ref('')
+const {
+  //isFetching: isNotificationsFetching,
+  //error: notificationError,
+  data: notifications,
+  execute: executeFetchNotifications
+} = useCustomFetch<NotificationResponse>('notification').json()
+
+const {
+  //isFetching: isUpdateNotificationsFetching,
+  //error: isUpdateNotificationError,
+  execute: executeUpdateNotifications
+  //data: _notifications
+} = useCustomFetch<NotificationResponse>(updateEndPoint, {
+  immediate: false
+})
+  .put()
+  .json()
+
+watch(notifications, () => {
+  totalPages.value = Math.ceil(notifications.value.data.length / itemsPerPage.value)
+})
+const isUnread = computed(() => {
+  const idx = notifications.value?.data.findIndex(
+    (notification: any) => notification.isRead === false
+  )
+  return idx > -1
+})
+
+const updateNotification = async (id: number | string | null) => {
+  updateEndPoint.value = `notification/${id}`
+
+  await executeUpdateNotifications()
+  await executeFetchNotifications()
+}
+
+const paginatedNotifications = computed(() => {
+  if (!notifications.value?.data) return []
+  const start = (currentPage.value - 1) * itemsPerPage.value
+  const end = start + itemsPerPage.value
+  return notifications.value.data.slice(start, end)
+})
+</script>

--- a/app/src/views/TeamView.vue
+++ b/app/src/views/TeamView.vue
@@ -135,6 +135,11 @@ watch(
   () => {
     if (!createTeamFetching.value && !createTeamError.value && createTeamResponse.value?.ok) {
       addSuccessToast('Team created successfully')
+      team.value = {
+        name: '',
+        description: '',
+        members: []
+      }
       showAddTeamModal.value = false
       executeFetchTeams()
     }


### PR DESCRIPTION
# Description

Fixes #211 
Solution:
    - Added Next and Previous buttons to navigate.
    - Display the current page number and total pages in the dropdown.
    - display a limited number of notifications per page (10).
    
Video Demo: 
https://github.com/globe-and-citizen/cnc-portal/assets/31665486/1390c2ea-6d28-47e7-a38b-7417dcad6f1a


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
