### PR TITLE
feat: add type filter dropdown to transaction history component

### DIFF
--- a/app/src/components/GenericTransactionHistory.vue
+++ b/app/src/components/GenericTransactionHistory.vue
@@ -2,17 +2,39 @@
 <template>
   <CardComponent :title="title" class="w-full">
     <template #card-action>
-      <div class="flex items-center gap-10">
+      <div class="flex items-center gap-2">
         <CustomDatePicker
           v-if="showDateFilter"
           v-model="dateRange"
+          class="min-w-[140px]"
           :data-test-prefix="dataTestPrefix"
         />
+        <div class="relative">
+          <ButtonUI
+            class="flex items-center cursor-pointer gap-4 border border-gray-300 min-w-[110px]"
+            @click="typeDropdownOpen = !typeDropdownOpen"
+            :data-test="`${dataTestPrefix}-type-filter`"
+          >
+            <span>{{ selectedTypeLabel }}</span>
+            <IconifyIcon icon="heroicons:chevron-down" class="w-4 h-4" />
+          </ButtonUI>
+          <ul
+            class="absolute right-0 mt-2 menu bg-base-200 border-2 rounded-box z-[1] w-40 p-2 shadow"
+            ref="typeDropdownTarget"
+            v-if="typeDropdownOpen"
+          >
+            <li @click="selectType('')"><a>All Types</a></li>
+            <li v-for="type in uniqueTypes" :key="type" @click="selectType(type)">
+              <a>{{ type }}</a>
+            </li>
+          </ul>
+        </div>
         <ButtonUI
           v-if="showExport"
           variant="success"
           @click="handleExport"
           :data-test="`${dataTestPrefix}-export-button`"
+          class="!ml-0 !px-4"
           >Export</ButtonUI
         >
       </div>
@@ -161,6 +183,7 @@ import { useCurrencyStore } from '@/stores/currencyStore'
 import { useTeamStore } from '@/stores'
 import { storeToRefs } from 'pinia'
 import { useRoute } from 'vue-router'
+import { onClickOutside } from '@vueuse/core'
 
 interface Props {
   transactions: BaseTransaction[]
@@ -192,10 +215,14 @@ const { nativeTokenPriceInUSD, nativeTokenPrice } = storeToRefs(currencyStore)
 const { currentTeam } = storeToRefs(teamStore)
 
 const dateRange = ref<[Date, Date] | null>(null)
+const selectedType = ref('')
 const receiptModal = ref(false)
 const selectedTransaction = ref<BaseTransaction | null>(null)
 const currentPage = ref(1)
 const itemsPerPage = ref(10)
+const typeDropdownOpen = ref(false)
+const typeDropdownTarget = ref<HTMLElement | null>(null)
+const selectedTypeLabel = computed(() => (selectedType.value ? selectedType.value : 'All Types'))
 
 onMounted(async () => {
   const teamId = route.params.id as string
@@ -226,13 +253,27 @@ const columns = computed(() => {
   return baseColumns
 })
 
+const uniqueTypes = computed(() => {
+  const types = new Set(props.transactions.map((tx) => tx.type))
+  return Array.from(types).sort()
+})
+
 const displayedTransactions = computed(() => {
-  if (!dateRange.value) return props.transactions
-  const [startDate, endDate] = dateRange.value
-  return props.transactions.filter((tx) => {
-    const txDate = new Date(tx.date)
-    return txDate >= startDate && txDate <= endDate
-  })
+  let filtered = props.transactions
+
+  if (dateRange.value) {
+    const [startDate, endDate] = dateRange.value
+    filtered = filtered.filter((tx) => {
+      const txDate = new Date(tx.date)
+      return txDate >= startDate && txDate <= endDate
+    })
+  }
+
+  if (selectedType.value) {
+    filtered = filtered.filter((tx) => tx.type === selectedType.value)
+  }
+
+  return filtered
 })
 
 const formatDate = (date: string | number) => {
@@ -395,4 +436,13 @@ const getMemberName = (address: string) => {
   )
   return member?.name || address
 }
+
+const selectType = (type: string) => {
+  selectedType.value = type
+  typeDropdownOpen.value = false
+}
+
+onClickOutside(typeDropdownTarget, () => {
+  typeDropdownOpen.value = false
+})
 </script>

--- a/app/src/components/__tests__/GenericTransactionHistory.spec.ts
+++ b/app/src/components/__tests__/GenericTransactionHistory.spec.ts
@@ -161,6 +161,10 @@ describe('GenericTransactionHistory', () => {
     getUserData: (address: string) => { name: string; imageUrl: string; address: string }
     getMemberImage: (address: string) => string
     getMemberName: (address: string) => string
+    itemsPerPage: number
+    currentPage: number
+    selectedType: string
+    typeDropdownOpen: boolean
   }
   let wrapper: VueWrapper
 
@@ -587,6 +591,39 @@ describe('GenericTransactionHistory', () => {
 
       const name = vm.getMemberName('0xunknown')
       expect(name).toBe('0xunknown')
+    })
+  })
+
+  describe('Type Filtering', () => {
+    it('closes type dropdown when clicking outside', async () => {
+      const wrapper = createWrapper()
+      const vm = wrapper.vm as unknown as IGenericTransactionHistory
+
+      // Open dropdown
+      vm.typeDropdownOpen = true
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('ul').exists()).toBe(true)
+
+      // Click outside
+      vm.typeDropdownOpen = false
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('ul').exists()).toBe(false)
+    })
+
+    it('displays correct type label in filter button', async () => {
+      const wrapper = createWrapper()
+      const vm = wrapper.vm as unknown as IGenericTransactionHistory
+
+      expect(wrapper.find('[data-test="transaction-history-type-filter"] span').text()).toBe(
+        'All Types'
+      )
+
+      vm.selectedType = 'deposit'
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('[data-test="transaction-history-type-filter"] span').text()).toBe(
+        'deposit'
+      )
     })
   })
 })


### PR DESCRIPTION
# Description

## Intial Issue Description

The description of the issue (in the kanban board) that this PR addresses. Please include the issue number in the title of the PR.

> Link to the issue in the kanban board
> If no issue exists, please create one and link it here.
Fixes #886 

## PR Summary Or Solution description

This PR adds a filter for different transactions and lets the user download only the txs they want.

![image](https://github.com/user-attachments/assets/15cb709d-ed7f-4212-be76-b509485aa14c)
![image](https://github.com/user-attachments/assets/7cf9383f-b641-4955-9c98-dd424b3f88de)
![image](https://github.com/user-attachments/assets/b37cebf2-0102-4aae-913b-b26cffbe49c3)


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)

## Contribution checklist

Before submitting the PR, please make sure you have applied the rules in [CONTRIBUTION.md](./../CONTRIBUTION.md)
