### PR TITLE
[Perf] Refactor Create vesting #1065

### DIFF
--- a/app/src/components/sections/VestingView/__tests__/VestingFlow.spec.ts
+++ b/app/src/components/sections/VestingView/__tests__/VestingFlow.spec.ts
@@ -7,7 +7,17 @@ import { parseUnits } from 'viem'
 import { VESTING_ADDRESS } from '@/constant'
 //import VestingStatusFilter from '@/components/sections/VestingView/VestingStatusFilter.vue'
 import VestingActions from '@/components/sections/VestingView/VestingActions.vue'
+import { WagmiPlugin, createConfig, http } from '@wagmi/vue'
+import { mainnet } from 'viem/chains'
+import { mockUseCurrencyStore } from '@/tests/mocks/index.mock'
+import { mockUseContractBalance } from '@/tests/mocks/useContractBalance.mock'
 
+const wagmiConfig = createConfig({
+  chains: [mainnet],
+  transports: {
+    [mainnet.id]: http()
+  }
+})
 // Mock Constants
 const memberAddress = '0x000000000000000000000000000000000000dead'
 const mockSymbol = ref('SHR')
@@ -122,6 +132,17 @@ vi.mock('@/stores', () => ({
 
 vi.mock('@/stores/useToastStore')
 
+vi.mock('@/stores/currencyStore', async (importOriginal) => {
+  const original: object = await importOriginal()
+  return {
+    ...original,
+    useCurrencyStore: vi.fn(() => ({ ...mockUseCurrencyStore() }))
+  }
+})
+vi.mock('@/composables/useContractBalance', () => ({
+  useContractBalance: vi.fn(() => mockUseContractBalance)
+}))
+
 describe('VestingFlow.vue', () => {
   let wrapper: VueWrapper
 
@@ -131,7 +152,7 @@ describe('VestingFlow.vue', () => {
         reloadKey: mockReloadKey.value
       },
       global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn })]
+        plugins: [createTestingPinia({ createSpy: vi.fn }), [WagmiPlugin, { config: wagmiConfig }]]
       }
     })
 

--- a/app/src/components/sections/VestingView/forms/CreateVesting.vue
+++ b/app/src/components/sections/VestingView/forms/CreateVesting.vue
@@ -97,14 +97,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue'
-import {
-  differenceInCalendarDays,
-  differenceInMonths,
-  differenceInYears,
-  addYears,
-  addMonths,
-  addDays
-} from '@/utils/dayUtils'
+import { differenceInCalendarDays, differenceInMonths, differenceInYears } from '@/utils/dayUtils'
 import ButtonUI from '@/components/ButtonUI.vue'
 import { useWaitForTransactionReceipt, useWriteContract, useReadContract } from '@wagmi/vue'
 import VestingABI from '@/artifacts/abi/Vesting.json'

