### PR TITLE
docs: fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ In the `./backend` folder, create a `.env` file with the following variables:
 - **DATABASE_URL**: A valid PostgreSQL database URL. Example:
   `DATABASE_URL=postgres://username:password@localhost:5432/database_name`
 
-  **\*PS** : If you are using the docker container we set up in the top section, the URL should be: `DATABASE_URL=postgres://root:root@localhost:5432/cnc-db`\*
+  **PS**: If you are using the docker container we set up in the top section, the URL should be: `DATABASE_URL=postgres://root:root@localhost:5432/cnc-db`\*
 
 - **SECRET_KEY**: An HS256 compatible key for securing the application. Example:
   `SECRET_KEY=1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0a1b`
@@ -85,11 +85,11 @@ In the `./backend` folder, create a `.env` file with the following variables:
 
 #### Constants
 
-First, go to ./app folder and run `npm run git:ignore-locally`. This command will ignore changes made to the deployed_addresses of the local hardhat network ensuring no conflict.
+First, go to ./app folder and run `npm run git:ignore-locally`. This command will ignore changes made to the deployed_addresses of the local hardhat network, ensuring no conflicts.
 
 Go to the ./contract folder and run `npm run moveConstants`
 
-This action will copy your deployed_addresses from different chains to `src/artifacts/deployed_addresses` directory and imports these constants in `src/constant/index.ts`.
+This action will copy your deployed_addresses from different chains to `src/artifacts/deployed_addresses` directory and imports these constants into `src/constant/index.ts`.
 
 #### Environment variables
 
@@ -100,7 +100,7 @@ In the `./app` folder, create a `.env` file with the following variable:
 - **VITE_APP_ETHERSCAN_URL**: The URL to see transaction detail. Example:
   `VITE_APP_ETHERSCAN_URL=https://sepolia.etherscan.io`
 - **_VITE_APP_NETWORK_ALIAS_**: The string identifier of an EVM compatible network that the app uses. Example: `VITE_APP_NETWORK_ALIAS=polygon`. This variable is optional but if you don't set your own network parameters it has to be provided. Use this if you want to use one of the preset networks which the application provides. Available options are:
-  1. `etherem` - The Ethereum Main Network
+  1. `ethereum` - The Ethereum Main Network
   2. `polygon` - The Polygon Main Network
   3. `sepolia` - The Sepolia Test Network
   4. `holesky` - The Holesky Test Network
@@ -127,7 +127,7 @@ In the `./app` folder, create a `.env` file with the following variable:
 
 ### 1- Run Docker containers
 
-In the root directory run
+In the root directory, run
 
 ```bash
 docker compose up --build
@@ -151,13 +151,13 @@ npm install
 
 #### Start the app in development mode
 
-In `./app` folder
+In the `./app` folder
 
 ```bash
 npm run dev
 ```
 
-In `./backend` folder
+In the `./backend` folder
 
 ```bash
 npm run start

--- a/docs/01_PROJECT_CHARTER.md
+++ b/docs/01_PROJECT_CHARTER.md
@@ -30,7 +30,7 @@ The CNC Portal addresses both problems by providing:
 | Component    | Description                                                                               |
 | ------------ | ----------------------------------------------------------------------------------------- |
 | `app/`       | Vue.js user-facing application — team, contract, governance, vesting, and token workflows |
-| `dashboard/` | Nuxt admin dashboard — activity analytics, member management, backoffice operations       |
+| `dashboard/` | Nuxt admin dashboard — activity analytics, member management, back-office operations       |
 | `backend/`   | Express.js REST API — authentication (SIWE/JWT), user data, platform statistics           |
 | `contract/`  | Hardhat smart contracts — wages, claims, expenses, vesting, proposals, board actions      |
 | `the-graph/` | Subgraph indexing for on-chain event consumption                                          |
@@ -79,7 +79,7 @@ Deliver an intuitive and secure CNC Portal that makes spinning up and running a 
 
 #### S — Specific
 
-- Deploy functional CNC Portal with 6 core modules (Auth, Teams, Payroll, Governance, Tokens, Analytics)
+- Deploy a functional CNC Portal with 6 core modules (Auth, Teams, Payroll, Governance, Tokens, Analytics)
 - Support multi-currency wages (Native token, USDC, custom tokens like SHER)
 - Enable BOD elections with automatic tie-breaking
 - Provide real-time analytics API and admin dashboard
@@ -153,7 +153,7 @@ Deliver an intuitive and secure CNC Portal that makes spinning up and running a 
 - Expense limits are configurable: no limit, max per transaction, max total, or max count
 - All limits are enforced on-chain
 - Expense validation occurs before submission
-- Rejections return expense to draft state for member editing
+- Rejections return the expense to draft state for member editing
 - All reimbursements are final on-chain transactions
 
 ### 4.2 Governance Rules
@@ -189,9 +189,9 @@ Deliver an intuitive and secure CNC Portal that makes spinning up and running a 
 **Team Ownership**
 
 - Team creator is automatically the owner/admin
