### PR TITLE
Add and enhance TeamSelectMenu component in NavBar

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -22,6 +22,9 @@
                       trailing-icon="heroicons:arrow-right-start-on-rectangle"
                     />
                   </template>
+                  <template #trailing>
+                    <TeamSelectMenu />
+                  </template>
                   <template #right>
                     <NavBar />
                   </template>
@@ -52,6 +55,7 @@ import { RouterView, useRoute } from 'vue-router'
 
 import LockScreen from '@/components/LockScreen.vue'
 import NavBar from '@/components/NavBar.vue'
+import TeamSelectMenu from '@/components/TeamSelectMenu.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import SidebarLayout from '@/components/ui/SidebarLayout.vue'
 

--- a/app/src/components/NavBar.vue
+++ b/app/src/components/NavBar.vue
@@ -22,7 +22,6 @@
 
         <NotificationDropdown />
 
-
         <div class="dropdown dropdown-end" data-test="profile">
           <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar">
             <div class="w-8 sm:w-10 rounded-full ring-3 ring-white ring-opacity-30 ring-offset-2">

--- a/app/src/components/NavBar.vue
+++ b/app/src/components/NavBar.vue
@@ -103,7 +103,4 @@ const { imageUrl } = storeToRefs(userStore)
   animation: fadeIn 0.2s ease-out;
 }
 
-/* *{
-  border: 1px solid red !important;
-} */
 </style>

--- a/app/src/components/NavBar.vue
+++ b/app/src/components/NavBar.vue
@@ -102,5 +102,4 @@ const { imageUrl } = storeToRefs(userStore)
 .dropdown-content {
   animation: fadeIn 0.2s ease-out;
 }
-
 </style>

--- a/app/src/components/NavBar.vue
+++ b/app/src/components/NavBar.vue
@@ -22,6 +22,7 @@
 
         <NotificationDropdown />
 
+
         <div class="dropdown dropdown-end" data-test="profile">
           <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar">
             <div class="w-8 sm:w-10 rounded-full ring-3 ring-white ring-opacity-30 ring-offset-2">
@@ -81,10 +82,6 @@ defineEmits(['toggleSideButton', 'toggleEditUserModal'])
 const { logout } = useAuth()
 const userStore = useUserDataStore()
 const { imageUrl } = storeToRefs(userStore)
-
-// defineProps<{
-//   isCollapsed: boolean
-// }>()
 </script>
 
 <style scoped>
@@ -106,4 +103,8 @@ const { imageUrl } = storeToRefs(userStore)
 .dropdown-content {
   animation: fadeIn 0.2s ease-out;
 }
+
+/* *{
+  border: 1px solid red !important;
+} */
 </style>

--- a/app/src/components/TeamSelectMenu.vue
+++ b/app/src/components/TeamSelectMenu.vue
@@ -55,11 +55,15 @@ const selectedTeam = computed({
 })
 
 // When teams load and no team is active yet, default to the first one
-watch(teamItems, (items) => {
-  const first = items[0]
-  if (!activeTeamId.value && first) {
-    teamStore.setCurrentTeamId(first.id)
-    router.push(`/teams/${first.id}`)
-  }
-}, { immediate: true })
+watch(
+  teamItems,
+  (items) => {
+    const first = items[0]
+    if (!activeTeamId.value && first) {
+      teamStore.setCurrentTeamId(first.id)
+      router.push(`/teams/${first.id}`)
+    }
+  },
+  { immediate: true }
+)
 </script>

--- a/app/src/components/TeamSelectMenu.vue
+++ b/app/src/components/TeamSelectMenu.vue
@@ -62,5 +62,5 @@ watch(teamItems, (items) => {
     teamStore.setCurrentTeamId(first.id)
     router.push(`/teams/${first.id}`)
   }
-})
+}, { immediate: true })
 </script>

--- a/app/src/components/TeamSelectMenu.vue
+++ b/app/src/components/TeamSelectMenu.vue
@@ -6,7 +6,8 @@
     placeholder="Select team"
     by="id"
     class="w-50"
-    icon="i-heroicons-user-group"
+    size="xl"
+    :avatar="selectedTeam?.avatar"
     :search-input="{ placeholder: 'Search team...' }"
   />
 </template>
@@ -29,12 +30,16 @@ const { data: teams, isPending: teamsLoading } = useGetTeamsQuery({
 })
 
 const teamItems = computed(() =>
-  (teams.value ?? []).map((t) => ({ label: t.name, id: t.id }))
+  (teams.value ?? []).map((t) => ({
+    label: t.name,
+    id: t.id,
+    avatar: { text: t.name.charAt(0).toUpperCase() }
+  }))
 )
 
 // The active team id: prefer the route param (most authoritative), then the store
