### PR TITLE
fix: update deployBankAccount function to include USDC

### DIFF
--- a/app/src/components/forms/DeploymentActions.vue
+++ b/app/src/components/forms/DeploymentActions.vue
@@ -244,7 +244,7 @@ const deployBankAccount = async () => {
   const initData = encodeFunctionData({
     abi: BankABI,
     functionName: 'initialize',
-    args: [TIPS_ADDRESS, currentAddress]
+    args: [TIPS_ADDRESS, USDT_ADDRESS, USDC_ADDRESS, currentAddress]
   })
 
   deployBank({


### PR DESCRIPTION


# Description
- Modified the deployBankAccount function in DeploymentActions.vue to accept USDT_ADDRESS and USDC_ADDRESS as additional arguments for the initialization process.
- This change enhances the deployment functionality by allowing multiple token addresses to be specified during the bank account deployment.


Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
