### PR TITLE
fix: cannot add member if the user has no name

### DIFF
--- a/app/src/components/sections/SingleTeamView/forms/AddMemberForm.vue
+++ b/app/src/components/sections/SingleTeamView/forms/AddMemberForm.vue
@@ -121,7 +121,7 @@ const rules = {
     $valid: helpers.withMessage(
       'At least one member is required',
       (value: Array<{ name: string; address: string }>) => {
-        return value.some((v) => v.name && v.address)
+        return value.some((v) => v.address)
       }
     )
   }


### PR DESCRIPTION
# Description

cannot add member if the user has no name

Fixes # (#376)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# Checklist:

* **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)