### PR TITLE
perf: being able to run all CI when label run is added to the PR

### DIFF
--- a/.github/workflows/app-vitest.yml
+++ b/.github/workflows/app-vitest.yml
@@ -2,15 +2,17 @@ name: Frontend Vitest Unit Tests
 
 on:
   pull_request_target:
-    types: [assigned]
+    types: [assigned, labeled]
   pull_request:
     branches: "**"
     paths:
       - "app/**"
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
 jobs:
   app-unit-test:
+    if: github.event.action != 'labeled' || github.event.label.name == 'run'
     runs-on: ubuntu-latest
     steps:
       - name: 🛫 Checkout

--- a/.github/workflows/backend-vitest.yml
+++ b/.github/workflows/backend-vitest.yml
@@ -5,10 +5,12 @@ on:
     branches: "**"
     paths:
       - "backend/**"
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
 jobs:
   api-unit-test:
+    if: github.event.action != 'labeled' || github.event.label.name == 'run'
     runs-on: ubuntu-latest
     container: node:20.10.0-alpine
     services:

--- a/.github/workflows/contract-vitest.yml
+++ b/.github/workflows/contract-vitest.yml
@@ -5,10 +5,12 @@ on:
     branches: "**"
     paths:
       - "contract/**"
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
 jobs:
   contract-unit-test:
+    if: github.event.action != 'labeled' || github.event.label.name == 'run'
     runs-on: ubuntu-latest
     steps:
       - name: 🛫 Checkout


### PR DESCRIPTION
# Description

## Intial Issue Description

The initial problem is that some CI are not runing in all PR. 
Because every folder CI run when there is an update in this particular forlder, we need a way to manylay trigger all ci when we need. 

> Link to the issue in the kanban board
> If no issue exists, please create one and link it here.
Fixes # (issue)

## Issues introduced and fixed (Optional)

If exit: The description of issues you find and fix in this PR.

## PR Summary Or Solution description

The summary should be a short description of the change, what you have done to fixe the issue. Please include the motivation for the change and how it was implemented. If applicable, please include screenshots or code snippets to illustrate the changes.

## Contribution

For your PR please add a comment to each file edited to explain the changes you made.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

- **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Contribution checklist

Before submitting the PR, please make sure you have applied the rules in [CONTRIBUTION.md](./../CONTRIBUTION.md)
