### PR TITLE
feature: add tooltip, copy address, and see in block explorer

### DIFF
--- a/app/src/components/MemberCard.vue
+++ b/app/src/components/MemberCard.vue
@@ -1,18 +1,18 @@
 <template>
-  <div
-    class="collapse bg-base-100"
-    :class="`${member.address != ownerAddress && ownerAddress == useUserDataStore().address ? 'collapse-arrow' : ''}`"
-  >
-    <input
-      type="checkbox"
-      v-if="member.address != ownerAddress && ownerAddress == useUserDataStore().address"
-    />
+  <div class="collapse bg-base-100 collapse-arrow">
+    <input type="checkbox" />
     <div class="collapse-title text-sm font-bold flex px-4">
       <span class="w-1/2">{{ member.name }}</span>
       <span class="w-2/3">{{ member.address }}</span>
     </div>
     <div class="collapse-content">
-      <div class="flex justify-center">
+      <div class="flex justify-center gap-2">
+        <button @click="openExplorer(member.address ?? '')" class="btn btn-primary btn-xs">
+          See in block explorer
+        </button>
+        <button @click="copy(member.address ?? '')" class="btn btn-info btn-xs">
+          {{ copied ? 'Copied!' : 'Copy address' }}
+        </button>
         <button
           v-if="member.address != ownerAddress && ownerAddress == useUserDataStore().address"
           class="btn btn-error btn-xs"
@@ -27,6 +27,10 @@
 <script setup lang="ts">
 import { useUserDataStore } from '@/stores/user'
 import type { MemberInput } from '@/types'
+import { ClipboardDocumentListIcon, ClipboardDocumentCheckIcon } from '@heroicons/vue/24/outline'
+import { useClipboard } from '@vueuse/core'
+import ToolTip from '@/components/ToolTip.vue'
+import { NETWORK } from '@/constant'
 import { ref } from 'vue'
 
 const emits = defineEmits(['deleteMember'])
@@ -36,4 +40,9 @@ const props = defineProps<{
   ownerAddress: String
 }>()
 const member = ref(props.member)
+const { copy, copied, isSupported } = useClipboard()
+
+const openExplorer = (address: string) => {
+  window.open(`${NETWORK.blockExplorerUrl}/address/${address}`, '_blank')
+}
 </script>

--- a/app/src/components/MemberCard.vue
+++ b/app/src/components/MemberCard.vue
@@ -36,9 +36,7 @@
 <script setup lang="ts">
 import { useUserDataStore } from '@/stores/user'
 import type { MemberInput } from '@/types'
-import { ClipboardDocumentListIcon, ClipboardDocumentCheckIcon } from '@heroicons/vue/24/outline'
 import { useClipboard } from '@vueuse/core'
-import ToolTip from '@/components/ToolTip.vue'
 import { NETWORK } from '@/constant'
 import { ref } from 'vue'
 

--- a/app/src/components/MemberCard.vue
+++ b/app/src/components/MemberCard.vue
@@ -15,6 +15,7 @@
           See in block explorer
         </button>
         <button
+          v-if="isSupported"
           @click="copy(member.address ?? '')"
           class="btn btn-info btn-xs"
           data-test="copy-address-button"

--- a/app/src/components/MemberCard.vue
+++ b/app/src/components/MemberCard.vue
@@ -7,15 +7,24 @@
     </div>
     <div class="collapse-content">
       <div class="flex justify-center gap-2">
-        <button @click="openExplorer(member.address ?? '')" class="btn btn-primary btn-xs">
+        <button
+          @click="openExplorer(member.address ?? '')"
+          class="btn btn-primary btn-xs"
+          data-test="show-address-button"
+        >
           See in block explorer
         </button>
-        <button @click="copy(member.address ?? '')" class="btn btn-info btn-xs">
+        <button
+          @click="copy(member.address ?? '')"
+          class="btn btn-info btn-xs"
+          data-test="copy-address-button"
+        >
           {{ copied ? 'Copied!' : 'Copy address' }}
         </button>
         <button
           v-if="member.address != ownerAddress && ownerAddress == useUserDataStore().address"
           class="btn btn-error btn-xs"
