### PR TITLE
Feat: Highlight winner and vote cast

### DIFF
--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
@@ -1,5 +1,29 @@
 <template>
-  <div class="bg-base-100 card border border-gray-300 flex flex-col">
+  <div
+    class="bg-base-100 card border border-gray-300 flex flex-col relative"
+    :class="{ 'border-warning': isElectionWinner }"
+  >
+    <!-- Winner Badge (aligned to straddle border) -->
+    <div
+      v-if="isElectionWinner"
+      class="absolute top-0 -translate-y-1/2 right-0 -translate-x-1/4 z-10"
+    >
+      <span class="badge badge-warning badge-lg gap-2 shadow-lg border-2 border-base-100">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-4 w-4"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+            clip-rule="evenodd"
+          />
+        </svg>
+        Winner
+      </span>
+    </div>
     <div class="card-body">
       <!-- User Component -->
       <UserComponent layout="alternate" :user="election.user" />
@@ -23,8 +47,18 @@
         :max="election.totalVotes"
       ></progress>
 
+      <!-- Conditional Button/Indicator -->
+      <div
+        v-if="hasVoted && voterChoice === election.user.address"
+        class="badge badge-outline badge-warning badge-xl"
+      >
+        <IconifyIcon icon="heroicons-solid:check" class="h-5 w-5" />
+        <span>Your Vote</span>
+      </div>
+
       <!-- View Results Button -->
       <ButtonUI
+        v-else
         variant="success"
         :outline="true"
         :disabled="hasVoted"
@@ -44,6 +78,7 @@
 <script setup lang="ts">
 import ButtonUI from '@/components/ButtonUI.vue'
 import UserComponent from './UserComponent.vue'
+import { Icon as IconifyIcon } from '@iconify/vue'
 import { computed, watch, type PropType, ref } from 'vue'
 import type { User } from '@/types'
 import { useReadContract } from '@wagmi/vue'
@@ -59,6 +94,7 @@ const props = defineProps({
       currentVotes: number
       totalVotes: number
       id: bigint
+      endDate: Date
     }>,
     required: true
   },
@@ -76,12 +112,54 @@ const { addErrorToast } = useToastStore()
 
 const isLoadingCastVoteLocal = ref(false)
 const electionsAddress = computed(() => teamStore.getContractAddressByType('Elections'))
