### PR TITLE
security: add _disableInitializers() to all upgradeable contract implementations

### DIFF
--- a/app/src/artifacts/abi/json/Bank.json
+++ b/app/src/artifacts/abi/json/Bank.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "EnforcedPause",
     "type": "error"
   },

--- a/app/src/artifacts/abi/json/BoardOfDirectors.json
+++ b/app/src/artifacts/abi/json/BoardOfDirectors.json
@@ -1,5 +1,10 @@
 [
   {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",

--- a/app/src/artifacts/abi/json/CashRemunerationEIP712.json
+++ b/app/src/artifacts/abi/json/CashRemunerationEIP712.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "BankContractNotFound",
     "type": "error"
   },

--- a/app/src/artifacts/abi/json/Elections.json
+++ b/app/src/artifacts/abi/json/Elections.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "AlreadyVoted",
     "type": "error"
   },

--- a/app/src/artifacts/abi/json/ExpenseAccountEIP712.json
+++ b/app/src/artifacts/abi/json/ExpenseAccountEIP712.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "AmountExceedsBudgetLimit",
     "type": "error"
   },

--- a/app/src/artifacts/abi/json/FeeCollector.json
+++ b/app/src/artifacts/abi/json/FeeCollector.json
@@ -1,5 +1,10 @@
 [
   {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
     "inputs": [
       {
         "internalType": "string",

--- a/app/src/artifacts/abi/json/InvestorV1.json
+++ b/app/src/artifacts/abi/json/InvestorV1.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "AccessControlBadConfirmation",
     "type": "error"
   },

--- a/app/src/artifacts/abi/json/Proposals.json
+++ b/app/src/artifacts/abi/json/Proposals.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "BoardOfDirectorAddressNotSet",
     "type": "error"
   },

--- a/app/src/artifacts/abi/json/Tips.json
+++ b/app/src/artifacts/abi/json/Tips.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "BalanceNotCleared",
     "type": "error"
   },

--- a/app/src/artifacts/abi/json/Vesting.json
+++ b/app/src/artifacts/abi/json/Vesting.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "CliffExceedsDuration",
     "type": "error"
   },

--- a/app/src/artifacts/abi/json/Voting.json
+++ b/app/src/artifacts/abi/json/Voting.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "BoardOfDirectorsNotFound",
     "type": "error"
   },

--- a/contract/contracts/Bank.sol
+++ b/contract/contracts/Bank.sol
@@ -119,6 +119,11 @@ contract Bank is OwnableUpgradeable, ReentrancyGuardUpgradeable, PausableUpgrade
     return investorAddress;
   }
 
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
   /**
    * @notice Initializes the Bank contract with supported tokens and owner
    * @dev This function replaces the constructor for upgradeable contracts

--- a/contract/contracts/BoardOfDirectors.sol
+++ b/contract/contracts/BoardOfDirectors.sol
@@ -106,6 +106,11 @@ contract BoardOfDirectors is ReentrancyGuardUpgradeable, IBoardOfDirectors {
   /// @dev The function can only be called by the contract itself.
   error NotSelf();
 
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
   /**
    * @dev Initializes the contract with the initial set of owners.
    * @param _owners The initial set of owners.

--- a/contract/contracts/CashRemunerationEIP712.sol
+++ b/contract/contracts/CashRemunerationEIP712.sol
@@ -184,6 +184,11 @@ contract CashRemunerationEIP712 is
   /// @param token The token whose `transfer` returned false.
   error TokenTransferFailed(address token);
 
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
   /**
    * @dev Initializes the contract with the specified owner.
    * @param _owner The address of the contract owner.

--- a/contract/contracts/Elections/Elections.sol
+++ b/contract/contracts/Elections/Elections.sol
@@ -87,6 +87,11 @@ contract Elections is Initializable, OwnableUpgradeable, PausableUpgradeable {
   /// @dev The BoardOfDirectors contract could not be located via the Officer.
   error BoardOfDirectorsNotFound();
 
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
   /**
    * @notice Initializes the Elections contract.
    * @param _owner Address that will own the contract.

--- a/contract/contracts/FeeCollector.sol
+++ b/contract/contracts/FeeCollector.sol
@@ -71,6 +71,11 @@ contract FeeCollector is
   /// @param available The current token balance.
   error InsufficientTokenBalance(address token, uint256 required, uint256 available);
 
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
   /**
    * @notice Initializes the FeeCollector with owner, fee configs, and supported tokens
    * @param _owner The address that will own this contract

--- a/contract/contracts/Investor/InvestorV1.sol
+++ b/contract/contracts/Investor/InvestorV1.sol
@@ -118,6 +118,11 @@ contract InvestorV1 is
   /// @param available The current contract balance.
   error InsufficientFundedTokenBalance(address token, uint256 required, uint256 available);
 
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
   /**
    * @notice Initializes the InvestorV1 token.
    * @param _name ERC20 token name.

--- a/contract/contracts/Officer.sol
+++ b/contract/contracts/Officer.sol
@@ -98,9 +98,11 @@ contract Officer is OwnableUpgradeable, ReentrancyGuardUpgradeable, PausableUpgr
    * @notice Sets the immutable fee collector used by this officer.
    * @param _feeCollector Address of the fee collector contract.
    */
