### PR TITLE
fix: update contract deployment status and hide buttons after deployment

### DIFF
--- a/app/src/components/forms/OfficerForm.vue
+++ b/app/src/components/forms/OfficerForm.vue
@@ -352,14 +352,14 @@ watch(officerTeam, async (value) => {
         await useCustomFetch<string>(`teams/${props.team.id}`)
           .put({ votingAddress: team.votingAddress })
           .json()
+        if (props.team.boardOfDirectorsAddress != team.bodAddress && isBoDDeployed.value) {
+          await useCustomFetch<string>(`teams/${props.team.id}`)
+            .put({ boardOfDirectorsAddress: team.bodAddress })
+            .json()
+        }
         emits('getTeam')
       }
-      if (props.team.boardOfDirectorsAddress != team.bodAddress && isBoDDeployed.value) {
-        await useCustomFetch<string>(`teams/${props.team.id}`)
-          .put({ boardOfDirectorsAddress: team.bodAddress })
-          .json()
-        emits('getTeam')
-      }
+
       if (
         props.team.expenseAccountAddress != team.expenseAccountAddress &&
         team.expenseAccountAddress != ethers.ZeroAddress
@@ -406,6 +406,7 @@ onMounted(() => {
       bodAddress: temp[4] as string,
       expenseAccountAddress: temp[5] as string
     }
+    console.log(team)
     if (team) {
       if (team.founders?.length === 0) {
         showCreateTeam.value = true

--- a/app/src/components/forms/OfficerForm.vue
+++ b/app/src/components/forms/OfficerForm.vue
@@ -6,6 +6,7 @@
     <div class="flex items-center justify-center mt-4">
       <button
         class="btn btn-primary btn-sm"
+        data-test="deploy-officer-button"
         v-if="!team?.officerAddress && !createOfficerLoading"
         @click="deployOfficerContract"
       >
@@ -27,8 +28,12 @@
           <div v-if="!showCreateTeam && !isLoadingGetTeam">
             <div class="flex flex-col">
               <h5 class="text-md font-bold">Founders</h5>
-              <div v-for="(founderAddress, index) in founders" :key="index">
-                <span v-if="team && team.members" class="badge badge-primary badge-sm">
+              <div v-for="(founderAddress, index) in founders" data-test="founder-div" :key="index">
+                <span
+                  v-if="team && team.members"
+                  data-test="founder"
+                  class="badge badge-primary badge-sm"
+                >
                   {{
                     team.members.find((member: Member) => member.address == founderAddress)?.name ||
                     'Unknown Member'
@@ -39,8 +44,12 @@
             </div>
             <div class="flex flex-col">
               <h5 class="text-md font-bold">Members</h5>
-              <div v-for="(memberAddress, index) in members" :key="index">
-                <span v-if="team && team.members" class="badge badge-secondary badge-sm">
+              <div v-for="(memberAddress, index) in members" data-test="member-div" :key="index">
+                <span
+                  v-if="team && team.members"
+                  data-test="member"
+                  class="badge badge-secondary badge-sm"
+                >
                   {{
                     team.members.find((member: Member) => member.address == memberAddress)?.name ||
                     'Unknown Member'
@@ -52,22 +61,38 @@
             <div class="flex flex-col">
               <h5 class="text-md font-bold">Deployments</h5>
               <div>
-                <span v-if="isBankDeployed" class="badge badge-primary badge-sm">
+                <span
+                  data-test="bank-address"
+                  v-if="isBankDeployed"
+                  class="badge badge-primary badge-sm"
+                >
                   Bank deployed at: {{ team?.bankAddress }}
                 </span>
               </div>
               <div>
-                <span v-if="isVotingDeployed" class="badge badge-primary badge-sm">
+                <span
+                  data-test="voting-address"
+                  v-if="isVotingDeployed"
+                  class="badge badge-primary badge-sm"
+                >
                   Voting deployed at: {{ team?.votingAddress }}
                 </span>
               </div>
               <div>
-                <span v-if="isBoDDeployed" class="badge badge-primary badge-sm">
+                <span
+                  data-test="bod-address"
+                  v-if="isBoDDeployed"
+                  class="badge badge-primary badge-sm"
+                >
                   BoD deployed at: {{ team?.boardOfDirectorsAddress }}
                 </span>
               </div>
               <div>
-                <span v-if="isExpenseDeployed" class="badge badge-primary badge-sm">
+                <span
+                  data-test="expense-address"
+                  v-if="isExpenseDeployed"
+                  class="badge badge-primary badge-sm"
+                >
                   Expense deployed at: {{ team?.expenseAccountAddress }}
                 </span>
               </div>
@@ -83,6 +108,7 @@
               </button>
               <LoadingButton
                 :color="'primary min-w-24'"
+                data-test="loading-deploy-bank"
                 v-if="isLoadingDeployBank || isConfirmingDeployBank"
               />
               <button
@@ -95,6 +121,7 @@
               </button>
               <LoadingButton
                 :color="'primary min-w-24'"
+                data-test="loading-deploy-expense"
                 v-if="isLoadingDeployExpense || isConfirmingDeployExpense"
               />
               <button
@@ -107,6 +134,7 @@
               </button>
               <LoadingButton
                 :color="'primary min-w-24'"
+                data-test="loading-deploy-voting"
                 v-if="isLoadingDeployVoting || isConfirmingDeployVoting"
               />
             </div>
@@ -229,7 +257,6 @@ const createOfficerLoading = computed(
 
 watch(createOfficerError, (value) => {
   if (value) {
-    console.error(value)
     loading.value = false
     addErrorToast('Failed to deploy officer contract')
   }
@@ -259,7 +286,6 @@ useWatchContractEvent({
         emits('getTeam')
         loading.value = false
       } catch (error) {
-        console.error(error)
         addErrorToast('Error updating officer address')
         loading.value = false
       }
@@ -290,7 +316,6 @@ const deployOfficerContract = async () => {
       args: [encodedFunction]
     })
   } catch (error) {
-    console.error(error)
     loading.value = false
     addErrorToast('Error deploying contract')
   }
@@ -367,7 +392,6 @@ watch(officerTeam, async (value) => {
         props.team.expenseAccountAddress != team.expenseAccountAddress &&
         team.expenseAccountAddress != ethers.ZeroAddress
       ) {
-        console.log('updating expense account')
         await useCustomFetch<string>(`teams/${props.team.id}`)
           .put({ expenseAccountAddress: team.expenseAccountAddress })
           .json()
@@ -409,7 +433,6 @@ onMounted(() => {
       bodAddress: temp[4] as string,
       expenseAccountAddress: temp[5] as string
     }
-    console.log(team)
     if (team) {
       if (team.founders?.length === 0) {
         showCreateTeam.value = true

--- a/app/src/components/forms/OfficerForm.vue
+++ b/app/src/components/forms/OfficerForm.vue
@@ -396,5 +396,29 @@ onMounted(() => {
   if (props.team.officerAddress) {
     fetchOfficerTeam()
   }
+  if (officerTeam.value) {
+    const temp: Array<Object> = officerTeam.value as unknown as Array<Object>
+    const team = {
+      founders: temp[0] as string[],
+      members: temp[1] as string[],
+      bankAddress: temp[2] as string,
+      votingAddress: temp[3] as string,
+      bodAddress: temp[4] as string,
+      expenseAccountAddress: temp[5] as string
+    }
+    if (team) {
+      if (team.founders?.length === 0) {
+        showCreateTeam.value = true
+      } else {
+        showCreateTeam.value = false
+        founders.value = team.founders
+        members.value = team.members
+        isBankDeployed.value = team.bankAddress != ethers.ZeroAddress
+        isVotingDeployed.value = team.votingAddress != ethers.ZeroAddress
+        isBoDDeployed.value = team.bodAddress != ethers.ZeroAddress
+        isExpenseDeployed.value = team.expenseAccountAddress != ethers.ZeroAddress
+      }
+    }
+  }
 })
 </script>

--- a/app/src/components/forms/OfficerForm.vue
+++ b/app/src/components/forms/OfficerForm.vue
@@ -77,6 +77,7 @@
                 class="btn btn-primary btn-sm"
                 v-if="!isBankDeployed && !isLoadingDeployBank && !isConfirmingDeployBank"
                 @click="deployBankAccount"
+                data-test="deployBankButton"
               >
                 Deploy Bank
               </button>
@@ -88,6 +89,7 @@
                 class="btn btn-primary btn-sm"
                 v-if="!isExpenseDeployed && !isLoadingDeployExpense && !isConfirmingDeployExpense"
                 @click="deployExpenseAccount"
+                data-test="deployExpenseButton"
               >
                 Deploy Expense
               </button>
@@ -99,6 +101,7 @@
                 class="btn btn-primary btn-sm"
                 v-if="!isVotingDeployed && !isLoadingDeployVoting && !isConfirmingDeployVoting"
                 @click="deployVotingContract"
+                data-test="deployVotingButton"
               >
                 Deploy Voting
               </button>

--- a/app/src/components/forms/__tests__/OfficerForm.spec.ts
+++ b/app/src/components/forms/__tests__/OfficerForm.spec.ts
@@ -1,7 +1,8 @@
 import { mount, VueWrapper } from '@vue/test-utils'
 import OfficerForm from '@/components/forms/OfficerForm.vue'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
+import { ethers } from 'ethers'
 
 // Mock the composables
 
@@ -103,5 +104,49 @@ describe('OfficerForm.vue', () => {
 
     expect(wrapper.findAll('.badge-primary').length).toBe(1)
     expect(wrapper.findAll('.badge-primary')[0].text()).toContain('0x1')
+  })
+  describe('OfficerForm.vue - Additional Tests', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    it('renders loading spinner when data is being fetched', () => {
+      mockUseReadContract.isLoading.value = true
+      const wrapper: VueWrapper = mount(OfficerForm, {
+        props: {
+          team: { officerAddress: '0x123' }
+        }
+      })
+
+      expect(wrapper.find('.loading-spinner').exists()).toBe(true)
+    })
+
+    it('hides Deploy Bank button when bank is deployed', () => {
+      const wrapper: VueWrapper = mount(OfficerForm, {
+        props: {
+          team: {
+            officerAddress: '0x123',
+            bankAddress: '0xBank'
+          }
+        }
+      })
+
+      const deployBankButton = wrapper.find('[data-test="deployBankButton"]')
+      expect(deployBankButton.exists()).toBe(false)
+    })
+
+    it('hides Deploy Expense button when expense is deployed', () => {
+      const wrapper: VueWrapper = mount(OfficerForm, {
+        props: {
+          team: {
+            officerAddress: '0x123',
+            expenseAccountAddress: '0xExpense'
+          }
+        }
+      })
+
+      const deployExpenseButton = wrapper.find('[data-test="deployExpenseButton"]')
+      expect(deployExpenseButton.exists()).toBe(false)
+    })
   })
 })

--- a/app/src/components/forms/__tests__/OfficerForm.spec.ts
+++ b/app/src/components/forms/__tests__/OfficerForm.spec.ts
@@ -46,6 +46,14 @@ const mockUseBalance = {
   error: ref(null),
   refetch: vi.fn()
 }
+const mockOfficerTeamData = ref(null)
+
+vi.mock('@wagmi/vue', () => ({
+  useReadContract: vi.fn(() => ({
+    data: mockOfficerTeamData,
+    isLoading: ref(false)
+  }))
+}))
 vi.mock('@wagmi/vue', async (importOriginal) => {
   const actual: Object = await importOriginal()
   return {
@@ -78,5 +86,22 @@ describe('OfficerForm.vue', () => {
     })
 
     expect(wrapper.find('.badge-primary').text()).toContain('0x123')
+  })
+  it('renders members and founders correctly', () => {
+    const wrapper: VueWrapper = mount(OfficerForm, {
+      props: {
+        team: {
+          officerAddress: '0x123',
+          members: [
+            { address: '0x1', name: 'Member 1' },
+            { address: '0x2', name: 'Member 2' }
+          ],
+          founders: ['0x1', '0x2']
+        }
+      }
+    })
+
+    expect(wrapper.findAll('.badge-primary').length).toBe(1)
+    expect(wrapper.findAll('.badge-primary')[0].text()).toContain('0x1')
   })
 })

--- a/app/src/components/forms/__tests__/OfficerForm.spec.ts
+++ b/app/src/components/forms/__tests__/OfficerForm.spec.ts
@@ -2,20 +2,17 @@ import { mount, VueWrapper } from '@vue/test-utils'
 import OfficerForm from '@/components/forms/OfficerForm.vue'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
+import CreateOfficerTeam from '../CreateOfficerTeam.vue'
+import LoadingButton from '@/components/LoadingButton.vue'
+import type { Team } from '@/types'
+import { useToastStore } from '@/stores/__mocks__/useToastStore'
 
 // Mock the composables
 
-vi.mock('@/stores/useToastStore', () => {
-  return {
-    useToastStore: vi.fn(() => ({
-      addSuccessToast: vi.fn(),
-      addErrorToast: vi.fn()
-    }))
-  }
-})
+vi.mock('@/stores/useToastStore')
 
 const mockUseReadContract = {
-  data: ref<string | null>(null),
+  data: ref<unknown | null>(null),
   isLoading: ref(false),
   error: ref(null),
   refetch: vi.fn()
@@ -25,7 +22,7 @@ const mockUseWatchContractEvent = {
 }
 const mockUseWriteContract = {
   writeContract: vi.fn(),
-  error: ref(null),
+  error: ref<unknown>(null),
   isPending: ref(false),
   data: ref(null)
 }
@@ -67,6 +64,10 @@ vi.mock('@wagmi/vue', async (importOriginal) => {
   }
 })
 
+interface Props {
+  team: Partial<Team>
+}
+
 describe('OfficerForm.vue', () => {
   it('renders officer deployment button when no officer contract is deployed', () => {
     const wrapper: VueWrapper = mount(OfficerForm, {
@@ -87,6 +88,22 @@ describe('OfficerForm.vue', () => {
 
     expect(wrapper.find('.badge-primary').text()).toContain('0x123')
   })
+
+  it('renders CreateOfficerTeam', async () => {
+    const wrapper: VueWrapper = mount(OfficerForm, {
+      props: {
+        team: { officerAddress: '0x123' }
+      }
+    })
+    mockUseReadContract.data.value = [[]]
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.findComponent(CreateOfficerTeam).exists()).toBeTruthy()
+    wrapper.findComponent(CreateOfficerTeam).vm.$emit('getTeam')
+
+    expect(wrapper.emitted('getTeam')).toBeTruthy()
+  })
+
   it('renders members and founders correctly', () => {
     const wrapper: VueWrapper = mount(OfficerForm, {
       props: {
@@ -104,6 +121,102 @@ describe('OfficerForm.vue', () => {
     expect(wrapper.findAll('.badge-primary').length).toBe(1)
     expect(wrapper.findAll('.badge-primary')[0].text()).toContain('0x1')
   })
+
+  it('renders all founders', async () => {
+    const wrapper: VueWrapper = mount(OfficerForm, {
+      props: {
+        team: {
+          officerAddress: '0x123',
+          members: [
+            { address: '0x1', name: 'Member 1' },
+            { address: '0x2', name: 'Member 2' }
+          ]
+        }
+      }
+    })
+    mockUseReadContract.data.value = [['0x1', '0x2', '0x3']]
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.findAll('div[data-test="founder-div"]').length).toBe(3)
+
+    const founders = wrapper.findAll('span[data-test="founder"]')
+    founders.forEach((founder, index) => {
+      if ((wrapper.vm.$props as Props)?.team?.members?.[index]) {
+        expect(founder.text()).toEqual(
+          `${(wrapper.vm.$props as unknown as Props).team.members?.[index]?.name ?? 'Unknown'} | ${(wrapper.vm.$props as unknown as Props).team.members?.[index]?.address ?? 'Unknown'}`
+        )
+      } else {
+        expect(founder.text()).toEqual('Unknown Member | 0x3')
+      }
+    })
+  })
+
+  it('renders all members', async () => {
+    const wrapper: VueWrapper = mount(OfficerForm, {
+      props: {
+        team: {
+          officerAddress: '0x123',
+          members: [
+            { address: '0x1', name: 'Member 1' },
+            { address: '0x2', name: 'Member 2' }
+          ]
+        }
+      }
+    })
+    mockUseReadContract.data.value = [['0xfounder'], ['0x1', '0x2', '0x3']]
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.findAll('div[data-test="member-div"]').length).toBe(3)
+
+    const members = wrapper.findAll('span[data-test="member"]')
+    members.forEach((member, index) => {
+      if ((wrapper.vm.$props as Props)?.team?.members?.[index]) {
+        expect(member.text()).toEqual(
+          `${(wrapper.vm.$props as unknown as Props).team.members?.[index]?.name ?? 'Unknown'} | ${(wrapper.vm.$props as unknown as Props).team.members?.[index]?.address ?? 'Unknown'}`
+        )
+      } else {
+        expect(member.text()).toEqual('Unknown Member | 0x3')
+      }
+    })
+  })
+
+  it('renders all deployed contract addresses', async () => {
+    const wrapper: VueWrapper = mount(OfficerForm, {
+      props: {
+        team: {
+          officerAddress: '0x123'
+        }
+      }
+    })
+
+    await wrapper.setValue({
+      isBankDeployed: true,
+      isVotingDeployed: true,
+      isBoDDeployed: true,
+      isExpenseDeployed: true
+    })
+
+    expect(wrapper.find('span[data-test="bank-address"').text()).toContain('Bank deployed at')
+    expect(wrapper.find('span[data-test="voting-address"').text()).toContain('Voting deployed at')
+    expect(wrapper.find('span[data-test="bod-address"').text()).toContain('BoD deployed at')
+    expect(wrapper.find('span[data-test="expense-address"').text()).toContain('Expense deployed at')
+  })
+
+  it('renders LoadingButton if createOfficerLoading is true', async () => {
+    const wrapper: VueWrapper = mount(OfficerForm, {
+      props: {
+        team: { officerAddress: '0x123' }
+      }
+    })
+
+    mockUseWriteContract.isPending.value = true
+    mockUseWaitForTransactionReceipt.isLoading.value = true
+    await wrapper.setValue({ loading: true })
+
+    await wrapper.vm.$nextTick()
+    expect(wrapper.findComponent(LoadingButton).exists()).toBeTruthy()
+  })
+
   describe('OfficerForm.vue - Additional Tests', () => {
     beforeEach(() => {
       vi.clearAllMocks()
@@ -146,6 +259,46 @@ describe('OfficerForm.vue', () => {
 
       const deployExpenseButton = wrapper.find('[data-test="deployExpenseButton"]')
       expect(deployExpenseButton.exists()).toBe(false)
+    })
+
+    it('calls addSuccessToast and emits getTeam when contract is deployed successfully', async () => {
+      const { addSuccessToast } = useToastStore()
+      const wrapper: VueWrapper = mount(OfficerForm, {
+        props: {
+          team: {
+            officerAddress: '0x123'
+          }
+        }
+      })
+
+      mockUseWaitForTransactionReceipt.isLoading.value = true
+      await wrapper.vm.$nextTick()
+
+      mockUseWaitForTransactionReceipt.isSuccess.value = true
+      mockUseWaitForTransactionReceipt.isLoading.value = false
+      await wrapper.vm.$nextTick()
+
+      expect(addSuccessToast).toHaveBeenCalledWith('Bank deployed successfully')
+      expect(addSuccessToast).toHaveBeenCalledWith('Voting deployed successfully')
+      expect(addSuccessToast).toHaveBeenCalledWith('Expense account deployed successfully')
+
+      expect(wrapper.emitted('getTeam')).toBeTruthy()
+    })
+
+    it('calls addErrorToast when contract deployment fails', async () => {
+      const { addErrorToast } = useToastStore()
+      const wrapper: VueWrapper = mount(OfficerForm, {
+        props: {
+          team: {
+            officerAddress: '0x123'
+          }
+        }
+      })
+
+      mockUseWriteContract.error.value = new Error('Bank deployment failed')
+      await wrapper.vm.$nextTick()
+
+      expect(addErrorToast).toHaveBeenCalledWith('Failed to deploy officer contract')
     })
   })
 })

--- a/app/src/components/forms/__tests__/OfficerForm.spec.ts
+++ b/app/src/components/forms/__tests__/OfficerForm.spec.ts
@@ -298,6 +298,9 @@ describe('OfficerForm.vue', () => {
       mockUseWriteContract.error.value = new Error('Bank deployment failed')
       await wrapper.vm.$nextTick()
 
+      expect(addErrorToast).toHaveBeenCalledWith('Failed to deploy bank')
+      expect(addErrorToast).toHaveBeenCalledWith('Failed to deploy voting')
+      expect(addErrorToast).toHaveBeenCalledWith('Failed to deploy expense account')
       expect(addErrorToast).toHaveBeenCalledWith('Failed to deploy officer contract')
     })
   })

--- a/app/src/components/forms/__tests__/OfficerForm.spec.ts
+++ b/app/src/components/forms/__tests__/OfficerForm.spec.ts
@@ -2,7 +2,6 @@ import { mount, VueWrapper } from '@vue/test-utils'
 import OfficerForm from '@/components/forms/OfficerForm.vue'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
-import { ethers } from 'ethers'
 
 // Mock the composables
 


### PR DESCRIPTION


# Description
- Resolved issue where 'Deploy Bank', 'Deploy Expense', and 'Deploy Voting' buttons were not being removed after successful deployment.
- Added reactive updates to UI based on contract deployment status to ensure buttons are hidden upon successful confirmation.
- Ensured proper state updates using watch and emitted events for `getTeam`.
- Improved reactivity handling for `isBankDeployed`, `isExpenseDeployed`, and `isVotingDeployed` flags.

## Contribution

For your PR please add a commnent to eache file edited to explain the changes you made.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

Make sur you run the following commands before submitting your PR:

- /app

```bash
npm run build
npm run test:unit
npm run type-check
npm run lint
npm run format
```

- /backend

```bash
npm run build
npm run test
npm run lint
npm run format
```

- /contract

```bash
npm run test
npm run lint
npm run format
```

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