+const isElectionEnded = computed(
+  () =>
+    props.election.endDate < new Date() ||
+    (Array.isArray(voterList.value) && voterList.value.length === props.election.totalVotes)
+)
+
+const isElectionWinner = computed(
+  () =>
+    isElectionEnded.value &&
+    Array.isArray(electionResults.value) &&
+    electionResults.value[0] === props.election.user.address
+)
+
+const { data: voterList } = useReadContract({
+  functionName: 'getElectionEligibleVoters',
+  address: electionsAddress.value,
+  abi: ELECTIONS_ABI,
+  args: [props.election.id],
+  query: {
+    enabled: computed(() => !!props.election.id)
+  }
+})
 
 const { data: hasVoted, error: errorHasVoted } = useReadContract({
   functionName: 'hasVoted',
   address: electionsAddress.value,
   abi: ELECTIONS_ABI,
   args: [props.election.id, userDataStore.address as Address]
+})
+
+const { data: voterChoice } = useReadContract({
+  functionName: 'getVoterChoice',
+  address: electionsAddress.value,
+  abi: ELECTIONS_ABI,
+  args: [props.election.id, userDataStore.address as Address]
+})
+
+const { data: electionResults } = useReadContract({
+  functionName: 'getElectionResults',
+  address: electionsAddress.value,
+  abi: ELECTIONS_ABI,
+  args: [props.election.id]
+})
+
+watch(electionResults, (newResults) => {
+  if (newResults) {
+    console.log('newElectionResults: ', newResults)
+  }
 })
 
 watch(errorHasVoted, (error) => {

--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
@@ -41,7 +41,7 @@
         v-else
         variant="success"
         :outline="true"
-        :disabled="hasVoted || electionStatus === 'upcoming'"
+        :disabled="hasVoted || electionStatus === 'upcoming' || electionStatus === 'ended'"
         :loading="isLoadingCastVoteLocal && isLoading"
         @click="
           () => {

--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
@@ -159,7 +159,6 @@ const isElectionWinner = computed(
 
 watch(errorHasVoted, (error) => {
   if (error) {
-    addErrorToast(`Error checking vote status`)
     log.error('Error checking vote status:', parseError(error))
   }
 })

--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
@@ -59,7 +59,7 @@
 import ButtonUI from '@/components/ButtonUI.vue'
 import UserComponent from './UserComponent.vue'
 import { Icon as IconifyIcon } from '@iconify/vue'
-import { computed, watch, type PropType, ref, onMounted, onBeforeUnmount } from 'vue'
+import { computed, watch, type PropType, ref } from 'vue'
 import type { User } from '@/types'
 import { useReadContract } from '@wagmi/vue'
 import { useUserDataStore, useTeamStore } from '@/stores'

--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
@@ -126,7 +126,6 @@ const { data: electionResults } = useReadContract({
 })
 
 const now = ref(new Date())
-// let timer: ReturnType<typeof setInterval>
 
 const timeLeft = computed(() => {
   const startDate = props.election.startDate
@@ -144,16 +143,6 @@ const { remaining: leftToStart } = useCountdown(timeLeft.value.toStart, {
 const { remaining: leftToEnd } = useCountdown(timeLeft.value.toEnd, {
   immediate: true
 })
-
-// onMounted(() => {
-//   timer = setInterval(() => {
-//     now.value = new Date()
-//   }, 1000 * 30) // Update every minute
-// })
-
-// onBeforeUnmount(() => {
-//   clearInterval(timer)
-// })
 
 const electionStatus = computed(() => {
   if (leftToStart.value > 0) return 'upcoming'

--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
@@ -6,23 +6,9 @@
     <!-- Winner Badge (aligned to straddle border) -->
     <div
       v-if="isElectionWinner"
-      class="absolute top-0 -translate-y-1/2 right-0 -translate-x-1/4 z-10"
+      class="absolute top-0 -translate-y-1/2 right-0 -translate-x-1/4 z-10 badge badge-warning badge-lg gap-2 shadow-lg border-2 border-base-100"
     >
-      <span class="badge badge-warning badge-lg gap-2 shadow-lg border-2 border-base-100">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-4 w-4"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-            clip-rule="evenodd"
-          />
-        </svg>
-        Winner
-      </span>
+      <span class=""> Winner </span>
     </div>
     <div class="card-body">
       <!-- User Component -->

--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
@@ -160,7 +160,7 @@ const isElectionWinner = computed(
   () =>
     electionStatus.value === 'ended' &&
     Array.isArray(electionResults.value) &&
-    electionResults.value[0] === props.election.user.address
+    electionResults.value.find((address) => address === props.election.user.address)
 )
 
 watch(errorHasVoted, (error) => {

--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
@@ -35,12 +35,6 @@
         </span>
       </div>
 
-      <!-- Custom Divider -->
-      <!-- <div class="flex items-center my-2">
-        <div class="w-6 h-6 rounded-full border-4 border-gray-600"></div>
-        <div class="flex-1 border-t-4 border-gray-200"></div>
-      </div> -->
-
       <progress
         class="progress progress-success my-4"
         :value="election.currentVotes"
@@ -112,18 +106,6 @@ const { addErrorToast } = useToastStore()
 
 const isLoadingCastVoteLocal = ref(false)
 const electionsAddress = computed(() => teamStore.getContractAddressByType('Elections'))
-const isElectionEnded = computed(
-  () =>
-    props.election.endDate < new Date() ||
-    (Array.isArray(voterList.value) && voterList.value.length === props.election.totalVotes)
-)
-
-const isElectionWinner = computed(
-  () =>
-    isElectionEnded.value &&
-    Array.isArray(electionResults.value) &&
-    electionResults.value[0] === props.election.user.address
-)
 
 const { data: voterList } = useReadContract({
   functionName: 'getElectionEligibleVoters',
@@ -156,11 +138,18 @@ const { data: electionResults } = useReadContract({
   args: [props.election.id]
 })
 
-watch(electionResults, (newResults) => {
-  if (newResults) {
-    console.log('newElectionResults: ', newResults)
-  }
-})
+const isElectionEnded = computed(
+  () =>
+    props.election.endDate < new Date() ||
+    (Array.isArray(voterList.value) && voterList.value.length === props.election.totalVotes)
+)
+
+const isElectionWinner = computed(
+  () =>
+    isElectionEnded.value &&
+    Array.isArray(electionResults.value) &&
+    electionResults.value[0] === props.election.user.address
+)
 
 watch(errorHasVoted, (error) => {
   if (error) {

--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
@@ -50,7 +50,7 @@
       <!-- Conditional Button/Indicator -->
       <div
         v-if="hasVoted && voterChoice === election.user.address"
-        class="badge badge-outline badge-warning badge-xl"
+        class="inline-flex items-center justify-center gap-2 py-3 px-6 rounded-full border-2 border-warning text-warning font-bold text-base h-12"
       >
         <IconifyIcon icon="heroicons-solid:check" class="h-5 w-5" />
         <span>Your Vote</span>

--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsSection.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsSection.vue
@@ -96,7 +96,8 @@ const candidates = computed(() => {
           imageUrl: user?.imageUrl
         },
         totalVotes: Number(voteCount.value) || 0,
-        currentVotes: votesPerCandidate[candidate] //5
+        currentVotes: votesPerCandidate[candidate], //5
+        endDate: new Date(Number((election.value as bigint[])[5]) * 1000)
       }
     })
   } else return []

--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsSection.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsSection.vue
@@ -97,6 +97,7 @@ const candidates = computed(() => {
         },
         totalVotes: Number(voteCount.value) || 0,
         currentVotes: votesPerCandidate[candidate], //5
+        startDate: new Date(Number((election.value as bigint[])[4]) * 1000),
         endDate: new Date(Number((election.value as bigint[])[5]) * 1000)
       }
     })

--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsSection.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsSection.vue
@@ -176,7 +176,6 @@ watch(
   async (newCandidates) => {
     if (newCandidates) {
       await fetchVotes()
-      addSuccessToast('Election candidates fetched successfully!')
     }
   },
   { immediate: true, deep: true }

--- a/app/src/components/sections/AdministrationView/ElectionStatus.vue
+++ b/app/src/components/sections/AdministrationView/ElectionStatus.vue
@@ -4,8 +4,10 @@
     <span class="badge badge-lg flex items-center gap-1 px-2 py-1 text-sm h-10" :class="badgeClass">
       <span class="w-3 h-3 rounded-full inline-block" :class="dotClass"></span>
       <span class="font-medium">{{ electionStatus.text }}</span>
-      <span class="mx-1">•</span>
-      {{ timeRemaining }} left
+      <span v-if="electionStatus.text !== 'Completed'" class="flex items-center gap-1">
+        <span class="mx-1">•</span>
+        {{ timeRemaining }} left
+      </span>
     </span>
   </div>
 </template>

--- a/app/src/components/sections/AdministrationView/ElectionStatus.vue
+++ b/app/src/components/sections/AdministrationView/ElectionStatus.vue
@@ -10,7 +10,8 @@
   </div>
 </template>
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useCountdown } from '@vueuse/core'
+import { computed, ref } from 'vue'
 
 const { formattedElection } = defineProps<{
   formattedElection: {
@@ -28,60 +29,68 @@ const { formattedElection } = defineProps<{
   }
 }>()
 
-// Calculate time remaining
 const now = ref(new Date())
-let timer: ReturnType<typeof setInterval>
 
-onMounted(() => {
-  timer = setInterval(() => {
-    now.value = new Date()
-  }, 1000 * 60) // Update every minute
+const timeLeft = computed(() => {
+  const startDate = formattedElection.startDate
+  const endDate = formattedElection.endDate
+  return {
+    toStart: Math.max(0, Math.floor((startDate.getTime() - now.value.getTime()) / 1000)),
+    toEnd: Math.max(0, Math.floor((endDate.getTime() - now.value.getTime()) / 1000))
+  }
 })
 
-onBeforeUnmount(() => {
-  clearInterval(timer)
+const { remaining: leftToStart } = useCountdown(timeLeft.value.toStart, {
+  immediate: true
+})
+
+const { remaining: leftToEnd } = useCountdown(timeLeft.value.toEnd, {
+  immediate: true
+})
+
+const electionStatus = computed(() => {
+  if (leftToStart.value > 0) return { text: 'Upcoming', color: 'warning' }
+
+  if (formattedElection.voters !== formattedElection.votesCast && leftToEnd.value > 0)
+    return { text: 'Active', color: 'success' }
+
+  return { text: 'Completed', color: 'neutral' }
 })
 
 const timeRemaining = computed(() => {
   if (!formattedElection) return 'No election data available'
 
-  const diff = formattedElection.endDate.getTime() - formattedElection.startDate.getTime()
+  let days
+  let hours
+  let minutes
 
-  if (diff <= 0) return 'election ended'
+  if (electionStatus.value.text === 'Upcoming') {
+    days = Math.floor(leftToStart.value / (60 * 60 * 24))
+    if (days > 0) return `${days} ${days === 1 ? 'day' : 'days'}`
 
-  const days = Math.floor(diff / (1000 * 60 * 60 * 24))
-  if (days > 0) return `${days} ${days === 1 ? 'day' : 'days'}`
+    const hours = Math.floor(leftToStart.value / (60 * 60))
+    if (hours > 0) return `${hours} ${hours === 1 ? 'hour' : 'hours'}`
 
-  const hours = Math.floor(diff / (1000 * 60 * 60))
-  if (hours > 0) return `${hours} ${hours === 1 ? 'hour' : 'hours'}`
+    const minutes = Math.floor(leftToStart.value / 60)
+    if (minutes > 0) return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`
 
-  const minutes = Math.floor(diff / (1000 * 60))
-  return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`
-})
-
-// Election status
-const electionStatus = computed(() => {
-  if (!formattedElection) return { text: 'No Election', class: 'bg-gray-100 text-gray-800' }
-
-  if (now.value < formattedElection.startDate) {
-    return {
-      text: 'Upcoming',
-      color: 'warning'
-    }
+    return `${leftToStart.value} seconds`
   }
-  if (
-    now.value > formattedElection.endDate ||
-    formattedElection.votesCast === formattedElection.voters
-  ) {
-    return {
-      text: 'Completed',
-      color: 'neutral'
-    }
+
+  if (electionStatus.value.text === 'Active') {
+    days = Math.floor(leftToEnd.value / (60 * 60 * 24))
+    if (days > 0) return `${days} ${days === 1 ? 'day' : 'days'}`
+
+    hours = Math.floor(leftToEnd.value / (60 * 60))
+    if (hours > 0) return `${hours} ${hours === 1 ? 'hour' : 'hours'}`
+
+    minutes = Math.floor(leftToEnd.value / 60)
+    if (minutes > 0) return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`
+
+    return `${leftToEnd.value} seconds`
   }
-  return {
-    text: 'Active',
-    color: 'success'
-  }
+
+  return 'Election ended'
 })
 
 const badgeClass = computed(() => `badge-${electionStatus.value.color} badge-outline`)

--- a/app/src/components/sections/AdministrationView/PublishResult.vue
+++ b/app/src/components/sections/AdministrationView/PublishResult.vue
@@ -10,7 +10,7 @@
   </ButtonUI>
 </template>
 <script lang="ts" setup>
-import { ELECTIONS_ABI } from '@/artifacts/abi/elections'
+import ELECTIONS_ABI from '@/artifacts/abi/elections.json'
 import ButtonUI from '@/components/ButtonUI.vue'
 import { useTeamStore, useToastStore } from '@/stores'
 import { log, parseError } from '@/utils'


### PR DESCRIPTION
# Description

## Intial Issue Description

Highlight the election winner and the user's choice.

> Link to the issue in the kanban board
> If no issue exists, please create one and link it here.
Fixes #1047, #1048, #967 


**Before:**
<img width="1185" height="509" alt="before_highlights" src="https://github.com/user-attachments/assets/2346f178-7a2c-42ad-b3a7-b4b3e047e976" />

**After:**
<img width="1153" height="511" alt="after_highlights" src="https://github.com/user-attachments/assets/206a6d90-1238-4519-a251-fd37ee6d45fe" />


## Issues introduced and fixed (Optional)

The cast a vote button was remaining active if the election ends because of expiry, made it to be disabled when the election expires.

## PR Summary Or Solution description

- Add highlight for the candidate voted for by the user.
- Add highlight for the election winners.
- Disable cast a vote button if election is upcoming
- Use useCountdown composable for election status
- Use start time for upcoming election count down