+          data-test="delete-member-button"
           @click="emits('deleteMember', member)"
         >
           Delete

--- a/app/src/components/ModalComponent.vue
+++ b/app/src/components/ModalComponent.vue
@@ -4,7 +4,7 @@
     class="modal modal-bottom sm:modal-middle"
     :class="{ 'modal-open': toggleOpen }"
   >
-    <div class="modal-box">
+    <div class="modal-box overflow-y-visible">
       <button class="btn btn-sm absolute right-4 top-4" @click="toggleOpen = false">✕</button>
       <slot></slot>
     </div>

--- a/app/src/components/TeamAccount.vue
+++ b/app/src/components/TeamAccount.vue
@@ -2,12 +2,23 @@
   <div class="stats bg-green-100 flex text-primary-content border-outline">
     <div class="stat flex flex-col justify-center items-center">
       <div class="stat-title">Team balance</div>
-      <span v-if="team.bankAddress">
-        <span
-          class="badge badge-sm"
-          :class="`${team.ownerAddress == useUserDataStore().address ? 'badge-primary' : 'badge-secondary'}`"
-          >{{ team.bankAddress }}</span
-        >
+      <span v-if="team.bankAddress" class="flex gap-2 items-center">
+        <ToolTip content="See address in block explorer">
+          <span
+            class="badge badge-sm cursor-pointer"
+            @click="openExplorer(team.bankAddress)"
+            :class="`${team.ownerAddress == useUserDataStore().address ? 'badge-primary' : 'badge-secondary'}`"
+            >{{ team.bankAddress }}</span
+          >
+        </ToolTip>
+        <ToolTip :content="copied ? 'Copied!' : 'Copy address'">
+          <ClipboardDocumentListIcon
+            v-if="isSupported && !copied"
+            class="size-5 cursor-pointer"
+            @click="copy(team.bankAddress)"
+          />
+          <ClipboardDocumentCheckIcon v-if="copied" class="size-5" />
+        </ToolTip>
       </span>
       <span
         class="loading loading-dots loading-xs"
@@ -61,7 +72,11 @@ import { NETWORK } from '@/constant'
 import { ref } from 'vue'
 import LoadingButton from '@/components/LoadingButton.vue'
 import { useUserDataStore } from '@/stores/user'
+import { ClipboardDocumentListIcon, ClipboardDocumentCheckIcon } from '@heroicons/vue/24/outline'
+import { useClipboard } from '@vueuse/core'
+import ToolTip from '@/components/ToolTip.vue'
 const tipAmount = ref(0)
+const { copy, copied, isSupported } = useClipboard()
 
 defineProps<{
   team: Partial<Team>
@@ -71,4 +86,8 @@ defineProps<{
   balanceLoading: boolean
 }>()
 const emits = defineEmits(['pushTip', 'sendTip', 'deposit', 'transfer'])
+
+const openExplorer = (address: string) => {
+  window.open(`${NETWORK.blockExplorerUrl}/address/${address}`, '_blank')
+}
 </script>

--- a/app/src/components/TeamAccount.vue
+++ b/app/src/components/TeamAccount.vue
@@ -3,15 +3,16 @@
     <div class="stat flex flex-col justify-center items-center">
       <div class="stat-title">Team balance</div>
       <span v-if="team.bankAddress" class="flex gap-2 items-center">
-        <ToolTip content="Click to see address in block explorer">
+        <ToolTip data-test="bank-address-tooltip" content="Click to see address in block explorer">
           <span
             class="badge badge-sm cursor-pointer"
+            data-test="team-bank-address"
             @click="openExplorer(team.bankAddress)"
             :class="`${team.ownerAddress == useUserDataStore().address ? 'badge-primary' : 'badge-secondary'}`"
             >{{ team.bankAddress }}</span
           >
         </ToolTip>
-        <ToolTip :content="copied ? 'Copied!' : 'Copy address'">
+        <ToolTip data-test="copy-address-tooltip" :content="copied ? 'Copied!' : 'Click to copy address'">
           <ClipboardDocumentListIcon
             v-if="isSupported && !copied"
             class="size-5 cursor-pointer"

--- a/app/src/components/TeamAccount.vue
+++ b/app/src/components/TeamAccount.vue
@@ -12,7 +12,10 @@
             >{{ team.bankAddress }}</span
           >
         </ToolTip>
-        <ToolTip data-test="copy-address-tooltip" :content="copied ? 'Copied!' : 'Click to copy address'">
+        <ToolTip
+          data-test="copy-address-tooltip"
+          :content="copied ? 'Copied!' : 'Click to copy address'"
+        >
           <ClipboardDocumentListIcon
             v-if="isSupported && !copied"
             class="size-5 cursor-pointer"

--- a/app/src/components/TeamAccount.vue
+++ b/app/src/components/TeamAccount.vue
@@ -3,7 +3,7 @@
     <div class="stat flex flex-col justify-center items-center">
       <div class="stat-title">Team balance</div>
       <span v-if="team.bankAddress" class="flex gap-2 items-center">
-        <ToolTip content="See address in block explorer">
+        <ToolTip content="Click to see address in block explorer">
           <span
             class="badge badge-sm cursor-pointer"
             @click="openExplorer(team.bankAddress)"

--- a/app/src/components/ToolTip.vue
+++ b/app/src/components/ToolTip.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="tooltip" :data-tip="content">
+    <slot></slot>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  content: string
+}>()
+</script>