--- a/app/src/components/sections/VestingView/forms/CreateVesting.vue
+++ b/app/src/components/sections/VestingView/forms/CreateVesting.vue
@@ -379,11 +379,6 @@ async function submit() {
     const totalAmountInUnits = parseUnits(totalAmount.value.toString(), 6)
     const balanceInUnits = parseUnits(tokenBalance.value.amount.toString(), 6)
     if (balanceInUnits < totalAmountInUnits) {
-      console.error('Insufficient token balance', {
-        balance: balanceInUnits,
-        required: totalAmountInUnits
-      })
-
       addErrorToast('Insufficient token balance')
       return
     }

--- a/app/src/components/sections/VestingView/forms/CreateVesting.vue
+++ b/app/src/components/sections/VestingView/forms/CreateVesting.vue
@@ -32,45 +32,6 @@
         {{ error.$message }}
       </span>
     </div>
-    <div class="flex flex-wrap gap-3 mt-4">
-      <label class="inline-flex items-center gap-2 input-md p-2 flex-1 min-w-[120px]">
-        <span class="text-xs flex-shrink-0">Years</span>
-        <input
-          type="number"
-          data-test="duration-years"
-          min="0"
-          v-model.number="duration.years"
-          class="input input-bordered w-full"
-        />
-      </label>
-      <label class="inline-flex items-center gap-2 input-md p-2 flex-1 min-w-[120px]">
-        <span class="text-xs flex-shrink-0">Months</span>
-        <input
-          type="number"
-          data-test="duration-month"
-          min="0"
-          v-model.number="duration.months"
-          class="input input-bordered w-full"
-        />
-      </label>
-      <label class="inline-flex items-center gap-2 input-md p-2 flex-1 min-w-[120px]">
-        <span class="text-xs flex-shrink-0">Days</span>
-        <input
-          type="number"
-          data-test="duration-days"
-          min="0"
-          v-model.number="duration.days"
-          class="input input-bordered w-full"
-        />
-      </label>
-      <span
-        v-for="error in $v.durationInDays.$errors"
-        :key="error.$uid"
-        class="text-xs text-red-500 mt-1"
-      >
-        {{ error.$message }}
-      </span>
-    </div>
 
     <div class="flex flex-wrap gap-3 mt-4 w-100">
       <div class="flex-1 min-w-[200px]">
@@ -233,27 +194,6 @@ watch(dateRange, async (val) => {
   if (updateCount.value === 2) await resetUpdateCount()
 })
 
-watch(
-  duration,
-  async (val) => {
-    const today = new Date()
-    if (!dateRange.value || !dateRange.value[0]) {
-      dateRange.value = [today, today]
-    }
-    if (updateCount.value > 2) return
-
-    const start = dateRange.value[0]
-    const { years, months, days } = val
-    let newEnd = addYears(start, years)
-    newEnd = addMonths(newEnd, months)
-    newEnd = addDays(newEnd, days)
-    dateRange.value = [start, newEnd]
-    updateCount.value++
-    if (updateCount.value === 2) await resetUpdateCount()
-  },
-  { deep: true }
-)
-
 const emit = defineEmits(['reload', 'closeAddVestingModal'])
 
 const {
@@ -382,10 +322,6 @@ const rules = {
   dateRange: {
     required: helpers.withMessage('Date range is required.', required)
   },
-  durationInDays: {
-    required: helpers.withMessage('Duration is required.', required),
-    minValue: helpers.withMessage('Duration must be at least 1 day.', minValue(1))
-  },
   cliff: {
     required: helpers.withMessage('Cliff is required.', required),
     minValue: minValue(0),
@@ -403,7 +339,6 @@ const rules = {
 const $v = useVuelidate(rules, {
   member,
   dateRange,
-  durationInDays,
   cliff,
   totalAmount
 })

--- a/app/src/components/sections/VestingView/forms/__tests__/CreateVestingInitial.spec.ts
+++ b/app/src/components/sections/VestingView/forms/__tests__/CreateVestingInitial.spec.ts
@@ -41,9 +41,10 @@ const mockWriteContract = {
   isPending: ref(false),
   data: ref(null)
 }
+type VestingInfosType = [string[], object[]] | [string[]] | [] | null | undefined
 
 // Mockeds
-const mockVestingInfos = ref([
+const mockVestingInfos = ref<VestingInfosType>([
   [memberAddress],
   [
     {
@@ -337,6 +338,27 @@ describe('CreateVesting.vue', () => {
       // The last argument should be the amount in units
       const expectedAmount = parseUnits('7', 18)
       expect(callArgs.args[1]).toEqual(expectedAmount)
+    })
+
+    it('returns an empty array from activeMembers if vestingInfos is not an array of length 2', () => {
+      interface IWrapper {
+        activeMembers: string[]
+      }
+
+      // Case 1: vestingInfos is undefined
+      mockVestingInfos.value = undefined
+      let wrapper = mountComponent()
+      expect((wrapper.vm as unknown as IWrapper).activeMembers).toEqual([])
+
+      // Case 2: vestingInfos is length 1
+      mockVestingInfos.value = [[memberAddress]] as unknown as [string[]]
+      wrapper = mountComponent()
+      expect((wrapper.vm as unknown as IWrapper).activeMembers).toEqual([])
+
+      // Case 3: vestingInfos is null
+      mockVestingInfos.value = null
+      wrapper = mountComponent()
+      expect((wrapper.vm as unknown as IWrapper).activeMembers).toEqual([])
     })
 
     it('returns the correct token balance for the given tokenAddress', () => {


### PR DESCRIPTION
# Description

## Intial Issue Description

refactor the create vestion component :

-Remove date manipulation. Only the date picker is enought.

-Use Select Member input to select the user

-Use team store currentTeam directly

-A member should be able to have 2 Vesting, remove the control. 

-Use UseContractBalance instead of TokenBalance from readContract. 

-Use VueLidate

> Link to the issue in the kanban board
> If no issue exists, please create one and link it here.
(Perf) #1065  

## Issues introduced and fixed (Optional)

The Contract don't allow a member to have 2 (two ) active vestings.
test fails due to mixing wagmi config and the update
## PR Summary Or Solution description

Following recommandations propsed by the Issue descrition. 

<img width="518" height="596" alt="image" src="https://github.com/user-attachments/assets/e494bec0-5ca9-4144-bb96-f41b459104ba" />


## Contribution

For your PR please add a comment to each file edited to explain the changes you made.

## Type of change

Please delete options that are not relevant.

- [ ] Perf 

- **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Contribution checklist

Before submitting the PR, please make sure you have applied the rules in [CONTRIBUTION.md](./../CONTRIBUTION.md)
