### PR TITLE
[Bug] 2 expense account address

### DIFF
--- a/app/src/components/sections/TeamView/forms/DeployContractSection.vue
+++ b/app/src/components/sections/TeamView/forms/DeployContractSection.vue
@@ -23,7 +23,7 @@ import { ref, watch, computed } from 'vue'
 import OfficerABI from '@/artifacts/abi/officer.json'
 import BankABI from '@/artifacts/abi/bank.json'
 // import VotingABI from '@/artifacts/abi/voting.json'
-import ExpenseAccountABI from '@/artifacts/abi/expense-account.json'
+
 import ExpenseAccountEIP712ABI from '@/artifacts/abi/expense-account-eip712.json'
 import CashRemunerationEIP712ABI from '@/artifacts/abi/CashRemunerationEIP712.json'
 import FACTORY_BEACON_ABI from '@/artifacts/abi/factory-beacon.json'
@@ -33,7 +33,6 @@ import {
   BANK_BEACON_ADDRESS,
   BOD_BEACON_ADDRESS,
   CASH_REMUNERATION_EIP712_BEACON_ADDRESS,
-  EXPENSE_ACCOUNT_BEACON_ADDRESS,
   EXPENSE_ACCOUNT_EIP712_BEACON_ADDRESS,
   INVESTOR_V1_BEACON_ADDRESS,
   OFFICER_BEACON,
@@ -119,10 +118,6 @@ const deployOfficerContract = async () => {
         beaconAddress: PROPOSALS_BEACON_ADDRESS
       },
       {
-        beaconType: 'ExpenseAccount',
-        beaconAddress: EXPENSE_ACCOUNT_BEACON_ADDRESS
-      },
-      {
         beaconType: 'ExpenseAccountEIP712',
         beaconAddress: EXPENSE_ACCOUNT_EIP712_BEACON_ADDRESS
       },
@@ -178,16 +173,6 @@ const deployOfficerContract = async () => {
       contractType: 'Proposals',
       initializerData: encodeFunctionData({
         abi: PROPOSALS_ABI,
-        functionName: 'initialize',
-        args: [currentUserAddress]
-      })
-    })
-
-    // Expense account
-    deployments.push({
-      contractType: 'ExpenseAccount',
-      initializerData: encodeFunctionData({
-        abi: ExpenseAccountABI,
         functionName: 'initialize',
         args: [currentUserAddress]
       })


### PR DESCRIPTION
# Description

## Intial Issue Description

When you want to transfer from bank to the expense account, you have 2 option of expense account address. It should be only one address
The officer contract should deploy only the EP-712 Expense account.

> Link to the issue in the kanban board
> If no issue exists, please create one and link it here.
Fixes #1078 

## Issues introduced and fixed (Optional)


## PR Summary Or Solution description

remove the old expence account from from deployContractSection.vue
<img width="512" height="316" alt="image" src="https://github.com/user-attachments/assets/d6d10384-ce76-4df6-a463-137848cfc223" />

## Contribution

For your PR please add a comment to each file edited to explain the changes you made.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

- **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Contribution checklist

Before submitting the PR, please make sure you have applied the rules in [CONTRIBUTION.md](./../CONTRIBUTION.md)
