### PR TITLE
contracts initilization

### DIFF
--- a/contract/contracts/CommisionManager.sol
+++ b/contract/contracts/CommisionManager.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import '@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol';
+
+/**
+ * @title CommissionManagerV
+ * @notice Manages global deposit and withdrawal fees and fund receiver for a banking system.
+ */
+contract CommissionManager is ReentrancyGuardUpgradeable, OwnableUpgradeable,PausableUpgradeable {
+    uint16 public globalDepositFee;   // in basis points (e.g., 100 = 1%)
+    uint16 public globalWithdrawFee;  // in basis points (e.g., 100 = 1%)
+    address public fundReceiver;
+
+    address[] private adminList;
+    mapping(address => bool) public admins;
+    mapping(address => uint256) private adminIndex;
+
+    event DepositFeeSet(uint16 newFee);
+    event WithdrawFeeSet(uint16 newFee);
+    event FundReceiverSet(address indexed newReceiver);
+    event FeeReceived(address indexed sender, uint256 amount, string reason);
+
+    event AdminAdded(address indexed admin);
+    event AdminRemoved(address indexed admin);
+
+    modifier onlyAdminOrOwner() {
+        require(admins[msg.sender] || msg.sender == owner(), "Caller is not an admin or the owner");
+        _;
+    }
+
+    function initialize(
+        uint16 _depositFee,
+        uint16 _withdrawFee,
+        address _fundReceiver
+    ) public initializer {
+        __Ownable_init(msg.sender);
+        __ReentrancyGuard_init();
+        require(_depositFee <= 1000 && _withdrawFee <= 1000, "Max 10%");
+        require(_fundReceiver != address(0), "Invalid receiver");
+
+        globalDepositFee = _depositFee;
+        globalWithdrawFee = _withdrawFee;
+        fundReceiver = _fundReceiver;
+    }
+
+    // Admin Management
+    function addAdmin(address admin) external onlyOwner  whenNotPaused {
+        require(!admins[admin], "Already an admin");
+        admins[admin] = true;
+        adminIndex[admin] = adminList.length;
+        adminList.push(admin);
+        emit AdminAdded(admin);
+    }
+
+    function removeAdmin(address admin) external onlyOwner whenNotPaused {
+        require(admins[admin], "Not an admin");
+        admins[admin] = false;
+        
+        uint256 indexToRemove = adminIndex[admin];
+        uint256 lastIndex = adminList.length - 1;
+
+        if (indexToRemove != lastIndex) {
+            address lastAdmin = adminList[lastIndex];
+            adminList[indexToRemove] = lastAdmin;
+            adminIndex[lastAdmin] = indexToRemove;
+        }
+        adminList.pop();
+        delete adminIndex[admin];
+        emit AdminRemoved(admin);
+    }
+
+    function isAdmin(address account) external view returns (bool) {
+        return admins[account];
+    }
+    // Fee Management
+    function setGlobalDepositFee(uint16 _fee) external onlyAdminOrOwner whenNotPaused {
+        require(_fee <= 1000, "Max 10%");
+        globalDepositFee = _fee;
+        emit DepositFeeSet(_fee);
+    }
+
+    function setGlobalWithdrawFee(uint16 _fee) external onlyAdminOrOwner whenNotPaused {
+        require(_fee <= 1000, "Max 10%");
+        globalWithdrawFee = _fee;
+        emit WithdrawFeeSet(_fee);
+    }
+
+    function setFundReceiver(address _receiver) external onlyAdminOrOwner whenNotPaused {
+        require(_receiver != address(0), "Invalid receiver");
+        fundReceiver = _receiver;
+        emit FundReceiverSet(_receiver);
+    }
+
+    // External getter for bank contract to calculate amounts
+    function getDepositFee() external view returns (uint16) {
+        return globalDepositFee;
+    }
+
+    function getWithdrawFee() external view returns (uint16) {
+        return globalWithdrawFee;
+    }
+
+    function getFundReceiver() external view returns (address) {
+        return fundReceiver;
+    }
+
+    // Accept fees (e.g., from Bank contract)
+    function receiveFee(string calldata reason) external payable nonReentrant  {
+        require(msg.value > 0, "No funds sent");
+        require(fundReceiver != address(0), "Fund receiver not set");
+
+        (bool success, ) = payable(fundReceiver).call{value: msg.value}("");
+        require(success, "Transfer failed");
+
+        emit FeeReceived(msg.sender, msg.value, reason);
+    }
+
+    function getAdminList() external view returns (address[] memory) {
+        return adminList;
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+}

--- a/contract/contracts/bank/BankV1.sol
+++ b/contract/contracts/bank/BankV1.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol';
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+
+
+interface ITips {
+  function pushTip(address[] calldata _teamMembersAddresses) external payable;
+  function sendTip(address[] calldata _teamMembersAddresses) external payable;
+}
+
+contract Bank is OwnableUpgradeable, ReentrancyGuardUpgradeable, PausableUpgradeable {
+  address public tipsAddress;
+  mapping(string => address) public supportedTokens;
+
+  event Deposited(address indexed depositor, uint256 amount);
+  event TokenDeposited(address indexed depositor, address indexed token, uint256 amount);
+  event Transfer(address indexed sender, address indexed to, uint256 amount);
+  event TokenTransfer(address indexed sender, address indexed to, address indexed token, uint256 amount);
+  event TipsAddressChanged(
+    address indexed addressWhoChanged,
+    address indexed oldAddress,
+    address indexed newAddress
+  );
+  event TokenAddressChanged(
+    address indexed addressWhoChanged,
+    string tokenSymbol,
+    address indexed oldAddress,
+    address indexed newAddress
+  );
+  event SendTip(address indexed addressWhoSends, address[] teamMembers, uint256 totalAmount);
+  event PushTip(address indexed addressWhoPushes, address[] teamMembers, uint256 totalAmount);
+  event SendTokenTip(address indexed addressWhoSends, address[] teamMembers, address indexed token, uint256 totalAmount);
+  event PushTokenTip(address indexed addressWhoPushes, address[] teamMembers, address indexed token, uint256 totalAmount);
+
+  function initialize(
+    address _tipsAddress,
+    address _usdtAddress,
+    address _usdcAddress,
+    address _sender
+  ) public initializer {
+    __Ownable_init(_sender);
+    __ReentrancyGuard_init();
+    __Pausable_init();
+    tipsAddress = _tipsAddress;
+    supportedTokens["USDT"] = _usdtAddress;
+    supportedTokens["USDC"] = _usdcAddress;
+  }
+
+  function isTokenSupported(address _token) public view returns (bool) {
+    return _token == supportedTokens["USDT"] || _token == supportedTokens["USDC"];
+  }
+
+  receive() external payable {
+    emit Deposited(msg.sender, msg.value);
+  }
+
+  function depositToken(address _token, uint256 _amount) external nonReentrant whenNotPaused {
+    require(isTokenSupported(_token), "Unsupported token");
+    require(_amount > 0, "Amount must be greater than zero");
+    
+    IERC20(_token).transferFrom(msg.sender, address(this), _amount);
+    emit TokenDeposited(msg.sender, _token, _amount);
+  }
+
+  function transfer(
+    address _to,
+    uint256 _amount
+  ) external payable onlyOwner nonReentrant whenNotPaused {
+    require(_to != address(0), 'Address cannot be zero');
+    require(_amount > 0, 'Amount must be greater than zero');
+
+    (bool sent, ) = _to.call{value: _amount}('');
+    require(sent, 'Failed to transfer');
+
+    emit Transfer(msg.sender, _to, _amount);
+  }
+
+  function transferToken(
+    address _token,
+    address _to,
+    uint256 _amount
+  ) external onlyOwner nonReentrant whenNotPaused {
+    require(isTokenSupported(_token), "Unsupported token");
+    require(_to != address(0), 'Address cannot be zero');
+    require(_amount > 0, 'Amount must be greater than zero');
+
+    IERC20(_token).transfer(_to, _amount);
+    emit TokenTransfer(msg.sender, _to, _token, _amount);
+  }
+
+  function changeTipsAddress(address _tipsAddress) external onlyOwner whenNotPaused {
+    require(_tipsAddress != address(0), 'Address cannot be zero');
+
+    address oldAddress = tipsAddress;
+    tipsAddress = _tipsAddress;
+
+    emit TipsAddressChanged(msg.sender, oldAddress, _tipsAddress);
+  }
+
+  function changeTokenAddress(string calldata _symbol, address _newAddress) external onlyOwner whenNotPaused {
+    require(_newAddress != address(0), 'Address cannot be zero');
+    require(keccak256(abi.encodePacked(_symbol)) == keccak256(abi.encodePacked("USDT")) || 
+            keccak256(abi.encodePacked(_symbol)) == keccak256(abi.encodePacked("USDC")), 
+            "Invalid token symbol");
+    
+    address oldAddress = supportedTokens[_symbol];
+    supportedTokens[_symbol] = _newAddress;
+    emit TokenAddressChanged(msg.sender, _symbol, oldAddress, _newAddress);
+  }
+
+  function pushTip(
+    address[] calldata _addresses,
+    uint256 _amount
+  ) external payable onlyOwner whenNotPaused {
+    ITips(tipsAddress).pushTip{value: _amount}(_addresses);
+    emit PushTip(msg.sender, _addresses, _amount);
+  }
+
+  function pushTokenTip(
+    address[] calldata _addresses,
+    address _token,
+    uint256 _amount
+  ) external onlyOwner whenNotPaused {
+    require(isTokenSupported(_token), "Unsupported token");
+    uint256 amountPerAddress = _amount / _addresses.length;
+        
+    require(IERC20(_token).transferFrom(msg.sender, address(this), _amount), "Token transfer failed");
+        
+    for (uint256 i = 0; i < _addresses.length; i++) {
+       require(_addresses[i] != address(0), "Invalid address");
+       require(IERC20(_token).transfer(_addresses[i], amountPerAddress), "Token transfer failed");
+    }
+
+    emit PushTokenTip(msg.sender, _addresses, _token, _amount);
+  }
+  
+
+  function sendTip(
+    address[] calldata _addresses,
+    uint256 _amount
+  ) external payable onlyOwner whenNotPaused {
+    ITips(tipsAddress).sendTip{value: _amount}(_addresses);
+    emit SendTip(msg.sender, _addresses, _amount);
+  }
+
+  function sendTokenTip(
+    address[] calldata _addresses,
+    address _token,
+    uint256 _amount
+  ) external onlyOwner whenNotPaused {
+    require(isTokenSupported(_token), "Unsupported token");
+    for (uint256 i = 0; i < _addresses.length; i++) {
+      require(_addresses[i] != address(0), "Invalid address");
+      require(IERC20(_token).transfer(_addresses[i], _amount), "Token transfer failed");
+    }
+    emit SendTokenTip(msg.sender, _addresses, _token, _amount);
+  }
+
+  function pause() external onlyOwner {
+    _pause();
+  }
+
+  function unpause() external onlyOwner {
+    _unpause();
+  }
+}

--- a/contract/contracts/bank/BankV2.sol
+++ b/contract/contracts/bank/BankV2.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./BankV1.sol"; // This should be the path to your existing deployed Bank logic
+import "../interfaces/ICommisionManager.sol";
+//the BankV2 inherit from BankV1
+contract BankV2 is Bank {
+    ICommissionManager public commissionManager;
+
+    // New events for V2 (do not override existing ones)
+    event CommissionManagerUpdated(address indexed oldCommissionManager, address indexed newCommissionManager);
+    event DepositedWithFee(address indexed depositor, uint256 netAmount, uint256 feeAmount);
+    event TransferWithFee(address indexed sender, address indexed to, uint256 netAmount, uint256 feeAmount);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers(); // Required for upgradeable contracts
+    }
+
+    /// @notice Reinitialization after upgrade to V2
+    function initializeV2(address _commissionManager) external reinitializer(2) {
+        require(_commissionManager != address(0), "Invalid commission manager");
+        commissionManager = ICommissionManager(_commissionManager);
+    }
+
+    /// @notice Update commission manager
+    function updateCommissionManager(address _newCommissionManager) external onlyOwner whenNotPaused {
+        require(_newCommissionManager != address(0), "Invalid address");
+        emit CommissionManagerUpdated(address(commissionManager), _newCommissionManager);
+        commissionManager = ICommissionManager(_newCommissionManager);
+    }
+    /// @notice Receive ETH and apply deposit fee
+    receive() external payable override {
+        uint256 originalAmount = msg.value;
+        require(originalAmount > 0, "Zero-value deposits are not allowed");
+        address fundReceiver = commissionManager.getFundReceiver();
+    
+        if(fundReceiver ==address(this)){
+            emit Deposited(msg.sender, originalAmount);// V1-compatible
+            emit DepositedWithFee(msg.sender, originalAmount, 0); // V2-specific
+            return ;
+        }
+        // Check if the receiver is not the contract itself
+        uint256 feeRate = commissionManager.getDepositFee();
+        
+        uint256 feeAmount = (originalAmount * feeRate) / 10000;
+
+        if (feeAmount > 0) {
+            commissionManager.receiveFee{value: feeAmount}("deposit");
+        }
+
+        uint256 netAmount = originalAmount - feeAmount;
+
+        emit Deposited(msg.sender, netAmount); // V1-compatible
+        emit DepositedWithFee(msg.sender, netAmount, feeAmount); // V2-specific
+        
+    }
+
+    /// @notice Transfer ETH with withdrawal fee
+    function transfer(address _to, uint256 _amount)
+        external
+        payable
+        override
+        onlyOwner
+        nonReentrant
+        whenNotPaused {
+        require(_to != address(0), "Address cannot be zero");
+        require(_amount > 0, "Amount must be greater than zero");
+        require(address(this).balance >= _amount, "Insufficient contract balance");
+        address fundReceiver = commissionManager.getFundReceiver();
+        
+        if (fundReceiver == address(this)) {
+            emit Transfer(msg.sender, _to, _amount);
+            emit TransferWithFee(msg.sender, _to, _amount, 0);
+            (bool sentFull, ) = _to.call{value: _amount}("");
+            require(sentFull, "Failed to transfer");
+            return;
+        }
+        
+        uint16 feeRate = commissionManager.getWithdrawFee();
+        uint256 feeAmount = (_amount * feeRate) / 10000;
+        if (feeAmount > 0) {
+            commissionManager.receiveFee{value: feeAmount}("withdraw");
+        }
+
+        uint256 netAmount = _amount - feeAmount;
+
+        (bool sent, ) = _to.call{value: netAmount}("");
+        require(sent, "Failed to transfer");
+
+        emit Transfer(msg.sender, _to, netAmount); // V1-compatible
+        emit TransferWithFee(msg.sender, _to, netAmount, feeAmount); // V2-specific
+    
+    }
+}

