### PR TITLE
Fix/enable disable expense

### DIFF
--- a/app/src/components/sections/ExpenseAccountView/ExpenseAccountTable.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseAccountTable.vue
@@ -88,10 +88,13 @@
         <span>{{ row.budgetData[2]?.value }} {{ tokenSymbol(row.tokenAddress) }}</span>
       </template>
       <template #transactions-data="{ row }">
-        <span>{{ row.balances[0] }}/{{ row.budgetData[0]?.value }}</span>
+        <span>{{ row.balances[0] }}/{{ row.budgetData[0]?.value }} TXs</span>
       </template>
       <template #amountTransferred-data="{ row }">
-        <span>{{ row.balances[1] }}/{{ row.budgetData[1]?.value }}</span>
+        <span
+          >{{ row.balances[1] }}/{{ row.budgetData[1]?.value }}
+          {{ tokenSymbol(row.tokenAddress) }}</span
+        >
       </template>
     </TableComponent>
   </div>
@@ -142,12 +145,12 @@ const columns = [
   },
   {
     key: 'transactions',
-    label: 'Total Transactions',
+    label: 'Max Transactions',
     sortable: false
   },
   {
     key: 'amountTransferred',
-    label: 'Amount Transferred',
+    label: 'Max Amount',
     sortable: false
   },
   {
@@ -174,7 +177,7 @@ const {
 //deactivate approval
 const {
   writeContract: executeDeactivateApproval,
-  isPending: isLoadingDeactivateApproval,
+  // isPending: isLoadingDeactivateApproval,
   error: errorDeactivateApproval,
   data: deactivateHash
 } = useWriteContract()
@@ -187,7 +190,7 @@ const { isLoading: isConfirmingDeactivate, isSuccess: isConfirmedDeactivate } =
 //activate approval
 const {
   writeContract: executeActivateApproval,
-  isPending: isLoadingActivateApproval,
+  // isPending: isLoadingActivateApproval,
   error: errorActivateApproval,
   data: activateHash
 } = useWriteContract()

--- a/app/src/components/sections/ExpenseAccountView/MyApprovedExpenseSection.vue
+++ b/app/src/components/sections/ExpenseAccountView/MyApprovedExpenseSection.vue
@@ -27,10 +27,13 @@
           <span> {{ row.budgetData[2]?.value }} {{ tokenSymbol(row.tokenAddress) }} </span>
         </template>
         <template #transactions-data="{ row }">
-          <span>{{ row.balances[0] }}/{{ row.budgetData[0]?.value }}</span>
+          <span>{{ row.balances[0] }}/{{ row.budgetData[0]?.value }} TXs</span>
         </template>
         <template #amountTransferred-data="{ row }">
-          <span>{{ row.balances[1] }}/{{ row.budgetData[1]?.value }}</span>
+          <span
+            >{{ row.balances[1] }}/{{ row.budgetData[1]?.value }}
+            {{ tokenSymbol(row.tokenAddress) }}</span
+          >
         </template>
       </TableComponent>
 
@@ -88,12 +91,12 @@ const columns = [
   },
   {
     key: 'transactions',
-    label: 'Total Transactions',
+    label: 'Max Transactions',
     sortable: false
   },
   {
     key: 'amountTransferred',
-    label: 'Amount Transferred',
+    label: 'Max Amount',
     sortable: false
   },
   {

--- a/app/src/stores/expenseStore.ts
+++ b/app/src/stores/expenseStore.ts
@@ -71,7 +71,7 @@ export const useExpenseDataStore = defineStore('expense', () => {
   // Todo count how many time it's called or mounted
   onMounted(async () => {
     await reloadExpenseData()
-    console.log('allExpenseData', allExpenseData.value)
+    // console.log('allExpenseData', allExpenseData.value)
   })
 
   return {


### PR DESCRIPTION
# Description

When you try to disable or enable an expense.
You click on the button, have the signing request, you sign
Then the loading state stop. Before you have the confirmation Popup.

The loading should be there, until the state change.

Fixes #779 

## Issues introduced and fixed (Optional)

- Change table headers labels to make them more understandable to the user
- Add symbols or units to values for `Max Transfers` and `Max Amount`

## PR Summary Or Solution description

Added refs for loading state that are cleared after enable and disable transactions are confirmed.

## Contribution

For your PR please add a comment to each file edited to explain the changes you made.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

- **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Contribution checklist

Before submitting the PR, please make sure you have applied the rules in [CONTRIBUTION.md](./../CONTRIBUTION.md)
