### PR TITLE
docs: fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ In the `./backend` folder, create a `.env` file with the following variables:
 
 #### Constants
 
-First, go to ./app folder and run `npm run git:ignore-locally`. This command will ignore changes made to the deployed_addresses of the local hardhat network ensuring no conflict.
+First, go to the ./app folder and run `npm run git:ignore-locally`. This command will ignore changes made to the deployed_addresses of the local hardhat network ensuring no conflict.
 
 Go to the ./contract folder and run `npm run moveConstants`
 
-This action will copy your deployed_addresses from different chains to `src/artifacts/deployed_addresses` directory and imports these constants in `src/constant/index.ts`.
+This action will copy your deployed_addresses from different chains to `src/artifacts/deployed_addresses` directory and import these constants in `src/constant/index.ts`.
 
 #### Environment variables
 
@@ -97,7 +97,7 @@ In the `./app` folder, create a `.env` file with the following variable:
 
 - **VITE_APP_BACKEND_URL**: The URL for the backend API. Example:
   `VITE_APP_BACKEND_URL=http://localhost:8000`
-- **VITE_APP_ETHERSCAN_URL**: The URL to see transaction detail. Example:
+- **VITE_APP_ETHERSCAN_URL**: The URL to see transaction details. Example:
   `VITE_APP_ETHERSCAN_URL=https://sepolia.etherscan.io`
 - **_VITE_APP_NETWORK_ALIAS_**: The string identifier of an EVM compatible network that the app uses. Example: `VITE_APP_NETWORK_ALIAS=polygon`. This variable is optional but if you don't set your own network parameters it has to be provided. Use this if you want to use one of the preset networks which the application provides. Available options are:
   1. `etherem` - The Ethereum Main Network
@@ -118,8 +118,8 @@ In the `./app` folder, create a `.env` file with the following variable:
 1. Go to `/app` folder by doing `cd app`
 2. Run `VITE_APP_NETWORK_ALIAS=hardhat npm run dev` just for building cache
 3. Run `npm run test:build:cache` to build cache. This allows you to skip the wallet installation and setup steps, which can be quite time-consuming
-4. Kill terminal that run the Vue App
-5. Run `anvil --load-state ./local-node-state.json` to run local node for e2e testing.
+4. Kill the terminal that runs the Vue App
+5. Run `anvil --load-state ./local-node-state.json` to run a local node for e2e testing.
 6. Run `npm run test` to run the tests.
 7. Or run `npm run test:headless` to run tests in headless mode
 
@@ -127,7 +127,7 @@ In the `./app` folder, create a `.env` file with the following variable:
 
 ### 1- Run Docker containers
 
-In the root directory run
+In the root directory, run
 
 ```bash
 docker compose up --build

--- a/docs/01_PROJECT_CHARTER.md
+++ b/docs/01_PROJECT_CHARTER.md
@@ -73,7 +73,7 @@ Deliver an intuitive and secure CNC Portal that makes spinning up and running a 
 | ------------------------ | --------------------------------------------------------------------------------------------- |
 | Contributor compensation | A team can create, approve, and execute a wage or claim end-to-end without off-platform tools |
 | Governance workflow      | A proposal can be created, voted on, and executed fully on-chain via the UI                   |
-| Analytics availability   | Platform statistics are available in real time for any active team                            |
+| Analytics availability   | Platform statistics are available in real-time for any active team                            |
 
 ### 3.2 SMART Objectives Breakdown
 
@@ -142,7 +142,7 @@ Deliver an intuitive and secure CNC Portal that makes spinning up and running a 
 
 - Each member can have wage rates defined in multiple currencies (Native token, USDC, SHER)
 - Maximum hours per week set by admin for each member
-- All claims must be submitted within 7 days of work period
+- All claims must be submitted within 7 days of the work period
 - No claim can contain more than 24 hours in a single submission
 - Multiple claims in a day are rate-limited to prevent abuse
 - Claims must be approved by admin before payment
@@ -153,7 +153,7 @@ Deliver an intuitive and secure CNC Portal that makes spinning up and running a 
 - Expense limits are configurable: no limit, max per transaction, max total, or max count
 - All limits are enforced on-chain
 - Expense validation occurs before submission
-- Rejections return expense to draft state for member editing
+- Rejections return the expense to draft state for member editing
 - All reimbursements are final on-chain transactions
 
 ### 4.2 Governance Rules
@@ -172,7 +172,7 @@ Deliver an intuitive and secure CNC Portal that makes spinning up and running a 
 - Each member gets one vote per election
 - Member can vote for up to N candidates (where N = number of seats)
 - Top N vote-getters become board members
-- Ties for final seat trigger tie-breaking mechanism
+- Ties for the final seat trigger the tie-breaking mechanism
 - BOD roles are updated on-chain immediately after election ends
 - Previous BOD is replaced entirely (not incremental)
 
@@ -189,9 +189,9 @@ Deliver an intuitive and secure CNC Portal that makes spinning up and running a 
 **Team Ownership**
 
 - Team creator is automatically the owner/admin
-- Owners cannot be removed unless promoted another admin first
+- Owners cannot be removed unless promoted to another admin first
 - Only owners can change team settings (name, description, contract)
-- Members can leave team unless they are sole owner
+- Members can leave the team unless they are sole owner
 
 **Member Roles**
 
@@ -201,7 +201,7 @@ Deliver an intuitive and secure CNC Portal that makes spinning up and running a 
 **Invitations**
 
 - Invitations are one-time use and expire after 7 days
-- Invited users must accept to join team (auto-join not allowed)
+- Invited users must accept to join the team (auto-join not allowed)
 - Cannot invite non-existent users
 - Duplicate invitations are rejected
 

--- a/docs/02_USER_STORIES.md
+++ b/docs/02_USER_STORIES.md
@@ -174,7 +174,7 @@
 - [ ] Invited user receives notification
 - [ ] User can accept/decline invitation
 - [ ] Accepted users appear in member list
-- [ ] Declined invitations don't add member
+- [ ] Declined invitations don't add members
 - [ ] Admin can view pending invitations
 
 **Priority:** P1 (Critical)  
@@ -244,7 +244,7 @@
 - [ ] Can set rates in multiple currencies: Native token, USDC, SHER
 - [ ] Each rate is per-hour amount
 - [ ] Can set maximum hours per week
-- [ ] Save button disabled until all required fields filled
+- [ ] Save button disabled until all required fields are filled
 - [ ] Wage stored on-chain
 - [ ] Success toast: "Wage set for [Member Name]"
 - [ ] Admin can edit/update wages for existing members
@@ -473,7 +473,7 @@
 
 **As a** team admin  
 **I want to** view expense reports
-**So that** I can track spending by member, category, period
+**So that** I can track spending by member, category, and period
 
 **Acceptance Criteria:**
 
@@ -594,7 +594,7 @@
 
 **Acceptance Criteria:**
 
-- [ ] System detects if tie exists for final seat
+- [ ] System detects if a tie exists for final seat
 - [ ] Tie-breaking options:
   - Admin override (admin votes for tied candidate)
   - Secondary vote (only tied candidates voted again)

--- a/docs/03_IMPLEMENTATION_STATUS.md
+++ b/docs/03_IMPLEMENTATION_STATUS.md
@@ -273,7 +273,7 @@ Contract groups in parentheses indicate which contracts were delivered in that m
 
 **For Product Managers:**
 
-- Track overall delivery progress in **Summary by Module** section
+- Track overall delivery progress in the **Summary by Module** section
 - Check **Milestone Progress** to assess timeline status
 - Review **Known Blockers** for risk items
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ Welcome to the CNC Portal documentation. This directory contains comprehensive d
 **New to the project?**
 
 - 📖 [Getting Started](#-getting-started) - Start here
-- 📋 [Project Charter](./01_PROJECT_CHARTER.md) - Vision, scope, objectives and milestones
+- 📋 [Project Charter](./01_PROJECT_CHARTER.md) - Vision, scope, objectives, and milestones
 - 🏗️ [Architecture Overview](./platform/architecture.md) - Understand the system
 - 🔐 [Authentication](./auth/README.md) - How users authenticate
 - 📊 [Statistics Feature](./features/stats/functional-specification.md) - Example feature
@@ -74,7 +74,7 @@ The [Project Charter](./01_PROJECT_CHARTER.md) is the authoritative reference fo
 
 ---
 
-## �📚 Documentation Structure
+## 📚 Documentation Structure
 
 ```
 docs/