+  /// @custom:oz-upgrades-unsafe-allow constructor
   constructor(address _feeCollector) {
     if (_feeCollector == address(0)) revert ZeroAddress();
     feeCollector = _feeCollector;
+    _disableInitializers();
   }
 
   /**

--- a/contract/contracts/Proposals/Proposals.sol
+++ b/contract/contracts/Proposals/Proposals.sol
@@ -176,6 +176,11 @@ contract Proposals is OwnableUpgradeable, PausableUpgradeable, ReentrancyGuardUp
     uint256 abstainCount
   );
 
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
   /**
    * @notice Initializes the Proposals contract.
    * @param _owner Address that will own the contract.

--- a/contract/contracts/Tips.sol
+++ b/contract/contracts/Tips.sol
@@ -71,6 +71,11 @@ contract Tips is OwnableUpgradeable, ReentrancyGuardUpgradeable, PausableUpgrade
   /// @param maximum The max push limit allowed.
   error LimitTooHigh(uint8 requested, uint8 maximum);
 
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
   /**
    * @notice Initializes the contract owner, reentrancy guard, pause state and default push limit.
    * @dev Proxy initializer; sets the caller as owner and pushLimit to 10.

--- a/contract/contracts/Vesting.sol
+++ b/contract/contracts/Vesting.sol
@@ -109,6 +109,11 @@ contract Vesting is OwnableUpgradeable, ReentrancyGuardUpgradeable, PausableUpgr
   /// @dev The releasable amount is zero.
   error NothingToRelease();
 
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
   /// @notice Initializer instead of constructor for proxy compatibility
   function initialize() public initializer {
     __Ownable_init(msg.sender);

--- a/contract/contracts/Voting/Voting.sol
+++ b/contract/contracts/Voting/Voting.sol
@@ -68,6 +68,11 @@ contract Voting is OwnableUpgradeable, ReentrancyGuardUpgradeable, PausableUpgra
   /// @dev The BoardOfDirectors contract could not be located via the Officer.
   error BoardOfDirectorsNotFound();
 
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
   /// @notice Initializes the contract
   /// @param _sender Address that will be set as the owner
   /// @dev This is the initialization function for the upgradeable contract pattern

--- a/contract/contracts/expense-account/ExpenseAccountEIP712.sol
+++ b/contract/contracts/expense-account/ExpenseAccountEIP712.sol
@@ -236,6 +236,11 @@ contract ExpenseAccountEIP712 is
   /// @dev The Bank contract could not be located via the Officer.
   error BankContractNotFound();
 
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
   /**
    * @notice Initializes the expense account contract.
    * @param owner The contract owner that will sign budget approvals.

--- a/contract/ignition/modules/ElectionsModule.ts
+++ b/contract/ignition/modules/ElectionsModule.ts
@@ -2,8 +2,10 @@ import { buildModule } from '@nomicfoundation/hardhat-ignition/modules'
 
 const electionsBeaconModule = buildModule('ElectionsBeaconModule', (m) => {
   const beaconAdmin = m.getAccount(0)
+  // Implementation remains UNINITIALIZED (initialized via beacon proxy at creation).
+  // The constructor calls `_disableInitializers()` to harden against the Parity-wallet
+  // class attack, so calling `initialize` on the bare impl would revert.
   const electionsImplementation = m.contract('Elections')
-  m.call(electionsImplementation, 'initialize', [beaconAdmin])
   const beacon = m.contract('Beacon', [electionsImplementation], {
     from: beaconAdmin
   })

--- a/contract/ignition/modules/OfficerModule.ts
+++ b/contract/ignition/modules/OfficerModule.ts
@@ -14,29 +14,28 @@ export default buildModule('Officer', (m) => {
   const beaconAdmin = m.getAccount(0)
   const { feeCollector } = m.useModule(FeeCollectorModule)
   const officer = m.contract('Officer', [feeCollector])
-  const { beacon: bankBeacon } = m.useModule(bankBeaconModule)
-  const { beacon: BoDBeacon } = m.useModule(boardOfDirectorsBeaconModule)
-  const { beacon: proposalBeacon } = m.useModule(proposalBeaconModule)
-  const { beacon: electionsBeacon } = m.useModule(electionsBeaconModule)
-  const { beacon: investorsV1Beacon } = m.useModule(investorsV1BeaconModule)
-  // const { expenseAccountFactoryBeacon } = m.useModule(ExpenseAccountModule)
-  const { expenseAccountEip712FactoryBeacon } = m.useModule(ExpenseAccountEIP712Module)
-  const { cashRemunerationEip712FactoryBeacon } = m.useModule(CashRemunerationEIP712Module)
-  const { beacon: safeDepositRouterBeacon } = m.useModule(SafeDepositRouterBeaconModule)
 
-  const beaconConfigs = [
-    { beaconType: 'Bank', beaconAddress: bankBeacon },
-    { beaconType: 'Elections', beaconAddress: electionsBeacon },
-    { beaconType: 'Proposals', beaconAddress: proposalBeacon },
-    { beaconType: 'BoardOfDirectors', beaconAddress: BoDBeacon },
-    // { beaconType: 'ExpenseAccount', beaconAddress: expenseAccountFactoryBeacon },
-    { beaconType: 'ExpenseAccountEIP712', beaconAddress: expenseAccountEip712FactoryBeacon },
-    { beaconType: 'InvestorV1', beaconAddress: investorsV1Beacon },
-    { beaconType: 'CashRemunerationEIP712', beaconAddress: cashRemunerationEip712FactoryBeacon },
-    { beaconType: 'SafeDepositRouter', beaconAddress: safeDepositRouterBeacon }
-  ]
+  // We still useModule these sub-modules so their beacons are deployed as part of
+  // the Officer deployment graph. Per-team Officer proxies (spawned via
+  // FactoryBeacon.createBeaconProxy) register their beacon addresses at runtime via
+  // `initialize`; we do NOT pre-register them against the bare implementation here.
+  m.useModule(bankBeaconModule)
+  m.useModule(boardOfDirectorsBeaconModule)
+  m.useModule(proposalBeaconModule)
+  m.useModule(electionsBeaconModule)
+  m.useModule(investorsV1BeaconModule)
+  // m.useModule(ExpenseAccountModule)
+  m.useModule(ExpenseAccountEIP712Module)
+  m.useModule(CashRemunerationEIP712Module)
+  m.useModule(SafeDepositRouterBeaconModule)
 
-  m.call(officer, 'initialize', [beaconAdmin, beaconConfigs, [], false])
+  // NOTE: We intentionally do NOT call `initialize` on the Officer implementation.
+  // The impl is only used as a delegatecall target for per-team Officer proxies
+  // spawned via FactoryBeacon.createBeaconProxy, each of which runs its own
+  // `initialize` at creation. Additionally, the Officer constructor now calls
+  // `_disableInitializers()` to harden the implementation against the Parity-wallet
+  // class attack, so calling `initialize` on the bare impl would revert with
+  // `InvalidInitialization()`.
 
   const beacon = m.contract('FactoryBeacon', [officer], {
     from: beaconAdmin

--- a/contract/ignition/modules/ProposalModule.ts
+++ b/contract/ignition/modules/ProposalModule.ts
@@ -2,8 +2,10 @@ import { buildModule } from '@nomicfoundation/hardhat-ignition/modules'
 
 const proposalBeaconModule = buildModule('ProposalBeaconModule', (m) => {
   const beaconAdmin = m.getAccount(0)
+  // Implementation remains UNINITIALIZED (initialized via beacon proxy at creation).
+  // The constructor calls `_disableInitializers()` to harden against the Parity-wallet
+  // class attack, so calling `initialize` on the bare impl would revert.
   const proposalImplementation = m.contract('Proposals')
-  m.call(proposalImplementation, 'initialize', [beaconAdmin])
   const beacon = m.contract('Beacon', [proposalImplementation], {
     from: beaconAdmin
   })

--- a/contract/ignition/modules/VotingBeaconModule.ts
+++ b/contract/ignition/modules/VotingBeaconModule.ts
@@ -2,8 +2,10 @@ import { buildModule } from '@nomicfoundation/hardhat-ignition/modules'
 
 const votingBeaconModule = buildModule('VotingBeaconModule', (m) => {
   const beaconAdmin = m.getAccount(0)
+  // Implementation remains UNINITIALIZED (initialized via beacon proxy at creation).
+  // The constructor calls `_disableInitializers()` to harden against the Parity-wallet
+  // class attack, so calling `initialize` on the bare impl would revert.
   const votingImplementation = m.contract('Voting')
-  m.call(votingImplementation, 'initialize', [beaconAdmin])
   const beacon = m.contract('Beacon', [votingImplementation], {
     from: beaconAdmin
   })

--- a/contract/test/Bank.spec.ts
+++ b/contract/test/Bank.spec.ts
@@ -46,9 +46,18 @@ describe('Bank', () => {
       { initializer: 'initialize' }
     )) as unknown as FeeCollector
 
-    officer = (await OfficerFactory.deploy(await feeCollector.getAddress())) as unknown as Officer
+    // Deploy Officer through a proxy; the implementation's constructor now calls
+    // `_disableInitializers()`, so `initialize` can only be invoked on a proxy.
+    officer = (await upgrades.deployProxy(
+      OfficerFactory,
+      [await owner.getAddress(), [], [], false],
+      {
+        initializer: 'initialize',
+        constructorArgs: [await feeCollector.getAddress()],
+        unsafeAllow: ['constructor', 'state-variable-immutable']
+      }
+    )) as unknown as Officer
     await officer.waitForDeployment()
-    await officer.initialize(await owner.getAddress(), [], [], false)
 
     const officerAddress = await officer.getAddress()
     await impersonateAccount(officerAddress)

--- a/contract/test/BoardOfDirectors.spec.ts
+++ b/contract/test/BoardOfDirectors.spec.ts
@@ -1,5 +1,6 @@
-import { ethers } from 'hardhat'
+import { ethers, upgrades } from 'hardhat'
 import { expect } from 'chai'
+import type { Bank } from '../typechain-types'
 
 describe('BoardOfDirectors', () => {
   async function deployFixture() {
@@ -20,9 +21,12 @@ describe('BoardOfDirectors', () => {
       .connect(founder)
       .setBoardOfDirectors([member1.address, member2.address, member3.address])
 
+    // Deploy Bank through a proxy; the implementation's constructor now calls
+    // `_disableInitializers()`, so `initialize` can only be invoked on a proxy.
     const BankFactory = await ethers.getContractFactory('Bank')
-    const bank = await BankFactory.deploy()
-    await bank.initialize([], founder.address)
+    const bank = (await upgrades.deployProxy(BankFactory, [[], founder.address], {
+      initializer: 'initialize'
+    })) as unknown as Bank
     await bank.transferOwnership(await board.getAddress())
 
     await founder.sendTransaction({ to: await bank.getAddress(), value: ethers.parseEther('5') })

--- a/contract/test/CashRemunerationEIP712.withdrawSher.spec.ts
+++ b/contract/test/CashRemunerationEIP712.withdrawSher.spec.ts
@@ -86,11 +86,19 @@ describe('Cash Remuneration - Withdraw SHER', function () {
       ])
     })
 
-    // Deploy Officer contract
+    // Deploy Officer through a proxy; the implementation's constructor now calls
+    // `_disableInitializers()`, so `initialize` can only be invoked on a proxy.
     const Officer = await ethers.getContractFactory('Officer')
-    officer = (await Officer.deploy(await feeCollector.getAddress())) as unknown as Officer
+    officer = (await upgrades.deployProxy(
+      Officer,
+      [owner.address, beaconConfigs, deployments, true],
+      {
+        initializer: 'initialize',
+        constructorArgs: [await feeCollector.getAddress()],
+        unsafeAllow: ['constructor', 'state-variable-immutable']
+      }
+    )) as unknown as Officer
     await officer.waitForDeployment()
-    await officer.initialize(owner.address, beaconConfigs, deployments, true)
 
     const deployedContracts = await officer.getDeployedContracts()
 

--- a/contract/test/Elections.spec.ts
+++ b/contract/test/Elections.spec.ts
@@ -14,11 +14,28 @@ describe('Elections', function () {
     const BoardFactory = await ethers.getContractFactory('MockBoardOfDirectors')
     const boardOfDirectors = await BoardFactory.deploy()
 
+    // Deploy Elections behind a beacon proxy. The implementation's constructor calls
+    // `_disableInitializers()`, so `initialize` can only run in the context of a proxy.
+    // Spawning the proxy through MockOfficer ensures the Elections proxy records
+    // `officerAddress = mockOfficer`.
     const ElectionsFactory = await ethers.getContractFactory('Elections')
-    const elections = await ElectionsFactory.deploy()
+    const electionsImpl = await ElectionsFactory.deploy()
+    const BeaconFactory = await ethers.getContractFactory('Beacon')
+    const electionsBeacon = await BeaconFactory.deploy(await electionsImpl.getAddress())
+    const initData = electionsImpl.interface.encodeFunctionData('initialize', [owner.address])
+    const tx = await mockOfficer.deployBeaconProxy(
+      await electionsBeacon.getAddress(),
+      initData,
+      'Elections'
+    )
+    await tx.wait()
+    const electionsProxyAddress = await mockOfficer.findDeployedContract('Elections')
+    const elections = (await ethers.getContractAt(
+      'Elections',
+      electionsProxyAddress
+    )) as unknown as Elections
 
     await mockOfficer.setDeployedContract('BoardOfDirectors', await boardOfDirectors.getAddress())
-    await mockOfficer.initializeUpgradeable(await elections.getAddress(), owner.address)
 
     return { elections, boardOfDirectors, owner, voter1, voter2, candidate1, candidate2, nonVoter }
   }

--- a/contract/test/ExpenseAccountEIP712V2.calendarBasedPeriods.spec.ts
+++ b/contract/test/ExpenseAccountEIP712V2.calendarBasedPeriods.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { ethers } from 'hardhat'
+import { ethers, upgrades } from 'hardhat'
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import { ExpenseAccountEIP712 } from '../typechain-types'
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers'
@@ -23,14 +23,15 @@ describe('ExpenseAccountEIP712V2', function () {
     const usdc = await USDC.deploy('USDC', 'USDC')
     await usdc.waitForDeployment()
 
+    // Deploy through a proxy; the implementation's constructor now calls
+    // `_disableInitializers()`, so `initialize` can only be invoked on a proxy.
     const ExpenseAccount = await ethers.getContractFactory('ExpenseAccountEIP712')
-    const expenseAccount = await ExpenseAccount.deploy()
+    const expenseAccount = (await upgrades.deployProxy(
+      ExpenseAccount,
+      [owner.address, [await usdt.getAddress(), await usdc.getAddress()]],
+      { initializer: 'initialize' }
+    )) as unknown as ExpenseAccountEIP712
     await expenseAccount.waitForDeployment()
-
-    await expenseAccount.initialize(owner.address, [
-      await usdt.getAddress(),
-      await usdc.getAddress()
-    ])
 
     // Fund the contract with native tokens
     await owner.sendTransaction({

--- a/contract/test/ExpenseAccountEIP712V2.customFrequency.spec.ts
+++ b/contract/test/ExpenseAccountEIP712V2.customFrequency.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { ethers } from 'hardhat'
+import { ethers, upgrades } from 'hardhat'
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import { ExpenseAccountEIP712 } from '../typechain-types'
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers'
@@ -22,14 +22,15 @@ describe('ExpenseAccountEIP712V2 - Custom Frequency', function () {
     const usdc = await USDC.deploy('USDC', 'USDC')
     await usdc.waitForDeployment()
 
+    // Deploy through a proxy; the implementation's constructor now calls
+    // `_disableInitializers()`, so `initialize` can only be invoked on a proxy.
     const ExpenseAccount = await ethers.getContractFactory('ExpenseAccountEIP712')
-    const expenseAccount = await ExpenseAccount.deploy()
+    const expenseAccount = (await upgrades.deployProxy(
+      ExpenseAccount,
+      [owner.address, [await usdt.getAddress(), await usdc.getAddress()]],
+      { initializer: 'initialize' }
+    )) as unknown as ExpenseAccountEIP712
     await expenseAccount.waitForDeployment()
-
-    await expenseAccount.initialize(owner.address, [
-      await usdt.getAddress(),
-      await usdc.getAddress()
-    ])
 
     // Fund the contract with native tokens
     await owner.sendTransaction({

--- a/contract/test/ExpenseAccountEIP712V2.isNewPeriod.spec.ts
+++ b/contract/test/ExpenseAccountEIP712V2.isNewPeriod.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { ethers } from 'hardhat'
+import { ethers, upgrades } from 'hardhat'
 import { loadFixture, time } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import { ExpenseAccountEIP712 } from '../typechain-types'
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers'
@@ -22,14 +22,15 @@ describe('ExpenseAccountEIP712V2', function () {
     const usdc = await USDC.deploy('USDC', 'USDC')
     await usdc.waitForDeployment()
 
+    // Deploy through a proxy; the implementation's constructor now calls
+    // `_disableInitializers()`, so `initialize` can only be invoked on a proxy.
     const ExpenseAccount = await ethers.getContractFactory('ExpenseAccountEIP712')
-    const expenseAccount = await ExpenseAccount.deploy()
+    const expenseAccount = (await upgrades.deployProxy(
+      ExpenseAccount,
+      [owner.address, [await usdt.getAddress(), await usdc.getAddress()]],
+      { initializer: 'initialize' }
+    )) as unknown as ExpenseAccountEIP712
     await expenseAccount.waitForDeployment()
-
-    await expenseAccount.initialize(owner.address, [
-      await usdt.getAddress(),
-      await usdc.getAddress()
-    ])
 
     // Fund the contract with native tokens
     await owner.sendTransaction({

--- a/contract/test/ExpenseAccountEIP712V2.spec.ts
+++ b/contract/test/ExpenseAccountEIP712V2.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { ethers } from 'hardhat'
+import { ethers, upgrades } from 'hardhat'
 import { loadFixture, time } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import { ExpenseAccountEIP712 } from '../typechain-types'
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers'
@@ -22,14 +22,15 @@ describe('ExpenseAccountEIP712V2', function () {
     const usdc = await USDC.deploy('USDC', 'USDC')
     await usdc.waitForDeployment()
 
+    // Deploy through a proxy; the implementation's constructor now calls
+    // `_disableInitializers()`, so `initialize` can only be invoked on a proxy.
     const ExpenseAccount = await ethers.getContractFactory('ExpenseAccountEIP712')
-    const expenseAccount = await ExpenseAccount.deploy()
+    const expenseAccount = (await upgrades.deployProxy(
+      ExpenseAccount,
+      [owner.address, [await usdt.getAddress(), await usdc.getAddress()]],
+      { initializer: 'initialize' }
+    )) as unknown as ExpenseAccountEIP712
     await expenseAccount.waitForDeployment()
-
-    await expenseAccount.initialize(owner.address, [
-      await usdt.getAddress(),
-      await usdc.getAddress()
-    ])
 
     // Fund the contract with native tokens
     await owner.sendTransaction({

--- a/contract/test/Officer.deployments.spec.ts
+++ b/contract/test/Officer.deployments.spec.ts
@@ -162,11 +162,19 @@ describe('Officer Contract', function () {
       initializerData: elections.interface.encodeFunctionData('initialize', [owner.address])
     })
 
-    // // Deploy Officer contract
+    // Deploy Officer through a proxy; the implementation's constructor now calls
+    // `_disableInitializers()`, so `initialize` can only be invoked on a proxy.
     const Officer = await ethers.getContractFactory('Officer')
-    officer = (await Officer.deploy(await feeCollector.getAddress())) as unknown as Officer
+    officer = (await upgrades.deployProxy(
+      Officer,
+      [owner.address, beaconConfigs, deployments, true],
+      {
+        initializer: 'initialize',
+        constructorArgs: [await feeCollector.getAddress()],
+        unsafeAllow: ['constructor', 'state-variable-immutable']
+      }
+    )) as unknown as Officer
     await officer.waitForDeployment()
-    await officer.initialize(owner.address, beaconConfigs, deployments, true)
 
     const deployedContracts = await officer.getDeployedContracts()
 

--- a/contract/test/Officer.spec.ts
+++ b/contract/test/Officer.spec.ts
@@ -46,17 +46,19 @@ describe('Officer Contract', function () {
     deployments: { contractType: string; initializerData: string }[] = [],
     isDeployAllContracts = false
   ) {
+    // Deploy Officer through a proxy; the implementation's constructor now calls
+    // `_disableInitializers()`, so `initialize` can only be invoked on a proxy.
     const OfficerFactory = await ethers.getContractFactory('Officer')
-    const instance = (await OfficerFactory.deploy(
-      await feeCollector.getAddress()
+    const instance = (await upgrades.deployProxy(
+      OfficerFactory,
+      [await owner.getAddress(), beaconConfigs, deployments, isDeployAllContracts],
+      {
+        initializer: 'initialize',
+        constructorArgs: [await feeCollector.getAddress()],
+        unsafeAllow: ['constructor', 'state-variable-immutable']
+      }
     )) as unknown as Officer
     await instance.waitForDeployment()
-    await instance.initialize(
-      await owner.getAddress(),
-      beaconConfigs,
-      deployments,
-      isDeployAllContracts
-    )
     return instance
   }
 

--- a/contract/test/OfficerUpgradeModule.spec.ts
+++ b/contract/test/OfficerUpgradeModule.spec.ts
@@ -1,7 +1,8 @@
-import { ethers } from 'hardhat'
+import { ethers, upgrades } from 'hardhat'
 import { expect } from 'chai'
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import { ZeroAddress } from 'ethers'
+import type { FeeCollector } from '../typechain-types'
 
 /**
  * Exercises the semantics of ignition/modules/OfficerUpgradeModule.ts:
@@ -15,13 +16,15 @@ describe('OfficerUpgradeModule', function () {
   async function deployFixture() {
     const [beaconOwner, officerOwner, attacker] = await ethers.getSigners()
 
-    // Officer requires a FeeCollector in its constructor.
+    // Officer requires a FeeCollector in its constructor. Deploy through a proxy
+    // since the FeeCollector impl now disables initializers in its constructor.
     const FeeCollectorFactory = await ethers.getContractFactory('FeeCollector')
-    const feeCollectorImpl = await FeeCollectorFactory.connect(beaconOwner).deploy()
+    const feeCollectorImpl = (await upgrades.deployProxy(
+      FeeCollectorFactory.connect(beaconOwner),
+      [beaconOwner.address, [], []],
+      { initializer: 'initialize' }
+    )) as unknown as FeeCollector
     await feeCollectorImpl.waitForDeployment()
-    // Use the implementation directly as feeCollector; Officer only reads its interface
-    // via isFeeCollectorToken, which is not under test here.
-    await feeCollectorImpl.initialize(beaconOwner.address, [], [])
 
     // Deploy the initial Officer implementation (module uses m.contract('Officer', [])
     // in practice this is pointed at a deployed implementation — we mimic with a real one).

--- a/contract/test/Proposals.spec.ts
+++ b/contract/test/Proposals.spec.ts
@@ -30,14 +30,28 @@ describe('Proposals Contract', function () {
     await boardOfDirectorsMock.addMember(boardMember2.address)
     await boardOfDirectorsMock.addMember(boardMember3.address)
 
+    // Deploy Proposals behind a beacon proxy. The implementation's constructor calls
+    // `_disableInitializers()`, so `initialize` can only run in the context of a proxy.
+    // Spawning the proxy through MockOfficer ensures the Proposals proxy records
+    // `officerAddress = mockOfficer`.
     const ProposalsFactory = await ethers.getContractFactory('Proposals')
-    const proposalsContract = await ProposalsFactory.deploy()
+    const proposalsImpl = await ProposalsFactory.deploy()
+    const BeaconFactory = await ethers.getContractFactory('Beacon')
+    const proposalsBeacon = await BeaconFactory.deploy(await proposalsImpl.getAddress())
+    const initData = proposalsImpl.interface.encodeFunctionData('initialize', [owner.address])
+    const tx = await mockOfficer.deployBeaconProxy(
+      await proposalsBeacon.getAddress(),
+      initData,
+      'Proposals'
+    )
+    await tx.wait()
+    const proposalsProxyAddress = await mockOfficer.findDeployedContract('Proposals')
+    const proposalsContract = await ethers.getContractAt('Proposals', proposalsProxyAddress)
 
     await mockOfficer.setDeployedContract(
       'BoardOfDirectors',
       await boardOfDirectorsMock.getAddress()
     )
-    await mockOfficer.initializeUpgradeable(await proposalsContract.getAddress(), owner.address)
 
     return {
       proposalsContract,
@@ -118,9 +132,16 @@ describe('Proposals Contract', function () {
     const MockOfficerFactory = await ethers.getContractFactory('MockOfficer')
     const mockOfficer = await MockOfficerFactory.deploy()
 
+    // Deploy Proposals behind a beacon proxy so `_disableInitializers()` on the impl
+    // doesn't block initialization, and `officerAddress` is set to mockOfficer.
     const ProposalsFactory = await ethers.getContractFactory('Proposals')
-    const proposalsContract = await ProposalsFactory.deploy()
-    await mockOfficer.initializeUpgradeable(await proposalsContract.getAddress(), owner.address)
+    const proposalsImpl = await ProposalsFactory.deploy()
+    const BeaconFactory = await ethers.getContractFactory('Beacon')
+    const proposalsBeacon = await BeaconFactory.deploy(await proposalsImpl.getAddress())
+    const initData = proposalsImpl.interface.encodeFunctionData('initialize', [owner.address])
+    await mockOfficer.deployBeaconProxy(await proposalsBeacon.getAddress(), initData, 'Proposals')
+    const proposalsProxyAddress = await mockOfficer.findDeployedContract('Proposals')
+    const proposalsContract = await ethers.getContractAt('Proposals', proposalsProxyAddress)
 
     const now = await time.latest()
 

--- a/contract/test/Voting.spec.ts
+++ b/contract/test/Voting.spec.ts
@@ -12,11 +12,26 @@ describe('Voting Contract', () => {
     const board = await BoardOfDirectorsMockFactory.deploy()
     await board.addMember(founder.address)
 
+    // Deploy Voting behind a beacon proxy. The implementation's constructor calls
+    // `_disableInitializers()`, so `initialize` can only run in the context of a proxy.
+    // Spawning the proxy through MockOfficer ensures the Voting proxy records
+    // `officerAddress = mockOfficer` (because msg.sender during the proxy's constructor
+    // delegatecall to `initialize` is the MockOfficer that created it).
     const VotingFactory = await ethers.getContractFactory('Voting')
-    const voting = await VotingFactory.deploy()
+    const votingImpl = await VotingFactory.deploy()
+    const BeaconFactory = await ethers.getContractFactory('Beacon')
+    const votingBeacon = await BeaconFactory.deploy(await votingImpl.getAddress())
+    const initData = votingImpl.interface.encodeFunctionData('initialize', [founder.address])
+    const tx = await mockOfficer.deployBeaconProxy(
+      await votingBeacon.getAddress(),
+      initData,
+      'Voting'
+    )
+    await tx.wait()
+    const votingProxyAddress = await mockOfficer.findDeployedContract('Voting')
+    const voting = await ethers.getContractAt('Voting', votingProxyAddress)
 
     await mockOfficer.setDeployedContract('BoardOfDirectors', await board.getAddress())
-    await mockOfficer.initializeUpgradeable(await voting.getAddress(), founder.address)
 
     return { voting, board, founder, voter1, voter2, voter3, voter4, outsider }
   }

--- a/dashboard/app/artifacts/abi/json/Bank.json
+++ b/dashboard/app/artifacts/abi/json/Bank.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "EnforcedPause",
     "type": "error"
   },

--- a/dashboard/app/artifacts/abi/json/BoardOfDirectors.json
+++ b/dashboard/app/artifacts/abi/json/BoardOfDirectors.json
@@ -1,5 +1,10 @@
 [
   {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",

--- a/dashboard/app/artifacts/abi/json/CashRemunerationEIP712.json
+++ b/dashboard/app/artifacts/abi/json/CashRemunerationEIP712.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "BankContractNotFound",
     "type": "error"
   },

--- a/dashboard/app/artifacts/abi/json/Elections.json
+++ b/dashboard/app/artifacts/abi/json/Elections.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "AlreadyVoted",
     "type": "error"
   },

--- a/dashboard/app/artifacts/abi/json/ExpenseAccountEIP712.json
+++ b/dashboard/app/artifacts/abi/json/ExpenseAccountEIP712.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "AmountExceedsBudgetLimit",
     "type": "error"
   },

--- a/dashboard/app/artifacts/abi/json/FeeCollector.json
+++ b/dashboard/app/artifacts/abi/json/FeeCollector.json
@@ -1,5 +1,10 @@
 [
   {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
     "inputs": [
       {
         "internalType": "string",

--- a/dashboard/app/artifacts/abi/json/InvestorV1.json
+++ b/dashboard/app/artifacts/abi/json/InvestorV1.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "AccessControlBadConfirmation",
     "type": "error"
   },

--- a/dashboard/app/artifacts/abi/json/Proposals.json
+++ b/dashboard/app/artifacts/abi/json/Proposals.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "BoardOfDirectorAddressNotSet",
     "type": "error"
   },

--- a/dashboard/app/artifacts/abi/json/Tips.json
+++ b/dashboard/app/artifacts/abi/json/Tips.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "BalanceNotCleared",
     "type": "error"
   },

--- a/dashboard/app/artifacts/abi/json/Vesting.json
+++ b/dashboard/app/artifacts/abi/json/Vesting.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "CliffExceedsDuration",
     "type": "error"
   },

--- a/dashboard/app/artifacts/abi/json/Voting.json
+++ b/dashboard/app/artifacts/abi/json/Voting.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "BoardOfDirectorsNotFound",
     "type": "error"
   },

--- a/ponder/abis/json/Bank.json
+++ b/ponder/abis/json/Bank.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "EnforcedPause",
     "type": "error"
   },

--- a/ponder/abis/json/BoardOfDirectors.json
+++ b/ponder/abis/json/BoardOfDirectors.json
@@ -1,5 +1,10 @@
 [
   {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",

--- a/ponder/abis/json/CashRemunerationEIP712.json
+++ b/ponder/abis/json/CashRemunerationEIP712.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "BankContractNotFound",
     "type": "error"
   },

--- a/ponder/abis/json/Elections.json
+++ b/ponder/abis/json/Elections.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "AlreadyVoted",
     "type": "error"
   },

--- a/ponder/abis/json/ExpenseAccountEIP712.json
+++ b/ponder/abis/json/ExpenseAccountEIP712.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "AmountExceedsBudgetLimit",
     "type": "error"
   },

--- a/ponder/abis/json/FeeCollector.json
+++ b/ponder/abis/json/FeeCollector.json
@@ -1,5 +1,10 @@
 [
   {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
     "inputs": [
       {
         "internalType": "string",

--- a/ponder/abis/json/InvestorV1.json
+++ b/ponder/abis/json/InvestorV1.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "AccessControlBadConfirmation",
     "type": "error"
   },

--- a/ponder/abis/json/Proposals.json
+++ b/ponder/abis/json/Proposals.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "BoardOfDirectorAddressNotSet",
     "type": "error"
   },

--- a/ponder/abis/json/Tips.json
+++ b/ponder/abis/json/Tips.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "BalanceNotCleared",
     "type": "error"
   },

--- a/ponder/abis/json/Vesting.json
+++ b/ponder/abis/json/Vesting.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "CliffExceedsDuration",
     "type": "error"
   },

--- a/ponder/abis/json/Voting.json
+++ b/ponder/abis/json/Voting.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "BoardOfDirectorsNotFound",
     "type": "error"
   },


### PR DESCRIPTION
Closes #1763

## Summary

Adds the canonical OpenZeppelin `_disableInitializers()` pattern to every upgradeable implementation in `contract/contracts/` so that the bare implementation cannot be taken over by an attacker. This is pure defense in depth against the Parity-wallet class attack: even if a future upgrade introduces a `selfdestruct` or unguarded `delegatecall` on one of these implementations, an attacker cannot pre-own the impl and trigger the destructive path.

See the linked issue for the full threat model.

## What changed

### Contract implementations (added `constructor { _disableInitializers(); }`)
- `contract/contracts/Bank.sol`
- `contract/contracts/Officer.sol` (appended to the existing `constructor(address _feeCollector)`)
- `contract/contracts/BoardOfDirectors.sol`
- `contract/contracts/Elections/Elections.sol`
- `contract/contracts/Proposals/Proposals.sol`
- `contract/contracts/Voting/Voting.sol`
- `contract/contracts/Tips.sol`
- `contract/contracts/Investor/InvestorV1.sol`
- `contract/contracts/Vesting.sol`
- `contract/contracts/CashRemunerationEIP712.sol`
- `contract/contracts/FeeCollector.sol`
- `contract/contracts/expense-account/ExpenseAccountEIP712.sol`

`contract/contracts/SafeDepositRouter.sol` already had the protection and is the reference pattern.

### Ignition modules (removed bare-impl `initialize` calls)
These calls were always dead state — the impls are only beacon targets, and each per-team proxy initializes itself when spawned via `FactoryBeacon.createBeaconProxy` or `Officer.deployBeaconProxy`. After the constructor change they would revert with `InvalidInitialization()`.

- `contract/ignition/modules/OfficerModule.ts` (was `OfficerModule.ts:39`)
- `contract/ignition/modules/VotingBeaconModule.ts`
- `contract/ignition/modules/ElectionsModule.ts`
- `contract/ignition/modules/ProposalModule.ts`

Modules that initialize a proxy (not a bare impl) — `ProxyModule.ts`, `VestingProxyModule.ts`, `FeeCollectorModule.ts`, etc. — are unchanged.

### Tests (deploy through a proxy instead of calling `initialize` on the impl)
- `contract/test/Bank.spec.ts` — Officer via `upgrades.deployProxy` with `constructorArgs`
- `contract/test/BoardOfDirectors.spec.ts` — Bank via `upgrades.deployProxy`
- `contract/test/CashRemunerationEIP712.withdrawSher.spec.ts` — Officer via `upgrades.deployProxy`
- `contract/test/Officer.deployments.spec.ts` — Officer via `upgrades.deployProxy`
- `contract/test/Officer.spec.ts` — Officer via `upgrades.deployProxy`
- `contract/test/OfficerUpgradeModule.spec.ts` — FeeCollector via `upgrades.deployProxy`
- `contract/test/ExpenseAccountEIP712V2*.spec.ts` (4 files) — ExpenseAccountEIP712 via `upgrades.deployProxy`
- `contract/test/Voting.spec.ts` — Voting via `MockOfficer.deployBeaconProxy` + `Beacon` (so the proxy initializes with `officerAddress = mockOfficer`)
- `contract/test/Elections.spec.ts` — same pattern for Elections
- `contract/test/Proposals.spec.ts` — same pattern for Proposals

No security fix was reverted to make a test pass; every test change deploys through a proxy instead.

### Regenerated ABI artifacts
`hardhat-abi-exporter` regenerates the ABI JSON files in `app/src/artifacts/abi/json/`, `dashboard/app/artifacts/abi/json/`, and `ponder/abis/json/` on every compile. Those are included so the tracked ABIs match the new constructors.

## Test Plan

- [x] `cd contract && npm test` — **441 passing, 0 failing** locally
- [x] `cd contract && npm run lint` — clean (solhint + eslint)
- [x] `cd contract && npm run format-check` — clean
- [x] `cd contract && npx hardhat compile` — clean
- [ ] CI green on this branch
