### PR TITLE
fix: show pagination controls only when there is a notification

### DIFF
--- a/app/src/components/NotificationDropdown.vue
+++ b/app/src/components/NotificationDropdown.vue
@@ -26,7 +26,10 @@
         </a>
       </li>
       <!-- Pagination Controls -->
-      <div class="join flex justify-between items-center p-2">
+      <div
+        class="join flex justify-between items-center p-2"
+        v-if="paginatedNotifications.length > 0"
+      >
         <button
           class="join-item btn-primary btn btn-xs"
           :class="currentPage === 1 ? 'btn-disabled' : ''"

--- a/app/src/components/__tests__/NotificationDropdown.spec.ts
+++ b/app/src/components/__tests__/NotificationDropdown.spec.ts
@@ -1,14 +1,47 @@
-// tests/components/NotificationDropdown.spec.ts
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import NotificationDropdown from '@/components/NotificationDropdown.vue'
-
+import { ref } from 'vue'
 // Mock data
+const mockNotifications = [
+  {
+    id: '1',
+    message: 'Notification 1',
+    isRead: false,
+    resource: 'teams/1',
+    author: 'Author 1',
+    createdAt: '2024-07-01'
+  },
+  {
+    id: '2',
+    message: 'Notification 2',
+    isRead: true,
+    resource: 'teams/2',
+    author: 'Author 2',
+    createdAt: '2024-07-02'
+  }
+  // Add more mock notifications as needed
+]
 
 describe('NotificationDropdown.vue', () => {
   let wrapper: ReturnType<typeof mount>
 
   beforeEach(() => {
+    // Mock the fetch function to return the mock notifications
+    vi.mock('@/composables/useCustomFetch', () => ({
+      useCustomFetch: () => ({
+        json: () => ({
+          data: ref({ data: mockNotifications }),
+          execute: vi.fn()
+        }),
+        put: () => ({
+          json: () => ({
+            execute: vi.fn()
+          })
+        })
+      })
+    }))
+
     wrapper = mount(NotificationDropdown, {
       props: {}
     })
@@ -17,5 +50,18 @@ describe('NotificationDropdown.vue', () => {
   it('renders correctly and displays the dropdown button', () => {
     const button = wrapper.find('div[role="button"]')
     expect(button.exists()).toBe(true)
+  })
+
+  it('renders the notifications list', async () => {
+    // Force an update to apply mock data
+    await wrapper.vm.$nextTick()
+    const notifications = wrapper.findAll('.notification__body')
+    expect(notifications.length).toBe(mockNotifications.length)
+  })
+
+  it('shows the badge when there are unread notifications', async () => {
+    await wrapper.vm.$nextTick()
+    const badge = wrapper.find('.badge')
+    expect(badge.exists()).toBe(true)
   })
 })

--- a/app/src/components/__tests__/NotificationDropdown.spec.ts
+++ b/app/src/components/__tests__/NotificationDropdown.spec.ts
@@ -1,0 +1,21 @@
+// tests/components/NotificationDropdown.spec.ts
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import NotificationDropdown from '@/components/NotificationDropdown.vue'
+
+// Mock data
+
+describe('NotificationDropdown.vue', () => {
+  let wrapper: ReturnType<typeof mount>
+
+  beforeEach(() => {
+    wrapper = mount(NotificationDropdown, {
+      props: {}
+    })
+  })
+
+  it('renders correctly and displays the dropdown button', () => {
+    const button = wrapper.find('div[role="button"]')
+    expect(button.exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
# Description

Fixes #272 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)



# Checklist:

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