--- a/contract/contracts/interfaces/ICommisionManager.sol
+++ b/contract/contracts/interfaces/ICommisionManager.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface ICommissionManager {
+    function getDepositFee() external view returns (uint16);
+    function getWithdrawFee() external view returns (uint16);
+    function getFundReceiver() external view returns (address);
+    function receiveFee(string calldata reason) external payable;
+}


### PR DESCRIPTION

## Experiment fees contract in a contract for demo

**Add BankV2 with CommissionManager integration for dynamic fee management**

## Description

This pull request introduces an updated version of the `Bank` contract (`BankV2`) along with a new modular `CommissionManager` contract to enable dynamic fee handling during deposit and withdrawal operations.

---

### 1. New Contract: `CommissionManager`

A standalone contract that manages:

- Global deposit and withdrawal fees in basis points (up to 10%)
- Configurable fund receiver address
- Admin access control (in addition to the owner)
- Secure fee transfers via the `receiveFee(string reason)` function

This contract is upgradeable using OpenZeppelin patterns (`OwnableUpgradeable`, `PausableUpgradeable`, `ReentrancyGuardUpgradeable`).

---

### 2. New Interface: `ICommissionManager`

A minimal interface used by `BankV2` to integrate with the commission logic.

Exposes the following methods:

- `getDepositFee()`
- `getWithdrawFee()`
- `getFundReceiver()`
- `receiveFee(string reason)` (payable)

---

### 3. Updated Contract: `BankV2`

A proxy-compatible extension of `BankV1` that adds:

- Dynamic fee deduction on ETH/POL deposits and transfers
- Integration with the external `CommissionManager` via `ICommissionManager`
- `initializeV2(address)` function for reinitialization during upgrade
- Additional events:
  - `DepositedWithFee`
  - `TransferWithFee`
- Guard conditions for fund receiver logic (e.g., bypass fees if receiver is the contract itself)

---

## Security and Upgrade Considerations

- Reentrancy protection applied to all external payable and transfer functions
- Fees are calculated using safe arithmetic and validated before forwarding
- Only the owner can update the commission manager contract reference
- Events are emitted before external calls to support secure and auditable flows

---

## Future Work

- Integrate fee handling for token-based transfers
- Add unit tests for fee deduction and forwarding
- Expose helper functions for frontends to simulate net values after fees

![payment_fees](https://github.com/user-attachments/assets/a32d40fb-387e-4d06-9b33-341aedf34ed8)

diagram_links: [link to the diagram](https://drive.google.com/file/d/1QDGQMrZfcdJ5poe26HJ2gwQ1jjlspS-L/view?usp=drive_link)