-- Owners cannot be removed unless promoted another admin first
+- Owners cannot be removed unless promoted to another admin first
 - Only owners can change team settings (name, description, contract)
-- Members can leave team unless they are sole owner
+- Members can leave team unless they are the sole owner
 
 **Member Roles**
 
@@ -201,7 +201,7 @@ Deliver an intuitive and secure CNC Portal that makes spinning up and running a 
 **Invitations**
 
 - Invitations are one-time use and expire after 7 days
-- Invited users must accept to join team (auto-join not allowed)
+- Invited users must accept to join the team (auto-join not allowed)
 - Cannot invite non-existent users
 - Duplicate invitations are rejected
 
@@ -226,7 +226,7 @@ Deliver an intuitive and secure CNC Portal that makes spinning up and running a 
 - Smart contracts must be upgradeable (proxy pattern)
 - Contract state must remain consistent with off-chain database
 - Failed transactions must be retried with exponential backoff
-- Gas prices monitored and transaction batching enabled
+- Gas prices are monitored and transaction batching enabled
 
 ---
 

--- a/docs/02_USER_STORIES.md
+++ b/docs/02_USER_STORIES.md
@@ -242,9 +242,9 @@
 
 - [ ] Wage form shows member name and address
 - [ ] Can set rates in multiple currencies: Native token, USDC, SHER
-- [ ] Each rate is per-hour amount
+- [ ] Each rate is a per-hour amount
 - [ ] Can set maximum hours per week
-- [ ] Save button disabled until all required fields filled
+- [ ] Save button disabled until all required fields are filled
 - [ ] Wage stored on-chain
 - [ ] Success toast: "Wage set for [Member Name]"
 - [ ] Admin can edit/update wages for existing members
@@ -473,7 +473,7 @@
 
 **As a** team admin  
 **I want to** view expense reports
-**So that** I can track spending by member, category, period
+**So that** I can track spending by member, category, and period
 
 **Acceptance Criteria:**
 
@@ -594,7 +594,7 @@
 
 **Acceptance Criteria:**
 
-- [ ] System detects if tie exists for final seat
+- [ ] System detects if a tie exists for final seat
 - [ ] Tie-breaking options:
   - Admin override (admin votes for tied candidate)
   - Secondary vote (only tied candidates voted again)

--- a/docs/03_IMPLEMENTATION_STATUS.md
+++ b/docs/03_IMPLEMENTATION_STATUS.md
@@ -273,7 +273,7 @@ Contract groups in parentheses indicate which contracts were delivered in that m
 
 **For Product Managers:**
 
-- Track overall delivery progress in **Summary by Module** section
+- Track overall delivery progress in the **Summary by Module** section
 - Check **Milestone Progress** to assess timeline status
 - Review **Known Blockers** for risk items
 
@@ -285,7 +285,7 @@ Contract groups in parentheses indicate which contracts were delivered in that m
 
 **For QA:**
 
-- Review status by test type in **Quality & Testing** section
+- Review status by test type in the **Quality & Testing** section
 - Plan test efforts based on feature completion status
 - Reference **User Stories** for acceptance criteria
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ The [Project Charter](./01_PROJECT_CHARTER.md) is the authoritative reference fo
 
 ---
 
