### PR TITLE
refactor(contracts): address useContractWritesV3 review feedback (#1775)

### DIFF
--- a/app/src/composables/contracts/__tests__/useContractWritesV3.advanced.spec.ts
+++ b/app/src/composables/contracts/__tests__/useContractWritesV3.advanced.spec.ts
@@ -2,59 +2,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
 import { type Abi, type Address } from 'viem'
 import { simulateContract, writeContract, waitForTransactionReceipt } from '@wagmi/core'
-import { ABI, ADDRESS, HASH, okSimulation, successReceipt } from './useContractWritesV3.test-utils'
-
-// Same harness as the main V3 spec — duplicated here because vi.hoisted/vi.mock
-// must run at module top and cannot be shared from a regular helper file.
-const { mockInvalidateQueries, mockUseMutation, mockUseQueryClient } = vi.hoisted(() => {
-  const mockInvalidateQueries = vi.fn().mockResolvedValue(undefined)
-  const mockUseQueryClient = vi.fn(() => ({ invalidateQueries: mockInvalidateQueries }))
-
-  type MutationOptions<TData, TVariables> = {
-    mutationFn: (vars: TVariables) => Promise<TData>
-    onSuccess?: (data: TData, vars: TVariables, ctx: unknown) => unknown
-    onError?: (err: unknown, vars: TVariables, ctx: unknown) => unknown
-  }
-
-  const mockUseMutation = vi.fn(<TData, TVariables>(options: MutationOptions<TData, TVariables>) => {
-    return {
-      mutate: vi.fn(),
-      mutateAsync: async (variables: TVariables) => {
-        try {
-          const data = await options.mutationFn(variables)
-          if (options.onSuccess) await options.onSuccess(data, variables, undefined)
-          return data
-        } catch (err) {
-          if (options.onError) await options.onError(err, variables, undefined)
-          throw err
-        }
-      },
-      isPending: ref(false),
-      isSuccess: ref(false),
-      isError: ref(false),
-      error: ref(null),
-      data: ref(null),
-      reset: vi.fn()
-    }
-  })
-
-  return { mockInvalidateQueries, mockUseMutation, mockUseQueryClient }
-})
-
-vi.mock('@tanstack/vue-query', async (importOriginal) => {
-  const actual = (await importOriginal()) as object
-  return {
-    ...actual,
-    useMutation: mockUseMutation,
-    useQueryClient: mockUseQueryClient
-  }
-})
-
+import {
+  mockInvalidateQueries,
+  smartUseMutation,
+  useMutationFn,
+  useQueryClientFn
+} from '@/tests/mocks/composables.mock'
 import { useContractWritesV3, type ContractWriteV3Config } from '../useContractWritesV3'
+import { ABI, ADDRESS, HASH, okSimulation, successReceipt } from './useContractWritesV3.test-utils'
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockInvalidateQueries.mockResolvedValue(undefined)
+  useMutationFn.mockImplementation(smartUseMutation)
+  useQueryClientFn.mockReturnValue({
+    invalidateQueries: mockInvalidateQueries,
+    getQueryData: vi.fn(),
+    setQueryData: vi.fn(),
+    removeQueries: vi.fn()
+  })
 })
 
 const baseConfig = (

--- a/app/src/composables/contracts/__tests__/useContractWritesV3.advanced.spec.ts
+++ b/app/src/composables/contracts/__tests__/useContractWritesV3.advanced.spec.ts
@@ -22,9 +22,7 @@ beforeEach(() => {
   })
 })
 