-const activeTeamId = computed(() =>
-  (route.params.id as string | undefined) ?? currentTeamId.value ?? null
+const activeTeamId = computed(
+  () => (route.params.id as string | undefined) ?? currentTeamId.value ?? null
 )
 
 const selectedTeam = computed({

--- a/app/src/components/TeamSelectMenu.vue
+++ b/app/src/components/TeamSelectMenu.vue
@@ -44,7 +44,6 @@ const activeTeamId = computed(
 
 const selectedTeam = computed({
   get() {
-    // console.log(' teamItems.value.find((t) => t.id === activeTeamId.value) ',  teamItems.value.find((t) => t.id === activeTeamId.value) )
     return teamItems.value.find((t) => Number(t.id) === Number(activeTeamId.value)) ?? undefined
   },
   set(item: { label: string; id: string } | undefined) {

--- a/app/src/components/TeamSelectMenu.vue
+++ b/app/src/components/TeamSelectMenu.vue
@@ -1,0 +1,61 @@
+<template>
+  <USelectMenu
+    v-model="selectedTeam"
+    :items="teamItems"
+    :loading="teamsLoading"
+    placeholder="Select team"
+    by="id"
+    class="w-50"
+    icon="i-heroicons-user-group"
+    :search-input="{ placeholder: 'Search team...' }"
+  />
+</template>
+
+<script setup lang="ts">
+import { useUserDataStore, useTeamStore } from '@/stores'
+import { useGetTeamsQuery } from '@/queries/team.queries'
+import { storeToRefs } from 'pinia'
+import { computed, watch } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+
+const router = useRouter()
+const route = useRoute()
+const userStore = useUserDataStore()
+const teamStore = useTeamStore()
+const { currentTeamId } = storeToRefs(teamStore)
+
+const { data: teams, isPending: teamsLoading } = useGetTeamsQuery({
+  queryParams: { userAddress: computed(() => userStore.address) }
+})
+
+const teamItems = computed(() =>
+  (teams.value ?? []).map((t) => ({ label: t.name, id: t.id }))
+)
+
+// The active team id: prefer the route param (most authoritative), then the store
+const activeTeamId = computed(() =>
+  (route.params.id as string | undefined) ?? currentTeamId.value ?? null
+)
+
+const selectedTeam = computed({
+  get() {
+    // console.log(' teamItems.value.find((t) => t.id === activeTeamId.value) ',  teamItems.value.find((t) => t.id === activeTeamId.value) )
+    return teamItems.value.find((t) => Number(t.id) === Number(activeTeamId.value)) ?? undefined
+  },
+  set(item: { label: string; id: string } | undefined) {
+    if (item) {
+      teamStore.setCurrentTeamId(item.id)
+      router.push(`/teams/${item.id}`)
+    }
+  }
+})
+
+// When teams load and no team is active yet, default to the first one
+watch(teamItems, (items) => {
+  const first = items[0]
+  if (!activeTeamId.value && first) {
+    teamStore.setCurrentTeamId(first.id)
+    router.push(`/teams/${first.id}`)
+  }
+})
+</script>

--- a/app/src/components/__tests__/TeamSelectMenu.spec.ts
+++ b/app/src/components/__tests__/TeamSelectMenu.spec.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { useTeamStore } from '@/stores'
+import TeamSelectMenu from '@/components/TeamSelectMenu.vue'
+import { useGetTeamsQuery } from '@/queries/team.queries'
+import { mockTeamStore, mockTeamsData } from '@/tests/mocks/index'
+import { mockRouterPush } from '@/tests/mocks/router.mock'
+import { createMockQueryResponse } from '@/tests/mocks/query.mock'
+
+// jsdom does not implement scrollIntoView — reka-ui calls it when highlighting items
+Element.prototype.scrollIntoView = vi.fn()
+
+// currentTeamId must be a Vue ref so that storeToRefs() can extract it properly
+const mockCurrentTeamId = ref<string | null>(mockTeamStore.currentTeamId)
+
+const createWrapper = () => mount(TeamSelectMenu, { attachTo: document.body })
+
+describe('TeamSelectMenu', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Element.prototype.scrollIntoView = vi.fn()
+    mockCurrentTeamId.value = mockTeamStore.currentTeamId
+
+    // Return the mock store with currentTeamId as a ref so storeToRefs works
+    vi.mocked(useTeamStore).mockImplementation(
+      () =>
+        ({
+          ...mockTeamStore,
+          currentTeamId: mockCurrentTeamId
+        }) as unknown as ReturnType<typeof useTeamStore>
+    )
+  })
+
+  describe('rendering', () => {
+    it('renders the select trigger button', () => {
+      const wrapper = createWrapper()
+      expect(wrapper.find('button').exists()).toBe(true)
+    })
+
+    it('shows a loading icon when teams are being fetched', () => {
+      vi.mocked(useGetTeamsQuery).mockReturnValueOnce(
+        createMockQueryResponse([], true) as ReturnType<typeof useGetTeamsQuery>
+      )
+      const wrapper = createWrapper()
+      expect(wrapper.find('svg').exists()).toBe(true)
+    })
+
+    it('shows placeholder text when no team matches', () => {
+      vi.mocked(useGetTeamsQuery).mockReturnValueOnce(
+        createMockQueryResponse([]) as ReturnType<typeof useGetTeamsQuery>
+      )
+      vi.mocked(useRoute).mockReturnValueOnce({
+        params: {},
+        path: '/teams',
+        meta: {}
+      } as ReturnType<typeof useRoute>)
+
+      const wrapper = createWrapper()
+      expect(wrapper.text()).toContain('Select team')
+    })
+  })
+
+  describe('default selection', () => {
+    it('pre-selects the team matching the current route param id', () => {
+      // useRoute is globally mocked with params.id = '1' and mockTeamsData[0].id = '1'
+      const wrapper = createWrapper()
+      expect(wrapper.text()).toContain(mockTeamsData[0]!.name)
+    })
+
+    it('auto-selects first team and navigates when no team is active', async () => {
+      mockCurrentTeamId.value = null
+      vi.mocked(useRoute).mockReturnValueOnce({
+        params: {},
+        path: '/teams',
+        meta: {}
+      } as ReturnType<typeof useRoute>)
+
+      createWrapper()
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(mockTeamStore.setCurrentTeamId).toHaveBeenCalledWith(mockTeamsData[0]!.id)
+      expect(mockRouterPush).toHaveBeenCalledWith(`/teams/${mockTeamsData[0]!.id}`)
+    })
+
+    it('does not auto-navigate when a team is already active via route param', async () => {
+      // useRoute returns params.id = '1' by default — team is already "active"
+      createWrapper()
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(mockRouterPush).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('team items', () => {
+    it('displays all team names in the dropdown', async () => {
+      const wrapper = createWrapper()
+      await wrapper.find('button').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      mockTeamsData.forEach((team) => {
+        expect(wrapper.html()).toContain(team.name)
+      })
+    })
+
+    it('renders the initial letter avatar for each team item', async () => {
+      const wrapper = createWrapper()
+      await wrapper.find('button').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      mockTeamsData.forEach((team) => {
+        expect(wrapper.html()).toContain(team.name.charAt(0).toUpperCase())
+      })
+    })
+  })
+
+  describe('team selection', () => {
+    it('calls setCurrentTeamId with the selected team id', async () => {
+      const wrapper = createWrapper()
+      await wrapper.find('button').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      const options = wrapper.findAll('[role="option"]')
+      if (options[0]) {
+        await options[0].trigger('click')
+        await wrapper.vm.$nextTick()
+        expect(mockTeamStore.setCurrentTeamId).toHaveBeenCalledWith(mockTeamsData[0]!.id)
+      }
+    })
+
+    it('navigates to /teams/:id when a team is selected', async () => {
+      const wrapper = createWrapper()
+      await wrapper.find('button').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      const options = wrapper.findAll('[role="option"]')
+      if (options[0]) {
+        await options[0].trigger('click')
+        await wrapper.vm.$nextTick()
+        expect(mockRouterPush).toHaveBeenCalledWith(`/teams/${mockTeamsData[0]!.id}`)
+      }
+    })
+  })
+
+  describe('search', () => {
+    it('renders a search input with the correct placeholder', async () => {
+      const wrapper = createWrapper()
+      await wrapper.find('button').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      // USelectMenu renders its dropdown in a portal attached to document.body
+      const input = document.querySelector('input')
+      expect(input).not.toBeNull()
+      expect(input?.getAttribute('placeholder')).toBe('Search team...')
+    })
+
+    it('filters teams by name based on search input', async () => {
+      vi.mocked(useGetTeamsQuery).mockReturnValueOnce(
+        createMockQueryResponse([
+          { ...mockTeamsData[0]!, id: '1', name: 'Alpha Team' },
+          { ...mockTeamsData[0]!, id: '2', name: 'Beta Squad' }
+        ]) as ReturnType<typeof useGetTeamsQuery>
+      )
+
+      const wrapper = createWrapper()
+      await wrapper.find('button').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      const input = document.querySelector('input') as HTMLInputElement
+      expect(input).not.toBeNull()
+
+      // Simulate typing — use nativeInputValueSetter to trigger reka-ui's input handler
+      input.value = 'Beta'
+      input.dispatchEvent(new InputEvent('input', { bubbles: true, cancelable: true }))
+      await wrapper.vm.$nextTick()
+
+      const listbox = document.querySelector('[role="listbox"]')
+      expect(listbox?.textContent).toContain('Beta Squad')
+      expect(listbox?.textContent).not.toContain('Alpha Team')
+    })
+  })
+})


### PR DESCRIPTION
This pull request introduces a new `TeamSelectMenu` component and integrates it into the application's main layout, allowing users to select and switch teams more easily. The changes also include necessary imports and some minor code cleanups.

**Team selection improvements:**

* Added a new `TeamSelectMenu` component (`TeamSelectMenu.vue`) that provides a dropdown menu for selecting teams, fetching available teams for the user, and updating the current team in both the store and the route.
* Integrated `TeamSelectMenu` into the main app layout by adding it to the `#trailing` slot in `App.vue`.
* Imported `TeamSelectMenu` in `App.vue` to enable its usage in the template.

**Minor code cleanup:**

* Removed commented-out `defineProps` code from `NavBar.vue` for clarity.
* Commented out a global border style in the `NavBar.vue` style section, likely used for debugging.