### PR TITLE
Fix/ceo can't create expense

### DIFF
--- a/app/src/components/sections/ExpenseAccountView/MyApprovedExpenseSection.vue
+++ b/app/src/components/sections/ExpenseAccountView/MyApprovedExpenseSection.vue
@@ -56,7 +56,7 @@ const {
   'expenseData',
   computed(() => `/expense?teamId=${teamStore.currentTeamId}`),
   {
-    queryKey: ['expenseData'],
+    queryKey: ['getExpenseData'],
     refetchInterval: 10000,
     refetchOnWindowFocus: true
   }

--- a/app/src/components/sections/ExpenseAccountView/TransferAction.vue
+++ b/app/src/components/sections/ExpenseAccountView/TransferAction.vue
@@ -45,6 +45,7 @@ import expenseAccountABI from '@/artifacts/abi/expense-account-eip712.json'
 import { estimateGas, readContract } from '@wagmi/core'
 import { config } from '@/wagmi.config'
 import ERC20ABI from '@/artifacts/abi/erc20.json'
+import { useQueryClient } from '@tanstack/vue-query'
 
 const props = defineProps<{ row: ExpenseResponse }>()
 
@@ -54,6 +55,7 @@ const { addErrorToast, addSuccessToast } = useToastStore()
 const { balances } = useContractBalance(
   ref(teamStore.getContractAddressByType('ExpenseAccountEIP712'))
 )
+const queryClient = useQueryClient()
 
 const showModal = ref(false)
 const tokenAmount = ref('')
@@ -104,6 +106,8 @@ const transferFromExpenseAccount = async (to: string, amount: string) => {
     if (budgetLimit.tokenAddress === zeroAddress) await transferNativeToken(to, amount, budgetLimit)
     else await transferErc20Token()
   }
+
+  queryClient.invalidateQueries({ queryKey: ['getExpenseData'] })
 }
 
 const transferNativeToken = async (to: string, amount: string, budgetLimit: BudgetLimit) => {

--- a/backend/src/controllers/expenseController.ts
+++ b/backend/src/controllers/expenseController.ts
@@ -24,6 +24,19 @@ export const addExpense = async (req: Request, res: Response) => {
   const data: BudgetLimit = (typeof body.data === "string")
     ? JSON.parse(body.data)
     : body.data;
+
+  const expenseAccountEip712Address = await prisma.teamContract.findFirst({
+    where: {
+      teamId: teamId,
+      type: "ExpenseAccountEIP712"
+    }
+  });
+
+  const owner = await publicClient.readContract({
+    address: expenseAccountEip712Address?.address as Address,
+    abi: ABI,
+    functionName: "owner"
+  }) as unknown as string;     
   
   // Validating the expense data
   let parametersError: string[] = [];
@@ -37,7 +50,7 @@ export const addExpense = async (req: Request, res: Response) => {
   }
   try {
     // Check if the caller is the owner of the team
-    if (!(await isOwnerOfTeam(callerAddress, teamId))) {
+    if (/*!(await isOwnerOfTeam(callerAddress, teamId))*/callerAddress != owner) {
       return errorResponse(403, "Caller is not the owner of the team", res);
     }
     // TODO: should be only one expense active for the user


### PR DESCRIPTION
# Description

## Intial Issue Description

When you are elected as a CEO, you can not create an expense, because the backend expect the team owner to be the one who create the expense..

> Link to the issue in the kanban board
> If no issue exists, please create one and link it here.
Fixes #1103 

## Issues introduced and fixed (Optional)

If exit: The description of issues you find and fix in this PR.

## PR Summary Or Solution description

- Use contract owner instead of team owner for check in backend.
- Invalidate fetch expense data query after transfer for immediate update

## Contribution

For your PR please add a comment to each file edited to explain the changes you made.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

- **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Contribution checklist

Before submitting the PR, please make sure you have applied the rules in [CONTRIBUTION.md](./../CONTRIBUTION.md)