--- a/app/src/components/__tests__/MemberCard.spec.ts
+++ b/app/src/components/__tests__/MemberCard.spec.ts
@@ -155,7 +155,7 @@ describe('MemberCard', () => {
 
       mockClipboard.isSupported.value = true
       await wrapper.vm.$nextTick()
-      
+
       const copyButton = wrapper.find('button[data-test="copy-address-button"]')
       await copyButton.trigger('click')
 

--- a/app/src/components/__tests__/MemberCard.spec.ts
+++ b/app/src/components/__tests__/MemberCard.spec.ts
@@ -37,8 +37,8 @@ describe('MemberCard', () => {
         }
       })
 
-      expect(wrapper.find('button').exists()).toBe(true)
-      expect(wrapper.find('button').text()).toBe('Delete')
+      expect(wrapper.find('button[data-test="delete-member-button"]').exists()).toBe(true)
+      expect(wrapper.find('button[data-test="delete-member-button"]').text()).toBe('Delete')
     })
 
     it('does not show delete button if user is not the owner', async () => {
@@ -50,7 +50,7 @@ describe('MemberCard', () => {
         }
       })
 
-      expect(wrapper.find('button').exists()).toBe(false)
+      expect(wrapper.find('button[data-test="delete-member-button"]').exists()).toBe(false)
     })
   })
   describe('Emits', () => {
@@ -62,7 +62,7 @@ describe('MemberCard', () => {
           ownerAddress: '0x4b6Bf5cD91446408290725879F5666dcd9785F62'
         }
       })
-      await wrapper.find('button').trigger('click')
+      await wrapper.find('button[data-test="delete-member-button"]').trigger('click')
 
       expect(wrapper.emitted().deleteMember).toBeTruthy()
       expect(wrapper.emitted().deleteMember[0]).toEqual([{ name: 'John Doe', address: '0x123' }])

--- a/app/src/components/__tests__/TeamAccount.spec.ts
+++ b/app/src/components/__tests__/TeamAccount.spec.ts
@@ -1,12 +1,24 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
 import TeamAccount from '@/components/TeamAccount.vue'
+import { ClipboardDocumentListIcon, ClipboardDocumentCheckIcon } from '@heroicons/vue/24/outline'
 import { NETWORK } from '@/constant'
+import { ref } from 'vue'
 
 vi.mock('@/stores/user', () => ({
   useUserDataStore: vi.fn(() => ({
     address: '0xaFeF48F7718c51fb7C6d1B314B3991D2e1d8421E'
   }))
+}))
+
+const mockCopy = vi.fn()
+const mockClipboard = {
+  copy: mockCopy,
+  copied: ref(false),
+  isSupported: ref(true)
+}
+vi.mock('@vueuse/core', () => ({
+  useClipboard: vi.fn(() => mockClipboard)
 }))
 
 describe('TeamAccount', () => {
@@ -27,6 +39,78 @@ describe('TeamAccount', () => {
     })
   }
   describe('Render', () => {
+    it('should show team bank address with tooltip if bank address exists', () => {
+      const team = { bankAddress: '0x123' }
+      const wrapper = createComponent({
+        team: {
+          ...team
+        }
+      })
+
+      expect(wrapper.find('[data-test="team-bank-address"]').exists()).toBeTruthy()
+      expect(wrapper.find('[data-test="team-bank-address"]').text()).toBe(team.bankAddress)
+
+      // ToolTip
+      const bankAddressTooltip = wrapper
+        .find('[data-test="bank-address-tooltip"]')
+        .findComponent({ name: 'ToolTip' })
+      expect(bankAddressTooltip.exists()).toBeTruthy()
+      expect(bankAddressTooltip.props().content).toBe('Click to see address in block explorer')
+    })
+
+    it('should show copy to clipboard icon with tooltip if bank address exists', () => {
+      const team = { bankAddress: '0x123' }
+      const wrapper = createComponent({
+        team: {
+          ...team
+        }
+      })
+
+      expect(wrapper.findComponent(ClipboardDocumentListIcon).exists()).toBe(true)
+
+      // ToolTip
+      const copyAddressTooltip = wrapper.find('[data-test="copy-address-tooltip"]').findComponent({
+        name: 'ToolTip'
+      })
+      expect(copyAddressTooltip.exists()).toBeTruthy()
+      expect(copyAddressTooltip.props().content).toBe('Click to copy address')
+    })
+
+    it('should not show copy to clipboard icon if copy not supported', async () => {
+      const wrapper = createComponent()
+
+      // mock clipboard
+      mockClipboard.isSupported.value = false
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.findComponent(ClipboardDocumentListIcon).exists()).toBe(false)
+    })
+
+    it('should change the copy icon when copied', async () => {
+      const wrapper = createComponent()
+
+      // mock clipboard
+      mockClipboard.isSupported.value = false
+      mockClipboard.copied.value = true
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.findComponent(ClipboardDocumentCheckIcon).exists()).toBe(true)
+    })
+
+    it('should change tooltip text to be "Copied!" when copied', async () => {
+      const wrapper = createComponent()
+
+      // mock clipboard
+      mockClipboard.isSupported.value = false
+      mockClipboard.copied.value = true
+      await wrapper.vm.$nextTick()
+
+      const copyAddressTooltip = wrapper.find('[data-test="copy-address-tooltip"]').findComponent({
+        name: 'ToolTip'
+      })
+      expect(copyAddressTooltip.props().content).toBe('Copied!')
+    })
+
     it('should display the team balance correctly', () => {
       const wrapper = createComponent()
       expect(wrapper.find('.stat-value').text()).toContain('100')
@@ -86,6 +170,37 @@ describe('TeamAccount', () => {
       await sendButton.trigger('click')
       expect(wrapper.emitted('pushTip')).toBeTruthy()
       expect((wrapper as any).emitted('pushTip')[0]).toEqual(['10'])
+    })
+
+    it('should open block explorer when bank address is clicked', async () => {
+      const team = { bankAddress: '0x123' }
+      const wrapper = createComponent({ team: { ...team } })
+      const bankAddress = wrapper.find('[data-test="team-bank-address"]')
+
+      // mock window.open
+      window.open = vi.fn()
+
+      await bankAddress.trigger('click')
+      expect(window.open).toBeCalledWith(
+        `${NETWORK.blockExplorerUrl}/address/${team.bankAddress}`,
+        '_blank'
+      )
+    })
+
+    it('should copy address to clipboard when copy to clipboard icon button is clicked', async () => {
+      const team = { bankAddress: '0x123' }
+      const wrapper = createComponent({ team: { ...team } })
+
+      // mock clipboard
+      mockClipboard.isSupported.value = true
+      mockClipboard.copied.value = false
+      await wrapper.vm.$nextTick()
+
+      const copyToClipboardIcon = wrapper.findComponent(ClipboardDocumentListIcon)
+
+      await copyToClipboardIcon.trigger('click')
+
+      expect(mockCopy).toBeCalledWith(team.bankAddress)
     })
   })
   describe('Methods', () => {

--- a/app/src/components/__tests__/TestToast.spec.ts
+++ b/app/src/components/__tests__/TestToast.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import Toast from '../TestToast.vue'
 import { ToastType } from '../../types'
 

--- a/app/src/components/forms/EditUserForm.vue
+++ b/app/src/components/forms/EditUserForm.vue
@@ -5,14 +5,18 @@
       <input type="text" class="grow" placeholder="John Doe" v-model="user.name" />
     </label>
     <label class="input input-bordered flex items-center gap-2 input-md input-disabled">
-      <span class="w-24">Wallet Address</span>
-      <input
-        type="text"
-        class="grow"
-        placeholder="Enter wallet address"
-        :value="user.address"
-        readonly
+      <span class="w-24 text-xs">Wallet Address</span>
+      <ToolTip content="Click to see address in block explorer">
+        <div type="text" class="w-full cursor-pointer" @click="openExplorer(user.address)" readonly>
+          {{ user.address }}
+        </div>
+      </ToolTip>
+      <ClipboardDocumentListIcon
+        v-if="isSupported && !copied"
+        class="size-5 cursor-pointer"
+        @click="copy(user.address)"
       />
+      <ClipboardDocumentCheckIcon class="size-5" v-if="copied" />
     </label>
   </div>
   <div class="modal-action justify-center">
@@ -22,7 +26,11 @@
 </template>
 
 <script setup lang="ts">
+import { NETWORK } from '@/constant'
 import LoadingButton from '../LoadingButton.vue'
+import ToolTip from '@/components/ToolTip.vue'
+import { ClipboardDocumentListIcon, ClipboardDocumentCheckIcon } from '@heroicons/vue/24/outline'
+import { useClipboard } from '@vueuse/core'
 const user = defineModel({
   default: {
     name: '',
@@ -34,6 +42,12 @@ defineProps<{
   isLoading: boolean
 }>()
 const emits = defineEmits(['submitEditUser'])
+
+const { copy, copied, isSupported } = useClipboard()
+
+const openExplorer = (address: string) => {
+  window.open(`${NETWORK.blockExplorerUrl}/address/${address}`, '_blank')
+}
 </script>
 
 <style scoped></style>

--- a/app/src/components/forms/EditUserForm.vue
+++ b/app/src/components/forms/EditUserForm.vue
@@ -1,27 +1,52 @@
 <template>
   <div class="flex flex-col gap-5 mt-4">
     <label class="input input-bordered flex items-center gap-2 input-md">
-      <span class="w-24">Name</span>
-      <input type="text" class="grow" placeholder="John Doe" v-model="user.name" />
+      <span class="w-24" data-test="name-label">Name</span>
+      <input
+        type="text"
+        class="grow"
+        data-test="name-input"
+        placeholder="John Doe"
+        v-model="user.name"
+      />
     </label>
     <label class="input input-bordered flex items-center gap-2 input-md input-disabled">
-      <span class="w-24 text-xs">Wallet Address</span>
-      <ToolTip content="Click to see address in block explorer">
-        <div type="text" class="w-full cursor-pointer" @click="openExplorer(user.address)" readonly>
+      <span class="w-24 text-xs" data-test="address-label">Wallet Address</span>
+      <ToolTip data-test="address-tooltip" content="Click to see address in block explorer">
+        <div
+          type="text"
+          class="w-full cursor-pointer"
+          @click="openExplorer(user.address)"
+          data-test="user-address"
+          readonly
+        >
           {{ user.address }}
         </div>
       </ToolTip>
-      <ClipboardDocumentListIcon
-        v-if="isSupported && !copied"
-        class="size-5 cursor-pointer"
-        @click="copy(user.address)"
-      />
-      <ClipboardDocumentCheckIcon class="size-5" v-if="copied" />
+      <ToolTip
+        data-test="copy-address-tooltip"
+        :content="copied ? 'Copied!' : 'Click to copy address'"
+      >
+        <ClipboardDocumentListIcon
+          v-if="isSupported && !copied"
+          data-test="copy-address-icon"
+          class="size-5 cursor-pointer"
+          @click="copy(user.address)"
+        />
+        <ClipboardDocumentCheckIcon class="size-5" v-if="copied" />
+      </ToolTip>
     </label>
   </div>
   <div class="modal-action justify-center">
     <LoadingButton v-if="isLoading" color="primary min-w-24" />
-    <button v-else class="btn btn-primary" @click="emits('submitEditUser')">Save</button>
+    <button
+      v-else
+      class="btn btn-primary"
+      data-test="submit-edit-user"
+      @click="emits('submitEditUser')"
+    >
+      Save
+    </button>
   </div>
 </template>
 

--- a/app/src/components/forms/__tests__/EditUserForm.spec.ts
+++ b/app/src/components/forms/__tests__/EditUserForm.spec.ts
@@ -1,0 +1,96 @@
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import EditUserForm from '@/components/forms/EditUserForm.vue'
+import { ClipboardDocumentListIcon, ClipboardDocumentCheckIcon } from '@heroicons/vue/24/outline'
+import { ref } from 'vue'
+import { NETWORK } from '@/constant'
+
+const mockCopy = vi.fn()
+const mockClipboard = {
+  copy: mockCopy,
+  copied: ref(false),
+  isSupported: ref(true)
+}
+vi.mock('@vueuse/core', () => ({
+  useClipboard: vi.fn(() => mockClipboard)
+}))
+
+describe('EditUserForm', () => {
+  let wrapper: VueWrapper
+  const user = {
+    name: 'John Doe',
+    address: '0x4b6Bf5cD91446408290725879F5666dcd9785F62'
+  }
+
+  beforeEach(() => {
+    wrapper = mount(EditUserForm, {
+      props: {
+        isLoading: false,
+        modelValue: user
+      }
+    })
+  })
+
+  describe('Render', () => {
+    it('renders label and input for name correctly', () => {
+      expect(wrapper.find('span[data-test="name-label"]').text()).toBe('Name')
+      expect(wrapper.find('input[data-test="name-input"]').exists()).toBeTruthy()
+    })
+
+    it('renders label and address with tooltip correctly', () => {
+      expect(wrapper.find('span[data-test="address-label"]').text()).toBe('Wallet Address')
+      expect(wrapper.find('div[data-test="user-address"]').text()).toBe(user.address)
+
+      // Tooltip
+      const addressTooltip = wrapper.find('[data-test="address-tooltip"]').findComponent({
+        name: 'ToolTip'
+      })
+      expect(addressTooltip.props().content).toBe('Click to see address in block explorer')
+    })
+
+    it('renders copy address icon correctly', () => {
+      expect(wrapper.findComponent(ClipboardDocumentListIcon).exists()).toBeTruthy()
+
+      // Tooltip
+      const copyIconTooltip = wrapper.find('[data-test="copy-address-tooltip"]').findComponent({
+        name: 'ToolTip'
+      })
+      expect(copyIconTooltip.props().content).toBe('Click to copy address')
+    })
+
+    it('renders submit button correctly', () => {
+      expect(wrapper.find('button[data-test="submit-edit-user"]').text()).toBe('Save')
+    })
+
+    it('renders loading button if isLoading true', async () => {
+      await wrapper.setProps({ isLoading: true })
+      expect(wrapper.findComponent({ name: 'LoadingButton' }).exists()).toBeTruthy()
+      expect(wrapper.find('button[data-test="submit-edit-user"]').exists()).toBeFalsy()
+    })
+  })
+
+  describe('Emits', () => {
+    it('emits submitEditUser when submit button is clicked', async () => {
+      await wrapper.find('button[data-test="submit-edit-user"]').trigger('click')
+      expect(wrapper.emitted('submitEditUser')).toBeTruthy()
+    })
+
+    it('opens new tab when address is clicked', async () => {
+      // mock window.open
+      window.open = vi.fn()
+
+      await wrapper.find('[data-test="user-address"]').trigger('click')
+
+      expect(window.open).toBeCalledWith(
+        `${NETWORK.blockExplorerUrl}/address/${user.address}`,
+        '_blank'
+      )
+    })
+
+    it('copies address when copy icon is clicked', async () => {
+      await wrapper.findComponent(ClipboardDocumentListIcon).trigger('click')
+
+      expect(mockCopy).toBeCalledWith(user.address)
+    })
+  })
+})

--- a/app/src/components/forms/__tests__/EditUserForm.spec.ts
+++ b/app/src/components/forms/__tests__/EditUserForm.spec.ts
@@ -35,7 +35,9 @@ describe('EditUserForm', () => {
     it('renders label and input for name correctly', () => {
       expect(wrapper.find('span[data-test="name-label"]').text()).toBe('Name')
       expect(wrapper.find('input[data-test="name-input"]').exists()).toBeTruthy()
-      expect(wrapper.find('input[data-test="name-input"]').text()).toBe(user.name)
+      expect(
+        (wrapper.find('input[data-test="name-input"]').element as HTMLInputElement).value
+      ).toBe(user.name)
     })
 
     it('renders label and address with tooltip correctly', () => {
@@ -95,6 +97,11 @@ describe('EditUserForm', () => {
     })
 
     it('copies address when copy icon is clicked', async () => {
+      // mock clipboard
+      mockClipboard.isSupported.value = true
+      mockClipboard.copied.value = false
+      await wrapper.vm.$nextTick()
+
       await wrapper.findComponent(ClipboardDocumentListIcon).trigger('click')
 
       expect(mockCopy).toBeCalledWith(user.address)

--- a/app/src/components/forms/__tests__/EditUserForm.spec.ts
+++ b/app/src/components/forms/__tests__/EditUserForm.spec.ts
@@ -1,7 +1,7 @@
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import EditUserForm from '@/components/forms/EditUserForm.vue'
-import { ClipboardDocumentListIcon, ClipboardDocumentCheckIcon } from '@heroicons/vue/24/outline'
+import { ClipboardDocumentListIcon } from '@heroicons/vue/24/outline'
 import { ref } from 'vue'
 import { NETWORK } from '@/constant'
 

--- a/app/src/components/forms/__tests__/EditUserForm.spec.ts
+++ b/app/src/components/forms/__tests__/EditUserForm.spec.ts
@@ -1,7 +1,7 @@
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import EditUserForm from '@/components/forms/EditUserForm.vue'
-import { ClipboardDocumentListIcon } from '@heroicons/vue/24/outline'
+import { ClipboardDocumentListIcon, ClipboardDocumentCheckIcon } from '@heroicons/vue/24/outline'
 import { ref } from 'vue'
 import { NETWORK } from '@/constant'
 
@@ -35,6 +35,7 @@ describe('EditUserForm', () => {
     it('renders label and input for name correctly', () => {
       expect(wrapper.find('span[data-test="name-label"]').text()).toBe('Name')
       expect(wrapper.find('input[data-test="name-input"]').exists()).toBeTruthy()
+      expect(wrapper.find('input[data-test="name-input"]').text()).toBe(user.name)
     })
 
     it('renders label and address with tooltip correctly', () => {
@@ -56,6 +57,12 @@ describe('EditUserForm', () => {
         name: 'ToolTip'
       })
       expect(copyIconTooltip.props().content).toBe('Click to copy address')
+    })
+
+    it('renders copied icon when copied', async () => {
+      mockClipboard.copied.value = true
+      await wrapper.vm.$nextTick()
+      expect(wrapper.findComponent(ClipboardDocumentCheckIcon).exists()).toBeTruthy()
     })
 
     it('renders submit button correctly', () => {

--- a/app/src/components/forms/__tests__/EditUserForm.spec.ts
+++ b/app/src/components/forms/__tests__/EditUserForm.spec.ts
@@ -1,5 +1,5 @@
-import { mount, type VueWrapper } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
 import EditUserForm from '@/components/forms/EditUserForm.vue'
 import { ClipboardDocumentListIcon, ClipboardDocumentCheckIcon } from '@heroicons/vue/24/outline'
 import { ref } from 'vue'
@@ -16,31 +16,31 @@ vi.mock('@vueuse/core', () => ({
 }))
 
 describe('EditUserForm', () => {
-  let wrapper: VueWrapper
   const user = {
     name: 'John Doe',
     address: '0x4b6Bf5cD91446408290725879F5666dcd9785F62'
   }
 
-  beforeEach(() => {
-    wrapper = mount(EditUserForm, {
+  const createComponent = (props?: any) => {
+    return mount(EditUserForm, {
       props: {
         isLoading: false,
-        modelValue: user
+        modelValue: user,
+        ...props
       }
     })
-  })
+  }
 
   describe('Render', () => {
     it('renders label and input for name correctly', () => {
+      const wrapper = createComponent()
       expect(wrapper.find('span[data-test="name-label"]').text()).toBe('Name')
       expect(wrapper.find('input[data-test="name-input"]').exists()).toBeTruthy()
-      expect(
-        (wrapper.find('input[data-test="name-input"]').element as HTMLInputElement).value
-      ).toBe(user.name)
+      expect(wrapper.props().modelValue.name).toBe(user.name)
     })
 
     it('renders label and address with tooltip correctly', () => {
+      const wrapper = createComponent()
       expect(wrapper.find('span[data-test="address-label"]').text()).toBe('Wallet Address')
       expect(wrapper.find('div[data-test="user-address"]').text()).toBe(user.address)
 
@@ -52,6 +52,7 @@ describe('EditUserForm', () => {
     })
 
     it('renders copy address icon correctly', () => {
+      const wrapper = createComponent()
       expect(wrapper.findComponent(ClipboardDocumentListIcon).exists()).toBeTruthy()
 
       // Tooltip
@@ -62,17 +63,19 @@ describe('EditUserForm', () => {
     })
 
     it('renders copied icon when copied', async () => {
+      const wrapper = createComponent()
       mockClipboard.copied.value = true
       await wrapper.vm.$nextTick()
       expect(wrapper.findComponent(ClipboardDocumentCheckIcon).exists()).toBeTruthy()
     })
 
     it('renders submit button correctly', () => {
+      const wrapper = createComponent()
       expect(wrapper.find('button[data-test="submit-edit-user"]').text()).toBe('Save')
     })
 
     it('renders loading button if isLoading true', async () => {
-      await wrapper.setProps({ isLoading: true })
+      const wrapper = createComponent({ isLoading: true })
       expect(wrapper.findComponent({ name: 'LoadingButton' }).exists()).toBeTruthy()
       expect(wrapper.find('button[data-test="submit-edit-user"]').exists()).toBeFalsy()
     })
@@ -80,11 +83,14 @@ describe('EditUserForm', () => {
 
   describe('Emits', () => {
     it('emits submitEditUser when submit button is clicked', async () => {
+      const wrapper = createComponent()
       await wrapper.find('button[data-test="submit-edit-user"]').trigger('click')
       expect(wrapper.emitted('submitEditUser')).toBeTruthy()
     })
 
     it('opens new tab when address is clicked', async () => {
+      const wrapper = createComponent()
+
       // mock window.open
       window.open = vi.fn()
 
@@ -97,6 +103,8 @@ describe('EditUserForm', () => {
     })
 
     it('copies address when copy icon is clicked', async () => {
+      const wrapper = createComponent()
+
       // mock clipboard
       mockClipboard.isSupported.value = true
       mockClipboard.copied.value = false

--- a/app/src/types/proposal.ts
+++ b/app/src/types/proposal.ts
@@ -1,5 +1,3 @@
-import type { User } from './user'
-
 export interface Proposal {
   id: string
   title: string


### PR DESCRIPTION
# Description

Add tooltip and copy address feature

https://www.loom.com/share/e2898110f0ab44889c2a8b59cf47983e?sid=8630765f-1fc4-4576-a184-aca1bac9a086

Fixes # (#243)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


# Checklist:

* **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)