-## �📚 Documentation Structure
+## 📚 Documentation Structure
 
 ```
 docs/
@@ -303,7 +303,7 @@ Each feature specification should follow this structure:
 
 - Use your IDE's search function to find specific topics
 - Check the feature folder for feature-specific documentation
-- Platform-wide standards are in `platform/` directory
+- Platform-wide standards are in the `platform/` directory
 - Look for `README.md` files in each folder for navigation
 
 ---
@@ -318,7 +318,7 @@ Each feature specification should follow this structure:
 
 **Prisma ORM:** Modern database toolkit for TypeScript and Node.js that provides type-safe database access.
 
-**SSR (Server-Side Rendering):** Rendering web pages on the server before sending to client.
+**SSR (Server-Side Rendering):** Rendering web pages on the server before sending to the client.
 
 **OpenAPI/Swagger:** Specification for describing RESTful APIs in a machine-readable format.
 
@@ -336,7 +336,7 @@ Each feature specification should follow this structure:
 
 ### Project-Specific Terms
 
-**Team:** Organization unit within CNC Portal where members collaborate.
+**Team:** An organization unit within CNC Portal where members collaborate.
 
 **Claim:** Time or work entry submitted by a member for compensation.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -95,7 +95,7 @@ A key architectural goal of M7 is to move treasury and payroll operations onto [
 | Bank account backed by Safe             | ⏳ Pending | Replace single-owner bank with Safe multi-sig                           |
 | Payroll (wages & claims) backed by Safe | ⏳ Pending | Safe as the fund source for wage disbursements                          |
 | Expense account backed by Safe          | ⏳ Pending | Expense approvals executed via Safe tx                                  |
-| Deploy multiple Safe instances per team | ⏳ Pending | Each team can have dedicated Safes (e.g. ops, payroll, reserve)         |
+| Deploy multiple Safe instances per team | ⏳ Pending | Each team can have dedicated Safes (e.g., ops, payroll, reserve)         |
 | BOD integration with Safe               | ⏳ Pending | BOD members as Safe signers, or Safe as BOD executor — architecture TBD |
 | Safe modules for extended functionality | ⏳ Pending | Custom modules for recurring payments, allowances, spending limits      |
 
@@ -106,8 +106,8 @@ A key architectural goal of M7 is to move treasury and payroll operations onto [
 | Task                                       | Status     | Notes                                                                                        |
 | ------------------------------------------ | ---------- | -------------------------------------------------------------------------------------------- |
 | Test Hardhat Ignition modules              | ⏳ Pending | Validate deployment scripts before mainnet                                                   |
-| Verify Frontend Proxy deployed correctly   | ⏳ Pending | Confirm proxy config in staging and production                                               |
-| Permissioning system necessity review      | ⏳ Pending | Implementation looks solid; evaluate whether RBAC layer is needed given on-chain permissions |
+| Verify Frontend Proxy is deployed correctly   | ⏳ Pending | Confirm proxy config in staging and production                                               |
+| Permissioning system necessity review      | ⏳ Pending | Implementation looks solid; evaluate whether an RBAC layer is needed given on-chain permissions |
 | Complete RBAC (member roles & permissions) | ⏳ Pending | If permissioning review confirms necessity                                                   |
 | Engage professional third-party audit firm | ⏳ Pending | OpenZeppelin, Trail of Bits, or equivalent                                                   |
 

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -30,7 +30,7 @@
 
 **Path**: `contracts/Officer.sol`
 
-Central hub and factory. Each team deploys one Officer which manages all other contracts.
+Central hub and factory. Each team deploys one Officer that manages all other contracts.
 
 **Features**:
 
@@ -65,8 +65,8 @@ Organizational treasury. Holds ETH and ERC20 tokens, routes transfers with proto
 **Features**:
 
 - Accept ETH via `receive()` and ERC20 via `depositToken()`
-- Transfer ETH/ERC20 to recipients; protocol fee (basis points) deducted and sent to FeeCollector
-- ERC20 fee only charged for tokens supported by FeeCollector
+- Transfer ETH/ERC20 to recipients; protocol fee (basis points) is deducted and sent to FeeCollector
+- ERC20 fee is only charged for tokens supported by FeeCollector
 - **Push-based dividend distribution** — no claim pattern; funds transfer directly to shareholders in the same transaction
 - Resolves InvestorV1 address dynamically via Officer (no stored investor address)
 - Pausable and reentrancy-protected
@@ -277,9 +277,9 @@ Linear ERC20 token vesting with cliff periods, organized by teams.
 **Features**:
 
 - Team-based: each team has an owner, token, and member list
-- Cliff period: no tokens releasable until cliff elapses
+- Cliff period: no tokens are releasable until cliff elapses
 - Linear vesting: tokens unlock proportionally after cliff
-- Team owner can stop vesting: releasable tokens go to member, unvested tokens return to owner
+- Team owner can stop vesting: releasable tokens go to the member, unvested tokens return to the owner
 - Archived history of stopped vestings per member/team
 - Upgradeable, Pausable, ReentrancyGuard
 

--- a/docs/contracts/contracts-architecture-diagram.md
+++ b/docs/contracts/contracts-architecture-diagram.md
@@ -310,7 +310,7 @@ sequenceDiagram
     participant Proposals as Proposals Contract
     participant BoD as BoardOfDirectors Contract
 
-    BoardMember->>Proposals: Check if member
+    BoardMember->>Proposals: Check if a member
     Proposals->>BoD: 1. isMember(sender)
     BoD-->>Proposals: 2. true
 
@@ -387,7 +387,7 @@ sequenceDiagram
 
 ### Why Storage Layout Matters
 
-When upgrading contracts via beacons, new implementations must maintain compatible storage layout:
+When upgrading contracts via beacons, new implementations must maintain a compatible storage layout:
 
 ```txt
 OLD IMPLEMENTATION                NEW IMPLEMENTATION


### PR DESCRIPTION
## Summary
- Automated typo/grammar cleanup for `globe-and-citizen/cnc-portal` documentation.

## Changed files
- `README.md`: 7 edit(s)
- `docs/01_PROJECT_CHARTER.md`: 7 edit(s)
- `docs/02_USER_STORIES.md`: 4 edit(s)
- `docs/03_IMPLEMENTATION_STATUS.md`: 2 edit(s)
- `docs/README.md`: 4 edit(s)
- `docs/ROADMAP.md`: 3 edit(s)
- `docs/contracts/README.md`: 5 edit(s)
- `docs/contracts/contracts-architecture-diagram.md`: 2 edit(s)

## Validation
- Reviewed only Markdown documentation files.
- Kept edits minimal and localized.

Automated typo fix. If this helps, feel free to drop a coffee tip to my Base network address: 0x1fD26F97267Ed2a5F674f8505e286271804d1046