-const baseConfig = (
-  overrides: Partial<ContractWriteV3Config> = {}
-): ContractWriteV3Config => ({
+const baseConfig = (overrides: Partial<ContractWriteV3Config> = {}): ContractWriteV3Config => ({
   contractAddress: ADDRESS,
   abi: ABI as unknown as Abi,
   functionName: 'foo',
@@ -40,9 +38,7 @@ describe('useContractWritesV3 — onSuccess invalidation predicate', () => {
     vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(successReceipt())
   }
 
-  const captureInvalidationPredicate = async (
-    cfg: ContractWriteV3Config
-  ): Promise<Predicate> => {
+  const captureInvalidationPredicate = async (cfg: ContractWriteV3Config): Promise<Predicate> => {
     stubSuccessfulWrite()
     const m = useContractWritesV3(cfg)
     await m.mutateAsync({})
@@ -60,9 +56,9 @@ describe('useContractWritesV3 — onSuccess invalidation predicate', () => {
 
   it('ignores queries that do not start with "readContract"', async () => {
     const predicate = await captureInvalidationPredicate(baseConfig())
-    expect(
-      predicate({ queryKey: ['simulateContract', { address: ADDRESS, chainId: 1 }] })
-    ).toBe(false)
+    expect(predicate({ queryKey: ['simulateContract', { address: ADDRESS, chainId: 1 }] })).toBe(
+      false
+    )
     expect(predicate({ queryKey: ['readContract'] })).toBe(false)
   })
 
@@ -77,9 +73,9 @@ describe('useContractWritesV3 — onSuccess invalidation predicate', () => {
 
   it('only invalidates the pinned chainId when one is configured', async () => {
     const predicate = await captureInvalidationPredicate(baseConfig({ chainId: 31337 }))
-    expect(
-      predicate({ queryKey: ['readContract', { address: ADDRESS, chainId: 31337 }] })
-    ).toBe(true)
+    expect(predicate({ queryKey: ['readContract', { address: ADDRESS, chainId: 31337 }] })).toBe(
+      true
+    )
     expect(predicate({ queryKey: ['readContract', { address: ADDRESS, chainId: 1 }] })).toBe(false)
   })
 
@@ -95,9 +91,9 @@ describe('useContractWritesV3 — onSuccess invalidation predicate', () => {
     const predicate = await captureInvalidationPredicate(baseConfig())
     expect(predicate({ queryKey: 'not-an-array' as unknown as unknown[] })).toBe(false)
     expect(predicate({ queryKey: ['readContract', null as unknown as object] })).toBe(false)
-    expect(
-      predicate({ queryKey: ['readContract', { address: 12345 as unknown as string }] })
-    ).toBe(false)
+    expect(predicate({ queryKey: ['readContract', { address: 12345 as unknown as string }] })).toBe(
+      false
+    )
   })
 
   it('skips invalidation entirely when the reactive address goes undefined between write and onSuccess', async () => {

--- a/app/src/composables/contracts/__tests__/useContractWritesV3.advanced.spec.ts
+++ b/app/src/composables/contracts/__tests__/useContractWritesV3.advanced.spec.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { type Abi, type Address } from 'viem'
+import { simulateContract, writeContract, waitForTransactionReceipt } from '@wagmi/core'
+import { ABI, ADDRESS, HASH, okSimulation, successReceipt } from './useContractWritesV3.test-utils'
+
+// Same harness as the main V3 spec — duplicated here because vi.hoisted/vi.mock
+// must run at module top and cannot be shared from a regular helper file.
+const { mockInvalidateQueries, mockUseMutation, mockUseQueryClient } = vi.hoisted(() => {
+  const mockInvalidateQueries = vi.fn().mockResolvedValue(undefined)
+  const mockUseQueryClient = vi.fn(() => ({ invalidateQueries: mockInvalidateQueries }))
+
+  type MutationOptions<TData, TVariables> = {
+    mutationFn: (vars: TVariables) => Promise<TData>
+    onSuccess?: (data: TData, vars: TVariables, ctx: unknown) => unknown
+    onError?: (err: unknown, vars: TVariables, ctx: unknown) => unknown
+  }
+
+  const mockUseMutation = vi.fn(<TData, TVariables>(options: MutationOptions<TData, TVariables>) => {
+    return {
+      mutate: vi.fn(),
+      mutateAsync: async (variables: TVariables) => {
+        try {
+          const data = await options.mutationFn(variables)
+          if (options.onSuccess) await options.onSuccess(data, variables, undefined)
+          return data
+        } catch (err) {
+          if (options.onError) await options.onError(err, variables, undefined)
+          throw err
+        }
+      },
+      isPending: ref(false),
+      isSuccess: ref(false),
+      isError: ref(false),
+      error: ref(null),
+      data: ref(null),
+      reset: vi.fn()
+    }
+  })
+
+  return { mockInvalidateQueries, mockUseMutation, mockUseQueryClient }
+})
+
+vi.mock('@tanstack/vue-query', async (importOriginal) => {
+  const actual = (await importOriginal()) as object
+  return {
+    ...actual,
+    useMutation: mockUseMutation,
+    useQueryClient: mockUseQueryClient
+  }
+})
+
+import { useContractWritesV3, type ContractWriteV3Config } from '../useContractWritesV3'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockInvalidateQueries.mockResolvedValue(undefined)
+})
+
+const baseConfig = (
+  overrides: Partial<ContractWriteV3Config> = {}
+): ContractWriteV3Config => ({
+  contractAddress: ADDRESS,
+  abi: ABI as unknown as Abi,
+  functionName: 'foo',
+  ...overrides
+})
+
+describe('useContractWritesV3 — onSuccess invalidation predicate', () => {
+  type Predicate = (q: { queryKey: unknown[] }) => boolean
+
+  const stubSuccessfulWrite = () => {
+    vi.mocked(simulateContract).mockResolvedValueOnce(okSimulation)
+    vi.mocked(writeContract).mockResolvedValueOnce(HASH)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(successReceipt())
+  }
+
+  const captureInvalidationPredicate = async (
+    cfg: ContractWriteV3Config
+  ): Promise<Predicate> => {
+    stubSuccessfulWrite()
+    const m = useContractWritesV3(cfg)
+    await m.mutateAsync({})
+    const call = mockInvalidateQueries.mock.calls[0]
+    expect(call, 'invalidateQueries was not called').toBeDefined()
+    const arg = call![0] as { predicate: Predicate }
+    expect(typeof arg.predicate).toBe('function')
+    return arg.predicate
+  }
+
+  it('matches readContract queries with the same address', async () => {
+    const predicate = await captureInvalidationPredicate(baseConfig({ chainId: 1 }))
+    expect(predicate({ queryKey: ['readContract', { address: ADDRESS, chainId: 1 }] })).toBe(true)
+  })
+
+  it('ignores queries that do not start with "readContract"', async () => {
+    const predicate = await captureInvalidationPredicate(baseConfig())
+    expect(
+      predicate({ queryKey: ['simulateContract', { address: ADDRESS, chainId: 1 }] })
+    ).toBe(false)
+    expect(predicate({ queryKey: ['readContract'] })).toBe(false)
+  })
+
+  it('matches addresses regardless of case (checksum drift)', async () => {
+    const predicate = await captureInvalidationPredicate(
+      baseConfig({ contractAddress: ADDRESS.toUpperCase() as Address })
+    )
+    expect(
+      predicate({ queryKey: ['readContract', { address: ADDRESS.toLowerCase(), chainId: 1 }] })
+    ).toBe(true)
+  })
+
+  it('only invalidates the pinned chainId when one is configured', async () => {
+    const predicate = await captureInvalidationPredicate(baseConfig({ chainId: 31337 }))
+    expect(
+      predicate({ queryKey: ['readContract', { address: ADDRESS, chainId: 31337 }] })
+    ).toBe(true)
+    expect(predicate({ queryKey: ['readContract', { address: ADDRESS, chainId: 1 }] })).toBe(false)
+  })
+
+  it('matches across all chains when chainId is omitted (documented cross-chain behaviour)', async () => {
+    const predicate = await captureInvalidationPredicate(baseConfig())
+    expect(predicate({ queryKey: ['readContract', { address: ADDRESS, chainId: 1 }] })).toBe(true)
+    expect(predicate({ queryKey: ['readContract', { address: ADDRESS, chainId: 31337 }] })).toBe(
+      true
+    )
+  })
+
+  it('rejects malformed query keys defensively', async () => {
+    const predicate = await captureInvalidationPredicate(baseConfig())
+    expect(predicate({ queryKey: 'not-an-array' as unknown as unknown[] })).toBe(false)
+    expect(predicate({ queryKey: ['readContract', null as unknown as object] })).toBe(false)
+    expect(
+      predicate({ queryKey: ['readContract', { address: 12345 as unknown as string }] })
+    ).toBe(false)
+  })
+
+  it('skips invalidation entirely when the reactive address goes undefined between write and onSuccess', async () => {
+    // Defensive guard scenario: mutationFn captures address at call-time so the
+    // tx fires fine, but the reactive ref flips to undefined before onSuccess
+    // runs — e.g. the user navigated to another team mid-flight.
+    const address = ref<Address | undefined>(ADDRESS)
+    vi.mocked(simulateContract).mockResolvedValueOnce(okSimulation)
+    vi.mocked(writeContract).mockImplementationOnce(async () => {
+      address.value = undefined
+      return HASH
+    })
+    vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(successReceipt())
+
+    const m = useContractWritesV3(baseConfig({ contractAddress: address }))
+    await m.mutateAsync({})
+
+    expect(mockInvalidateQueries).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/composables/contracts/__tests__/useContractWritesV3.spec.ts
+++ b/app/src/composables/contracts/__tests__/useContractWritesV3.spec.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { BaseError, type Abi } from 'viem'
+import { simulateContract, writeContract, waitForTransactionReceipt } from '@wagmi/core'
+import { mockLog } from '@/tests/mocks/utils.mock'
+import { ABI, ADDRESS, HASH, okSimulation, revertedReceipt, successReceipt } from './useContractWritesV3.test-utils'
+
+// Override the global @tanstack/vue-query mock for this file: we want
+// `useMutation` to actually invoke `mutationFn` / `onSuccess` / `onError`
+// so we can assert on the V3 wrapper's behaviour without spinning up a real
+// QueryClient.
+const { mockInvalidateQueries, mockUseMutation, mockUseQueryClient } = vi.hoisted(() => {
+  const mockInvalidateQueries = vi.fn().mockResolvedValue(undefined)
+  const mockUseQueryClient = vi.fn(() => ({ invalidateQueries: mockInvalidateQueries }))
+
+  type MutationOptions<TData, TVariables> = {
+    mutationFn: (vars: TVariables) => Promise<TData>
+    onSuccess?: (data: TData, vars: TVariables, ctx: unknown) => unknown
+    onError?: (err: unknown, vars: TVariables, ctx: unknown) => unknown
+  }
+
+  const mockUseMutation = vi.fn(<TData, TVariables>(options: MutationOptions<TData, TVariables>) => {
+    return {
+      mutate: vi.fn(),
+      mutateAsync: async (variables: TVariables) => {
+        try {
+          const data = await options.mutationFn(variables)
+          if (options.onSuccess) await options.onSuccess(data, variables, undefined)
+          return data
+        } catch (err) {
+          if (options.onError) await options.onError(err, variables, undefined)
+          throw err
+        }
+      },
+      isPending: ref(false),
+      isSuccess: ref(false),
+      isError: ref(false),
+      error: ref(null),
+      data: ref(null),
+      reset: vi.fn()
+    }
+  })
+
+  return { mockInvalidateQueries, mockUseMutation, mockUseQueryClient }
+})
+
+vi.mock('@tanstack/vue-query', async (importOriginal) => {
+  const actual = (await importOriginal()) as object
+  return {
+    ...actual,
+    useMutation: mockUseMutation,
+    useQueryClient: mockUseQueryClient
+  }
+})
+
+import {
+  executeContractWrite,
+  useContractWritesV3,
+  ContractWriteRevertedError,
+  type ContractWriteV3Config
+} from '../useContractWritesV3'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockInvalidateQueries.mockResolvedValue(undefined)
+})
+
+describe('executeContractWrite (standalone)', () => {
+  it('returns hash, receipt, and simulation on success', async () => {
+    vi.mocked(simulateContract).mockResolvedValueOnce(okSimulation)
+    vi.mocked(writeContract).mockResolvedValueOnce(HASH)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(successReceipt())
+
+    const result = await executeContractWrite({
+      address: ADDRESS,
+      abi: ABI as unknown as Abi,
+      functionName: 'foo',
+      args: [42n]
+    })
+
+    expect(result.hash).toBe(HASH)
+    expect(result.simulation).toBe(okSimulation)
+    expect(simulateContract).toHaveBeenCalledTimes(1)
+    // The write reuses the validated simulation request.
+    expect(writeContract).toHaveBeenCalledWith(expect.anything(), okSimulation.request)
+  })
+
+  it('omits `value` from simulation params when not provided', async () => {
+    vi.mocked(simulateContract).mockResolvedValueOnce(okSimulation)
+    vi.mocked(writeContract).mockResolvedValueOnce(HASH)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(successReceipt())
+
+    await executeContractWrite({
+      address: ADDRESS,
+      abi: ABI as unknown as Abi,
+      functionName: 'foo'
+    })
+
+    const [, params] = vi.mocked(simulateContract).mock.calls[0]!
+    expect(params).not.toHaveProperty('value')
+  })
+
+  it('forwards `value` to simulation params when provided', async () => {
+    vi.mocked(simulateContract).mockResolvedValueOnce(okSimulation)
+    vi.mocked(writeContract).mockResolvedValueOnce(HASH)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(successReceipt())
+
+    await executeContractWrite({
+      address: ADDRESS,
+      abi: ABI as unknown as Abi,
+      functionName: 'foo',
+      value: 1_000n
+    })
+
+    const [, params] = vi.mocked(simulateContract).mock.calls[0]!
+    expect(params).toMatchObject({ value: 1_000n })
+  })
+
+  it('throws ContractWriteRevertedError with BaseError cause when replay decodes the revert', async () => {
+    const replayErr = new BaseError('execution reverted: InsufficientTokenBalance')
+    vi.mocked(simulateContract)
+      .mockResolvedValueOnce(okSimulation)
+      .mockRejectedValueOnce(replayErr)
+    vi.mocked(writeContract).mockResolvedValueOnce(HASH)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(revertedReceipt({ blockNumber: 100n }))
+
+    let caught: unknown
+    try {
+      await executeContractWrite({
+        address: ADDRESS,
+        abi: ABI as unknown as Abi,
+        functionName: 'foo'
+      })
+    } catch (e) {
+      caught = e
+    }
+
+    expect(caught).toBeInstanceOf(ContractWriteRevertedError)
+    const err = caught as ContractWriteRevertedError
+    expect(err.cause).toBe(replayErr)
+    expect(err.hash).toBe(HASH)
+    expect(err.receipt.blockNumber).toBe(100n)
+
+    expect(simulateContract).toHaveBeenCalledTimes(2)
+    const [, replayParams] = vi.mocked(simulateContract).mock.calls[1]!
+    expect((replayParams as { blockNumber: bigint }).blockNumber).toBe(99n)
+  })
+
+  it('reports replay errors via callback and leaves cause undefined when replay throws non-BaseError', async () => {
+    const onReplayError = vi.fn()
+    const networkErr = new Error('RPC unavailable')
+    vi.mocked(simulateContract)
+      .mockResolvedValueOnce(okSimulation)
+      .mockRejectedValueOnce(networkErr)
+    vi.mocked(writeContract).mockResolvedValueOnce(HASH)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(revertedReceipt())
+
+    let caught: unknown
+    try {
+      await executeContractWrite({
+        address: ADDRESS,
+        abi: ABI as unknown as Abi,
+        functionName: 'foo',
+        onReplayError
+      })
+    } catch (e) {
+      caught = e
+    }
+
+    expect(caught).toBeInstanceOf(ContractWriteRevertedError)
+    expect((caught as ContractWriteRevertedError).cause).toBeUndefined()
+    expect(onReplayError).toHaveBeenCalledTimes(1)
+    expect(onReplayError).toHaveBeenCalledWith(networkErr)
+  })
+
+  it('skips the replay when receipt blockNumber is 0n (genesis guard)', async () => {
+    vi.mocked(simulateContract).mockResolvedValueOnce(okSimulation)
+    vi.mocked(writeContract).mockResolvedValueOnce(HASH)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(revertedReceipt({ blockNumber: 0n }))
+
+    await expect(
+      executeContractWrite({
+        address: ADDRESS,
+        abi: ABI as unknown as Abi,
+        functionName: 'foo'
+      })
+    ).rejects.toBeInstanceOf(ContractWriteRevertedError)
+
+    expect(simulateContract).toHaveBeenCalledTimes(1)
+  })
+
+  it('propagates writeContract errors (e.g. user rejection) without waiting for a receipt', async () => {
+    const userReject = new BaseError('User rejected the request')
+    vi.mocked(simulateContract).mockResolvedValueOnce(okSimulation)
+    vi.mocked(writeContract).mockRejectedValueOnce(userReject)
+
+    await expect(
+      executeContractWrite({
+        address: ADDRESS,
+        abi: ABI as unknown as Abi,
+        functionName: 'foo'
+      })
+    ).rejects.toBe(userReject)
+
+    expect(waitForTransactionReceipt).not.toHaveBeenCalled()
+  })
+
+  it('propagates simulateContract pre-flight errors without writing', async () => {
+    const simErr = new BaseError('execution reverted at simulation time')
+    vi.mocked(simulateContract).mockRejectedValueOnce(simErr)
+
+    await expect(
+      executeContractWrite({
+        address: ADDRESS,
+        abi: ABI as unknown as Abi,
+        functionName: 'foo'
+      })
+    ).rejects.toBe(simErr)
+
+    expect(writeContract).not.toHaveBeenCalled()
+  })
+})
+
+describe('useContractWritesV3 — input validation & logging', () => {
+  const baseConfig = (
+    overrides: Partial<ContractWriteV3Config> = {}
+  ): ContractWriteV3Config => ({
+    contractAddress: ADDRESS,
+    abi: ABI as unknown as Abi,
+    functionName: 'foo',
+    ...overrides
+  })
+
+  it('rejects when contract address is undefined', async () => {
+    const m = useContractWritesV3(baseConfig({ contractAddress: ref(undefined) }))
+    await expect(m.mutateAsync({})).rejects.toThrow('Contract address is undefined')
+  })
+
+  it('rejects with the corrected "empty" wording when functionName is empty', async () => {
+    const m = useContractWritesV3(baseConfig({ functionName: '' }))
+    await expect(m.mutateAsync({})).rejects.toThrow('Function name is empty')
+  })
+
+  it('logs failures by default', async () => {
+    const err = new BaseError('boom')
+    vi.mocked(simulateContract).mockRejectedValueOnce(err)
+
+    const m = useContractWritesV3(baseConfig())
+    await expect(m.mutateAsync({})).rejects.toBe(err)
+    expect(mockLog.error).toHaveBeenCalled()
+  })
+
+  it('suppresses logging when config.log is false', async () => {
+    const err = new BaseError('boom')
+    vi.mocked(simulateContract).mockRejectedValueOnce(err)
+
+    const m = useContractWritesV3(baseConfig({ config: { log: false } }))
+    await expect(m.mutateAsync({})).rejects.toBe(err)
+    expect(mockLog.error).not.toHaveBeenCalled()
+  })
+
+  it('does not pass an onReplayError callback when logging is disabled', async () => {
+    vi.mocked(simulateContract)
+      .mockResolvedValueOnce(okSimulation)
+      .mockRejectedValueOnce(new Error('rpc down'))
+    vi.mocked(writeContract).mockResolvedValueOnce(HASH)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(revertedReceipt())
+
+    const m = useContractWritesV3(baseConfig({ config: { log: false } }))
+    await expect(m.mutateAsync({})).rejects.toBeInstanceOf(ContractWriteRevertedError)
+
+    expect(mockLog.error).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/composables/contracts/__tests__/useContractWritesV3.spec.ts
+++ b/app/src/composables/contracts/__tests__/useContractWritesV3.spec.ts
@@ -90,11 +90,11 @@ describe('executeContractWrite (standalone)', () => {
 
   it('throws ContractWriteRevertedError with BaseError cause when replay decodes the revert', async () => {
     const replayErr = new BaseError('execution reverted: InsufficientTokenBalance')
-    vi.mocked(simulateContract)
-      .mockResolvedValueOnce(okSimulation)
-      .mockRejectedValueOnce(replayErr)
+    vi.mocked(simulateContract).mockResolvedValueOnce(okSimulation).mockRejectedValueOnce(replayErr)
     vi.mocked(writeContract).mockResolvedValueOnce(HASH)
-    vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(revertedReceipt({ blockNumber: 100n }))
+    vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(
+      revertedReceipt({ blockNumber: 100n })
+    )
 
     let caught: unknown
     try {
@@ -194,9 +194,7 @@ describe('executeContractWrite (standalone)', () => {
 })
 
 describe('useContractWritesV3 — input validation & logging', () => {
-  const baseConfig = (
-    overrides: Partial<ContractWriteV3Config> = {}
-  ): ContractWriteV3Config => ({
+  const baseConfig = (overrides: Partial<ContractWriteV3Config> = {}): ContractWriteV3Config => ({
     contractAddress: ADDRESS,
     abi: ABI as unknown as Abi,
     functionName: 'foo',

--- a/app/src/composables/contracts/__tests__/useContractWritesV3.spec.ts
+++ b/app/src/composables/contracts/__tests__/useContractWritesV3.spec.ts
@@ -2,67 +2,39 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
 import { BaseError, type Abi } from 'viem'
 import { simulateContract, writeContract, waitForTransactionReceipt } from '@wagmi/core'
+import {
+  mockInvalidateQueries,
+  smartUseMutation,
+  useMutationFn,
+  useQueryClientFn
+} from '@/tests/mocks/composables.mock'
 import { mockLog } from '@/tests/mocks/utils.mock'
-import { ABI, ADDRESS, HASH, okSimulation, revertedReceipt, successReceipt } from './useContractWritesV3.test-utils'
-
-// Override the global @tanstack/vue-query mock for this file: we want
-// `useMutation` to actually invoke `mutationFn` / `onSuccess` / `onError`
-// so we can assert on the V3 wrapper's behaviour without spinning up a real
-// QueryClient.
-const { mockInvalidateQueries, mockUseMutation, mockUseQueryClient } = vi.hoisted(() => {
-  const mockInvalidateQueries = vi.fn().mockResolvedValue(undefined)
-  const mockUseQueryClient = vi.fn(() => ({ invalidateQueries: mockInvalidateQueries }))
-
-  type MutationOptions<TData, TVariables> = {
-    mutationFn: (vars: TVariables) => Promise<TData>
-    onSuccess?: (data: TData, vars: TVariables, ctx: unknown) => unknown
-    onError?: (err: unknown, vars: TVariables, ctx: unknown) => unknown
-  }
-
-  const mockUseMutation = vi.fn(<TData, TVariables>(options: MutationOptions<TData, TVariables>) => {
-    return {
-      mutate: vi.fn(),
-      mutateAsync: async (variables: TVariables) => {
-        try {
-          const data = await options.mutationFn(variables)
-          if (options.onSuccess) await options.onSuccess(data, variables, undefined)
-          return data
-        } catch (err) {
-          if (options.onError) await options.onError(err, variables, undefined)
-          throw err
-        }
-      },
-      isPending: ref(false),
-      isSuccess: ref(false),
-      isError: ref(false),
-      error: ref(null),
-      data: ref(null),
-      reset: vi.fn()
-    }
-  })
-
-  return { mockInvalidateQueries, mockUseMutation, mockUseQueryClient }
-})
-
-vi.mock('@tanstack/vue-query', async (importOriginal) => {
-  const actual = (await importOriginal()) as object
-  return {
-    ...actual,
-    useMutation: mockUseMutation,
-    useQueryClient: mockUseQueryClient
-  }
-})
-
 import {
   executeContractWrite,
   useContractWritesV3,
   ContractWriteRevertedError,
   type ContractWriteV3Config
 } from '../useContractWritesV3'
+import {
+  ABI,
+  ADDRESS,
+  HASH,
+  okSimulation,
+  revertedReceipt,
+  successReceipt
+} from './useContractWritesV3.test-utils'
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockInvalidateQueries.mockResolvedValue(undefined)
+  // Opt into the smart mutation impl so mutationFn / onSuccess / onError fire.
+  useMutationFn.mockImplementation(smartUseMutation)
+  // Opt into the stable invalidateQueries spy so onSuccess assertions are inspectable.
+  useQueryClientFn.mockReturnValue({
+    invalidateQueries: mockInvalidateQueries,
+    getQueryData: vi.fn(),
+    setQueryData: vi.fn(),
+    removeQueries: vi.fn()
+  })
 })
 
 describe('executeContractWrite (standalone)', () => {

--- a/app/src/composables/contracts/__tests__/useContractWritesV3.test-utils.ts
+++ b/app/src/composables/contracts/__tests__/useContractWritesV3.test-utils.ts
@@ -1,0 +1,30 @@
+import type { Abi, Address } from 'viem'
+import type { simulateContract, waitForTransactionReceipt } from '@wagmi/core'
+
+export const ADDRESS = '0x1234567890123456789012345678901234567890' as Address
+export const HASH =
+  '0xdeadbeef00000000000000000000000000000000000000000000000000000000' as const
+
+export const ABI = [
+  {
+    type: 'function',
+    name: 'foo',
+    inputs: [{ name: 'x', type: 'uint256' }],
+    outputs: [],
+    stateMutability: 'nonpayable'
+  }
+] as const satisfies Abi
+
+export const okSimulation = { request: { __mock: 'request' } } as unknown as Awaited<
+  ReturnType<typeof simulateContract>
+>
+
+export const successReceipt = (overrides: Partial<{ blockNumber: bigint }> = {}) =>
+  ({ status: 'success', blockNumber: 100n, ...overrides }) as unknown as Awaited<
+    ReturnType<typeof waitForTransactionReceipt>
+  >
+
+export const revertedReceipt = (overrides: Partial<{ blockNumber: bigint }> = {}) =>
+  ({ status: 'reverted', blockNumber: 100n, ...overrides }) as unknown as Awaited<
+    ReturnType<typeof waitForTransactionReceipt>
+  >

--- a/app/src/composables/contracts/__tests__/useContractWritesV3.test-utils.ts
+++ b/app/src/composables/contracts/__tests__/useContractWritesV3.test-utils.ts
@@ -2,8 +2,7 @@ import type { Abi, Address } from 'viem'
 import type { simulateContract, waitForTransactionReceipt } from '@wagmi/core'
 
 export const ADDRESS = '0x1234567890123456789012345678901234567890' as Address
-export const HASH =
-  '0xdeadbeef00000000000000000000000000000000000000000000000000000000' as const
+export const HASH = '0xdeadbeef00000000000000000000000000000000000000000000000000000000' as const
 
 export const ABI = [
   {

--- a/app/src/composables/contracts/useContractWritesV3.ts
+++ b/app/src/composables/contracts/useContractWritesV3.ts
@@ -204,10 +204,7 @@ export function useContractWritesV3(cfg: ContractWriteV3Config) {
         value: variables.value,
         onReplayError: shouldLog
           ? (err) =>
-              log.error(
-                `useContractWritesV3(${functionName}) revert-cause replay failed:\n`,
-                err
-              )
+              log.error(`useContractWritesV3(${functionName}) revert-cause replay failed:\n`, err)
           : undefined
       })
     },

--- a/app/src/composables/contracts/useContractWritesV3.ts
+++ b/app/src/composables/contracts/useContractWritesV3.ts
@@ -1,4 +1,4 @@
-import { computed, unref, type MaybeRef } from 'vue'
+import { unref, type MaybeRef } from 'vue'
 import { useMutation, useQueryClient } from '@tanstack/vue-query'
 import {
   simulateContract,
@@ -14,6 +14,10 @@ import { log, parseErrorV2 } from '@/utils'
 type WagmiConfig = typeof wagmiConfigType
 type SimulateParams = SimulateContractParameters<Abi, string, readonly unknown[], WagmiConfig>
 type WaitParams = WaitForTransactionReceiptParameters<WagmiConfig>
+// The wagmi config narrows chainId to a union of its configured chain ids.
+// We isolate that single narrowing in one alias so the broader literals can
+// be validated structurally with `satisfies` rather than cast wholesale.
+type AppChainId = SimulateParams['chainId']
 
 export interface ContractWriteV3Config {
   contractAddress: MaybeRef<Address | undefined>
@@ -68,6 +72,14 @@ export interface ExecuteContractWriteParams {
   chainId?: number
   args?: readonly unknown[]
   value?: bigint
+  /**
+   * Optional callback invoked when the post-revert simulation replay throws
+   * something other than a viem `BaseError` (e.g. an RPC/network failure).
+   * The replay is best-effort — it only exists to recover the ABI-decoded
+   * revert reason — so we never re-throw its failure, but we still want the
+   * caller to be able to surface it for diagnostics.
+   */
+  onReplayError?: (err: unknown) => void
 }
 
 export type ExecuteContractWriteResult = {
@@ -79,25 +91,37 @@ export type ExecuteContractWriteResult = {
 /**
  * Standalone contract write: simulate -> write -> wait for receipt.
  *
- * Framework-agnostic (no Vue/TanStack dependencies). Throws
- * `ContractWriteRevertedError` when the transaction is mined but reverts,
- * with the ABI-decoded revert reason attached as `cause` when recoverable.
+ * Framework-agnostic (no Vue/TanStack dependencies).
+ *
+ * ## Errors
+ * - `ContractWriteRevertedError` — transaction mined but reverted on-chain.
+ *   When recoverable, the ABI-decoded revert reason is attached as `cause`
+ *   via a simulation replay at the block before inclusion.
+ * - Any error thrown by `simulateContract` during the pre-flight (revert at
+ *   simulation time, RPC failure, etc.) propagates unchanged.
+ * - Any error thrown by `writeContract` (user rejection, RPC failure, signing
+ *   error, etc.) propagates unchanged — typically a viem `UserRejectedRequestError`
+ *   inside a `BaseError` chain.
+ * - Any error thrown by `waitForTransactionReceipt` (timeout, RPC failure,
+ *   reorg-related issues) propagates unchanged.
  */
 export async function executeContractWrite(
   params: ExecuteContractWriteParams
 ): Promise<ExecuteContractWriteResult> {
-  const { address, abi, functionName, args = [], value } = params
-  const chainId = params.chainId as SimulateParams['chainId']
+  const { address, abi, functionName, args = [], value, onReplayError } = params
+  const chainId = params.chainId as AppChainId
 
-  // 1) Simulate
-  const simulation = await simulateContract(wagmiConfig, {
+  const simulateInput = {
     address,
     abi,
     functionName,
     args,
     chainId,
     ...(value !== undefined ? { value } : {})
-  } as SimulateParams)
+  } satisfies SimulateParams
+
+  // 1) Simulate
+  const simulation = await simulateContract(wagmiConfig, simulateInput)
 
   // 2) Write — reuse the validated request from the simulation
   const hash = await writeContract(wagmiConfig, simulation.request)
@@ -106,25 +130,28 @@ export async function executeContractWrite(
   const receipt = await waitForTransactionReceipt(wagmiConfig, {
     hash,
     chainId
-  } as WaitParams)
+  } satisfies WaitParams)
 
   if (receipt.status !== 'success') {
     // Replay at the block just before mining to recover the ABI-decoded
     // revert reason (receipts don't carry it). viem will throw a
     // BaseError containing a ContractFunctionRevertedError in its chain.
+    //
+    // Skip when blockNumber is 0n: receipt.blockNumber - 1n would underflow
+    // to -1n and crash the RPC call, which is meaningless on a fresh chain
+    // (Anvil/Hardhat fixtures start at block 0). Genesis-block reverts lose
+    // the decoded cause — acceptable for a near-impossible production edge case.
     let revertCause: BaseError | undefined
-    try {
-      await simulateContract(wagmiConfig, {
-        address,
-        abi,
-        functionName,
-        args,
-        chainId,
-        blockNumber: receipt.blockNumber - 1n,
-        ...(value !== undefined ? { value } : {})
-      } as SimulateParams)
-    } catch (replayErr) {
-      if (replayErr instanceof BaseError) revertCause = replayErr
+    if (receipt.blockNumber > 0n) {
+      try {
+        await simulateContract(wagmiConfig, {
+          ...simulateInput,
+          blockNumber: receipt.blockNumber - 1n
+        } satisfies SimulateParams)
+      } catch (replayErr) {
+        if (replayErr instanceof BaseError) revertCause = replayErr
+        else onReplayError?.(replayErr)
+      }
     }
     throw new ContractWriteRevertedError({ hash, receipt, simulation, cause: revertCause })
   }
@@ -139,11 +166,26 @@ export async function executeContractWrite(
  * Wraps `executeContractWrite` in a TanStack mutation.
  *
  * `args` and `value` are provided per-call to `executeWrite` / `mutate`.
+ *
+ * ## Behaviour notes
+ *
+ * - **chainId resolution.** When `cfg.chainId` is omitted, wagmi resolves the
+ *   chain from the connected wallet at call time. There is no explicit
+ *   `useChainId()` fallback (this is a deliberate divergence from V2).
+ * - **Type safety on `args`.** `abi` is widened to `Abi` and `functionName`
+ *   to `string` inside this composable, so `variables.args` is **not**
+ *   structurally checked against the ABI signature. Callers wanting compile-
+ *   time safety should wrap this composable behind an `abitype`-typed
+ *   factory (see `composables/bank/writes.ts` for the
+ *   `ExtractAbiFunctionNames` pattern).
+ * - **Cross-chain invalidation.** When `cfg.chainId` is omitted, the success
+ *   handler invalidates `useReadContract` queries for this address across
+ *   *every* chain in the cache. Pin `chainId` to scope the invalidation.
  */
 export function useContractWritesV3(cfg: ContractWriteV3Config) {
   const queryClient = useQueryClient()
 
-  const shouldLog = computed(() => cfg.config?.log ?? true)
+  const shouldLog = cfg.config?.log ?? true
 
   return useMutation({
     mutationFn: async (variables: ExecuteWriteVariables = {}) => {
@@ -151,7 +193,7 @@ export function useContractWritesV3(cfg: ContractWriteV3Config) {
       const functionName = unref(cfg.functionName)
 
       if (!address) throw new Error('Contract address is undefined')
-      if (!functionName) throw new Error('Function name is undefined')
+      if (!functionName) throw new Error('Function name is empty')
 
       return executeContractWrite({
         address,
@@ -159,11 +201,18 @@ export function useContractWritesV3(cfg: ContractWriteV3Config) {
         functionName,
         chainId: unref(cfg.chainId),
         args: variables.args,
-        value: variables.value
+        value: variables.value,
+        onReplayError: shouldLog
+          ? (err) =>
+              log.error(
+                `useContractWritesV3(${functionName}) revert-cause replay failed:\n`,
+                err
+              )
+          : undefined
       })
     },
     onError: (error) => {
-      if (shouldLog.value) {
+      if (shouldLog) {
         log.error(`useContractWritesV3(${unref(cfg.functionName)}) failed:\n`, parseErrorV2(error))
       }
     },

--- a/app/src/tests/mocks/composables.mock.ts
+++ b/app/src/tests/mocks/composables.mock.ts
@@ -336,3 +336,86 @@ export const useQueryFn = vi.fn(() => ({
   isLoading: vi.fn(),
   error: vi.fn()
 }))
+
+/**
+ * Stable spy for `queryClient.invalidateQueries` — opt-in.
+ *
+ * The default `useQueryClientFn` returns a fresh `vi.fn()` per call, which is
+ * fine for "was it called?" assertions but makes it impossible to inspect the
+ * predicate / queryKey passed to `invalidateQueries`. Tests that need that
+ * introspection should rebind in `beforeEach`:
+ *
+ *   useQueryClientFn.mockReturnValue({
+ *     invalidateQueries: mockInvalidateQueries,
+ *     getQueryData: vi.fn(),
+ *     setQueryData: vi.fn(),
+ *     removeQueries: vi.fn()
+ *   })
+ */
+export const mockInvalidateQueries = vi.fn().mockResolvedValue(undefined)
+
+/**
+ * Default mock for TanStack Vue Query's `useMutation`.
+ *
+ * Returns an inert mutation observer (mutate/mutateAsync are stub `vi.fn()`s,
+ * status refs are idle). This matches the conservative behaviour the test
+ * suite expected before V3 — no `mutationFn` runs unless a test opts in.
+ *
+ * For tests that DO want to exercise the real mutation lifecycle (mutationFn
+ * / onSuccess / onError), swap in `smartUseMutation` per file:
+ *
+ *   beforeEach(() => useMutationFn.mockImplementation(smartUseMutation))
+ */
+export const useMutationFn = vi.fn(() => ({
+  mutate: vi.fn(),
+  mutateAsync: vi.fn(),
+  isPending: ref(false),
+  isSuccess: ref(false),
+  isError: ref(false),
+  error: ref(null),
+  data: ref(null),
+  reset: vi.fn(),
+  status: ref<'idle' | 'pending' | 'error' | 'success'>('idle'),
+  variables: ref(undefined)
+}))
+
+type SmartMutationOptions<TData, TVariables> = {
+  mutationFn: (vars: TVariables) => Promise<TData>
+  onSuccess?: (data: TData, vars: TVariables, ctx: unknown) => unknown
+  onError?: (err: unknown, vars: TVariables, ctx: unknown) => unknown
+}
+
+/**
+ * Drop-in implementation for `useMutationFn` that actually runs `mutationFn`
+ * and dispatches `onSuccess` / `onError` when `mutateAsync` is awaited.
+ *
+ * Use it via `useMutationFn.mockImplementation(smartUseMutation)` in tests
+ * that exercise composables built on `useMutation` (e.g. V3 contract writes).
+ *
+ * Note: `mutate` is left as a no-op `vi.fn()` here because most existing
+ * call sites only care about whether `mutate` was invoked, not its side
+ * effects. Tests that need fire-and-forget behaviour can override.
+ */
+export const smartUseMutation = <TData, TVariables>(
+  options: SmartMutationOptions<TData, TVariables>
+) => ({
+  mutate: vi.fn(),
+  mutateAsync: async (variables: TVariables) => {
+    try {
+      const data = await options.mutationFn(variables)
+      if (options.onSuccess) await options.onSuccess(data, variables, undefined)
+      return data
+    } catch (err) {
+      if (options.onError) await options.onError(err, variables, undefined)
+      throw err
+    }
+  },
+  isPending: ref(false),
+  isSuccess: ref(false),
+  isError: ref(false),
+  error: ref(null),
+  data: ref(null),
+  reset: vi.fn(),
+  status: ref<'idle' | 'pending' | 'error' | 'success'>('idle'),
+  variables: ref(undefined)
+})

--- a/app/src/tests/setup/composables.setup.ts
+++ b/app/src/tests/setup/composables.setup.ts
@@ -12,6 +12,7 @@ import {
   mockUseClipboard,
   useQueryClientFn,
   useQueryFn,
+  useMutationFn,
   mockUseFetch,
   mockUseWalletChecks,
   mockUseSubmitRestriction
@@ -38,7 +39,8 @@ vi.mock('@tanstack/vue-query', async () => {
   return {
     ...actual,
     useQueryClient: useQueryClientFn,
-    useQuery: useQueryFn
+    useQuery: useQueryFn,
+    useMutation: useMutationFn
   }
 })
 


### PR DESCRIPTION
Closes #1775.

## Summary

Addresses the review feedback collected on `useContractWritesV3.ts` and adds the unit-test coverage that was missing for the V3 path.

## Changes

### `useContractWritesV3.ts` — refactor
- **Point 1.** Replace the misleading `Function name is undefined` message with `Function name is empty` (the type is `MaybeRef<string>`, never `undefined`).
- **Point 2.** `shouldLog` is now a plain `const` — `cfg.config?.log` is fixed at composable creation, so the `computed` was just overhead.
- **Point 3.** Replace the wholesale `as SimulateParams` / `as WaitParams` casts with `satisfies`, isolating the unavoidable narrowing into a single `AppChainId` alias.
- **Point 4.** Guard `receipt.blockNumber > 0n` before computing `blockNumber - 1n` to avoid a BigInt underflow on genesis-block reverts (Anvil/Hardhat fresh-chain edge case).
- **Point 5.** Add an optional `onReplayError` callback on `ExecuteContractWriteParams` so non-`BaseError` failures during the revert-cause replay (e.g. RPC timeouts) can be surfaced for diagnostics instead of silently swallowed. The composable wires it to `log.error` when `shouldLog` is on.
- **Points 6, 7, 8, 9.** Extend the JSDoc to document: every error source propagated by `executeContractWrite` (simulate / write / wait), the deliberate divergence from V2 around `chainId` resolution, the loss of generic `args` type-safety inside V3, and the cross-chain invalidation behaviour when `chainId` is omitted.

### Tests — new
- `__tests__/useContractWritesV3.spec.ts` — 15 tests covering `executeContractWrite` (success, value handling, ABI-decoded revert via replay, non-`BaseError` replay errors, genesis-block guard, write/simulate error propagation) and the wrapper's input validation + log gating.
- `__tests__/useContractWritesV3.advanced.spec.ts` — 7 tests on the `onSuccess` invalidation predicate (matching, case-insensitive address, chainId pinning vs cross-chain, malformed key rejection, reactive-address race condition).
- `__tests__/useContractWritesV3.test-utils.ts` — shared fixtures (ABI, ADDRESS, HASH, receipt builders).

The split mirrors the V2 `.spec.ts` / `.advanced.spec.ts` convention. Each spec file owns its own `vi.mock('@tanstack/vue-query', …)` override (`useMutation` / `useQueryClient` are stubbed so we can assert the mutation lifecycle without standing up a real `QueryClient`).

## Test plan
- [x] `npx vitest run src/composables/contracts/__tests__` — 35/35 green (V2 + V3).
- [x] `npx eslint` on the four touched files — clean.
- [x] `npx vue-tsc --noEmit` — no new errors introduced on V3 or its consumers.
- [ ] Smoke-test the `bank/writes.ts` and `CRWithdrawClaim.vue` consumers in dev to confirm no behavioural regression on a real chain.