@@ -303,7 +303,7 @@ Each feature specification should follow this structure:
 
 - Use your IDE's search function to find specific topics
 - Check the feature folder for feature-specific documentation
-- Platform-wide standards are in `platform/` directory
+- Platform-wide standards are in the `platform/` directory
 - Look for `README.md` files in each folder for navigation
 
 ---
@@ -318,7 +318,7 @@ Each feature specification should follow this structure:
 
 **Prisma ORM:** Modern database toolkit for TypeScript and Node.js that provides type-safe database access.
 
-**SSR (Server-Side Rendering):** Rendering web pages on the server before sending to client.
+**SSR (Server-Side Rendering):** Rendering web pages on the server before sending to the client.
 
 **OpenAPI/Swagger:** Specification for describing RESTful APIs in a machine-readable format.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -113,7 +113,7 @@ A key architectural goal of M7 is to move treasury and payroll operations onto [
 
 **Key activities:**
 
-- Remediate all critical and high security findings
+- Remediate all critical and high-security findings
 - Drive E2E suite to full critical-path coverage
 - Implement Safe as the underlying multi-sig for bank/payroll/expense accounts
 - Decide and implement BOD ↔ Safe architecture

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -147,7 +147,7 @@ Multi-signature governance contract. Board members approve actions that auto-exe
 
 **Features**:
 
-- Board membership set by Elections contract
+- Board membership set by the Elections contract
 - Any board member can propose an encoded action
 - Majority (>50%) approval required for execution
 - Auto-executes approved actions against any target contract
@@ -279,7 +279,7 @@ Linear ERC20 token vesting with cliff periods, organized by teams.
 - Team-based: each team has an owner, token, and member list
 - Cliff period: no tokens releasable until cliff elapses
 - Linear vesting: tokens unlock proportionally after cliff
-- Team owner can stop vesting: releasable tokens go to member, unvested tokens return to owner
+- Team owner can stop vesting: releasable tokens go to the member, unvested tokens return to owner
 - Archived history of stopped vestings per member/team
 - Upgradeable, Pausable, ReentrancyGuard
 


### PR DESCRIPTION
## Summary
- Automated typo/grammar cleanup for `globe-and-citizen/cnc-portal` documentation.

## Changed files
- `README.md`: 6 edit(s)
- `docs/01_PROJECT_CHARTER.md`: 7 edit(s)
- `docs/02_USER_STORIES.md`: 4 edit(s)
- `docs/03_IMPLEMENTATION_STATUS.md`: 1 edit(s)
- `docs/README.md`: 4 edit(s)
- `docs/ROADMAP.md`: 1 edit(s)
- `docs/contracts/README.md`: 2 edit(s)

## Validation
- Reviewed only Markdown documentation files.
- Kept edits minimal and localized.

Automated typo fix. If this helps, feel free to drop a coffee tip to my Base network address: 0x1fD26F97267Ed2a5F674f8505e286271804d1046