### PR TITLE
fix: update amount parsing in DistributeMintForm to use parseUnits

### DIFF
--- a/app/src/components/sections/SherTokenView/forms/DistributeMintForm.vue
+++ b/app/src/components/sections/SherTokenView/forms/DistributeMintForm.vue
@@ -124,7 +124,7 @@ import { log } from '@/utils'
 import { Icon as IconifyIcon } from '@iconify/vue'
 import useVuelidate from '@vuelidate/core'
 import { helpers, numeric, required } from '@vuelidate/validators'
-import { parseEther, isAddress } from 'viem'
+import { parseUnits, isAddress } from 'viem'
 import { ref, watch } from 'vue'
 import { reactive } from 'vue'
 
@@ -162,7 +162,7 @@ const onSubmit = () => {
     shareholderWithAmounts.map((shareholder) => {
       return {
         shareholder: shareholder.shareholder,
-        amount: parseEther(shareholder.amount?.toString() ?? '0')
+        amount: parseUnits(shareholder.amount?.toString() ?? '0', 6)
       }
     })
   )


### PR DESCRIPTION
# Description

## Intial Issue Description

When you distribute sher to user you have mode than then number you want.
For ex, you distribute 2, you will receive 2 000 000

Fixes [#939](https://github.com/globe-and-citizen/cnc-portal/issues/939)

## PR Summary Or Solution description

The solution was to define the decimal when converting the string into a bigInt

## Contribution

For your PR please add a comment to each file edited to explain the changes you made.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

- **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Contribution checklist

Before submitting the PR, please make sure you have applied the rules in [CONTRIBUTION.md](./../CONTRIBUTION.md)
