### PR TITLE
chore: update echarts and zrender dependencies to latest versions

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -19,7 +19,7 @@
         "@wagmi/vue": "^0.0.48",
         "buffer": "^6.0.3",
         "dayjs": "^1.11.10",
-        "echarts": "^5.5.1",
+        "echarts": "^5.6.0",
         "ethers": "^6.13.1",
         "jspdf": "^2.5.2",
         "jspdf-autotable": "^3.8.4",
@@ -9648,12 +9648,13 @@
       "dev": true
     },
     "node_modules/echarts": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
-      "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.6.0"
+        "zrender": "5.6.1"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -19600,9 +19601,10 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
-      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"
       }
@@ -19610,7 +19612,8 @@
     "node_modules/zrender/node_modules/tslib": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/zustand": {
       "version": "4.4.1",

--- a/app/package.json
+++ b/app/package.json
@@ -35,7 +35,7 @@
     "@wagmi/vue": "^0.0.48",
     "buffer": "^6.0.3",
     "dayjs": "^1.11.10",
-    "echarts": "^5.5.1",
+    "echarts": "^5.6.0",
     "ethers": "^6.13.1",
     "jspdf": "^2.5.2",
     "jspdf-autotable": "^3.8.4",


### PR DESCRIPTION


# Description

- Upgraded echarts from version 5.5.1 to 5.6.0 in package.json and package-lock.json.
- Updated zrender from version 5.6.0 to 5.6.1, ensuring compatibility with the latest echarts version.
- Adjusted integrity hashes and added license information for both packages.
## Contribution

For your PR please add a commnent to eache file edited to explain the changes you made.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines



