### PR TITLE
docs: 📝 set up AGENTS.md, reconcile copilot-instructions, add drift detection

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,12 +1,14 @@
 # CNC Portal GitHub Copilot Instructions
 
+> **Primary entry point for AI agents is [`AGENTS.md`](../AGENTS.md) at the repo root.** This file and the [`copilot-instructions/`](./copilot-instructions/) folder hold deeper area-specific guides referenced from there.
+
 The CNC Portal is a multi-component application enabling financial recognition of micro contributions in open-source projects and promoting effective governance tools.
 
 ## Architecture Overview
 
 **Tech Stack:**
 
-- **Frontend** (`app/`): Vue.js 3, TypeScript, Vite, Pinia (state management), Web3 integration with wagmi, tailwind & daisyUI
+- **Frontend** (`app/`): Vue 3, TypeScript, Vite, Pinia, TanStack Query, wagmi/viem, Apollo Client, Tailwind v4, Nuxt UI v4
 - **Backend** (`backend/`): Express.js, TypeScript, Prisma ORM, PostgreSQL, JWT authentication
 - **Contracts** (`contract/`): Hardhat, Solidity, TypeScript testing, Ethereum blockchain integration
 - **Subgraph** (`the-graph/`): The Graph Protocol
@@ -19,14 +21,11 @@ The CNC Portal is a multi-component application enabling financial recognition o
 
 ## Comprehensive Instructions
 
-For detailed coding guidelines and best practices, please refer to the organized instruction files in the [`copilot-instructions/`](./copilot-instructions/) directory:
+For detailed coding guidelines and best practices, see the instruction files in the [`copilot-instructions/`](./copilot-instructions/) directory:
 
 ### Core Development Guidelines
 
 - [Vue.js Component Standards](./copilot-instructions/vue-component-standards.md)
-- [TypeScript Guidelines](./copilot-instructions/typescript-guidelines.md)
-- [Web3 Integration](./copilot-instructions/web3-integration.md)
-- [State Management](./copilot-instructions/state-management.md)
 
 ### Testing Guidelines
 
@@ -35,16 +34,8 @@ For detailed coding guidelines and best practices, please refer to the organized
 - [Web3 Testing](./copilot-instructions/testing-web3.md)
 - [Testing Anti-Patterns](./copilot-instructions/testing-anti-patterns.md)
 
-### Quality & Performance
-
-- [Performance Optimization](./copilot-instructions/performance-optimization.md)
-- [Accessibility](./copilot-instructions/accessibility.md)
-- [Security](./copilot-instructions/security.md)
-- [Error Handling](./copilot-instructions/error-handling.md)
-
 ### Project Specific
 
-- [Repository Patterns](./copilot-instructions/repository-patterns.md)
 - [Review Checklist](./copilot-instructions/review-checklist.md)
 - [Commit Conventions](./copilot-instructions/commit-conventions.md)
 
@@ -120,14 +111,14 @@ For detailed coding guidelines and best practices, please refer to the organized
 
 **Backend:**
 
+- ESLint + Prettier
 - TypeScript compilation
-- Prisma client generation required
-- Comprehensive test suite (163 tests)
-- Note: Linting scripts not currently available
+- Prisma client generation required (`npx prisma generate`)
+- Comprehensive Vitest unit + e2e test suites
 
 **Contracts:**
 
-- Solidity linting and formatting
-- Extensive test coverage (350+ tests)
+- Solhint + ESLint, Prettier (with `prettier-plugin-solidity`)
+- Extensive Hardhat test coverage
 - TypeScript for test files
 - Gas usage reporting

--- a/.github/copilot-instructions/README.md
+++ b/.github/copilot-instructions/README.md
@@ -4,9 +4,11 @@ This directory contains comprehensive coding guidelines and instructions for the
 
 ## Project Overview
 
+> Repo-wide orientation lives in [`AGENTS.md`](../../AGENTS.md). This folder holds deeper area-specific guides.
+
 CNC Portal is a Crypto Native Corporation Portal built with:
 
-- **App**: Vue.js 3 + TypeScript + Vite + Tailwind CSS
+- **App**: Vue 3 + TypeScript + Vite + Tailwind v4 + Nuxt UI v4
 - **Backend**: Node.js + TypeScript + Prisma + PostgreSQL
 - **Smart Contracts**: Hardhat + Solidity
 - **Dashboard**: Nuxt 4 + Nuxt UI + TypeScript + Tailwind CSS
@@ -97,18 +99,6 @@ Make all interfaces accessible for everyone, including users with disabilities
 ## Usage
 
 When working on the CNC Portal project, GitHub Copilot will automatically reference these instructions to provide contextually appropriate suggestions that follow the established patterns and best practices.
-
-## File Status
-
-### Complete Files
-
-- ✅ [Testing Overview](./testing-overview.md) - Comprehensive testing philosophy and organization
-- ✅ [Testing Patterns](./testing-patterns.md) - Detailed testing patterns with examples
-- ✅ [Web3 Testing](./testing-web3.md) - Web3/contract specific testing patterns
-- ✅ [Testing Anti-Patterns](./testing-anti-patterns.md) - What to avoid in testing
-- ✅ [Vue.js Component Standards](./vue-component-standards.md) - Complete Vue.js guidelines
-- ✅ [Review Checklist](./review-checklist.md) - Comprehensive code review checklist
-- ✅ [Commit Conventions](./commit-conventions.md) - Detailed commit message standards
 
 ## Contributing
 

--- a/.github/copilot-instructions/commit-conventions.md
+++ b/.github/copilot-instructions/commit-conventions.md
@@ -1,84 +1,78 @@
 # Commit Message Conventions
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
+> Authoritative source: [`AGENTS.md`](../../AGENTS.md). This file expands the rationale.
+
+## Format
 
 ```text
-<type>(<scope>): <description>
+<type><gitmoji>: <subject>
 
 [optional body]
 [optional footer]
 ```
 
-**Types:** feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+- **No scope.** Don't write `feat(api): …` — just `feat: …`.
+- **Gitmoji is required**, paired with the type.
+- **Imperative, present tense** in the subject ("add", not "added").
+- **Subject ≤ 72 chars, no trailing period.**
+- Same format applies to **issue titles and PR titles**.
 
-**Scopes:** components, stores, utils, types, api, contracts, subgraph, tests, docs, config
+## Type → gitmoji mapping
 
-**Guidelines:**
+| Type | Gitmoji | Use for |
+| --- | --- | --- |
+| `feat` | ✨ | New feature |
+| `fix` | 🐛 | Bug fix |
+| `refactor` | ♻️ | Code change without behavior change |
+| `docs` | 📝 | Documentation only |
+| `test` | ✅ | Adding/updating tests |
+| `chore` | 🔧 | Tooling, deps, housekeeping |
+| `style` | 💄 | Formatting / UI style only |
+| `perf` | ⚡️ | Performance improvement |
+| `build` | 📦 | Build system or external deps |
+| `ci` | 👷 | CI configuration |
 
-- Use imperative mood ("add", not "added")
-- Subject ≤ 72 chars, no period
-- Be specific and descriptive
-- Reference issues/PRs in footer if needed
-- For breaking changes, add `!` after type/scope and explain in body
+## Examples
 
-**Examples:**
+Good:
 
 ```text
-feat(components): add token selection dropdown
-fix(api): handle network errors gracefully
-docs: update README
-refactor(utils): extract shared validation logic
-chore(deps): update security dependencies
+feat: ✨ add token selection dropdown
+fix: 🐛 handle null team owner
+refactor: ♻️ extract shared validation logic
+docs: 📝 update README env-var section
+chore: 🔧 bump prettier to 3.6.2
 ```
 
-**Good:**
-
-```text
-feat(stores): implement user preference management
-fix(web3): validate address format before contract call
-```
-
-**Bad:**
+Bad:
 
 ```text
 fix: bug
 feat: added some stuff
 update: changes
+feat(api): ✨ add endpoint   ← no scopes
 ```
 
-**Body (optional):**
+## Atomic commits
 
-- Explain what and why, not how
-- Separate from subject with blank line
+One commit per logical change. **Do not** batch unrelated changes, and **do not** squash an entire PR into a single commit at the end. Commit as each piece lands so the history is reviewable.
 
-**Footer (optional):**
+## Body & footer (optional)
 
-- Reference issues, PRs, or breaking changes
+- **Body** — explain *why*, not *what*. Separate from subject with a blank line.
+- **Breaking changes** — append `!` after the type (e.g. `feat!: ✨ …`) and describe in the body.
+- **Issue refs** — link via the PR description rather than commit footers; the team relies on PR-level linking, not `Fixes #123` trailers.
 
-```text
-Fixes #123
-BREAKING CHANGE: API now requires JWT auth
-```
+## Never
 
-**Automation:**
+- `Co-Authored-By` trailers (per project policy).
+- "🤖 Generated with Claude Code" footers.
+- Non-English subjects.
 
-- Commit messages are checked by commitlint and pre-commit hook:
+## Release notes
 
-```bash
-npx commitlint --edit $1
-```
-
-- Use VS Code "Conventional Commits" extension for help
-
-**Release notes:**
-
-- Proper commit messages enable changelog and release note generation:
+Conventional commit messages enable changelog generation via the root-level script:
 
 ```bash
 npx conventional-changelog -p angular -i CHANGELOG.md -s
-gh release create v1.2.0 --generate-notes
 ```
-
-**Summary:**
-
-- Clear, consistent commit messages = better history, changelogs, and collaboration.

--- a/.github/copilot-instructions/testing-overview.md
+++ b/.github/copilot-instructions/testing-overview.md
@@ -1,301 +1,105 @@
 # Testing Overview
 
-## Testing Philosophy
+> **Canonical references in the codebase** (read these instead of trusting outdated snippets):
+>
+> - Component spec — `app/src/components/__tests__/SelectComponent.spec.ts`
+> - Composable spec with `vi.hoisted` — `app/src/composables/__tests__/useContractFunction.spec.ts`
+> - Web3 / wagmi spec — `app/src/__tests__/wagmi.spec.ts`
+> - Pure-utility spec — `app/src/utils/__tests__/currencyUtil.spec.ts`
+> - Mutation + query spec — `app/src/queries/__tests__/weeklyClaim.queries.spec.ts`
 
-The CNC Portal project follows a comprehensive testing strategy that ensures code reliability, maintainability, and user experience quality. Our testing approach prioritizes behavior-driven testing over implementation details.
+This file documents _principles_. When you need to write a new test, copy the structure from the closest canonical reference above — those files are the source of truth and stay correct because CI runs them.
 
-## Testing Framework Stack
+## Philosophy
 
-- **Unit & Component Testing**: Vitest
-- **Test Utilities**: Vue Test Utils
-- **Mocking**: Vitest mocking system
-- **E2E Testing**: Playwright
-- **Coverage**: Built-in Vitest coverage
+Behavior over implementation. Tests should fail when the user-visible contract breaks, not when an internal variable is renamed.
 
-## Test File Organization
+## Stack
 
-### Directory Structure
+- **Unit & component**: Vitest
+- **Test utilities**: `@vue/test-utils`
+- **Mocking**: Vitest (`vi.hoisted`, `vi.mock`)
+- **E2E**: Playwright (+ Synpress for wallet flows)
+- **Coverage**: Vitest istanbul
+
+## File layout
+
+Co-locate tests with the code they cover, in `__tests__/`:
 
 ```text
-src/
-├── components/
-│   ├── ComponentName.vue
-│   └── __tests__/
-│       ├── ComponentName.spec.ts          # Basic functionality tests
-│       └── ComponentName.advanced.spec.ts # Complex features & edge cases
-├── composables/
-│   ├── useCustomComposable.ts
-│   └── __tests__/
-│       └── useCustomComposable.spec.ts
-└── utils/
-    ├── helpers.ts
-    └── __tests__/
-        └── helpers.spec.ts
+src/components/Foo.vue
+src/components/__tests__/Foo.spec.ts
+src/composables/useFoo.ts
+src/composables/__tests__/useFoo.spec.ts
+src/utils/foo.ts
+src/utils/__tests__/foo.spec.ts
 ```
 
-### Test Categories
+Naming:
 
-#### 1. Unit Tests (`*.spec.ts`)
+- `Foo.spec.ts` — basic
+- `Foo.advanced.spec.ts` — complex / edge cases
+- `Foo.integration.spec.ts` — multi-component / store interaction
+- E2E in `app/test/e2e/`
 
-- Pure functions and utilities
-- Individual component behavior
-- Composable functions
-- Store actions and getters
+## Core principles
 
-#### 2. Integration Tests (`*.integration.spec.ts`)
+- **Use `data-test` attributes**, never CSS classes or DOM structure, to query elements. The component standard requires `data-test` on every interactive element.
+- **Test what users see**, not `wrapper.vm.someInternalRef`.
+- **One responsibility per test**, descriptive name (`should emit update:modelValue when option is selected`, not `works correctly`).
+- **Cover, for each component**: rendering with different props, user interactions, prop/state changes, event emissions, error states, loading states, accessibility, edge cases.
 
-- Component interaction with stores
-- API integration with composables
-- Multi-component workflows
+## Mocking conventions
 
-#### 3. E2E Tests (`test/e2e/`)
+The canonical pattern is `vi.hoisted` for mocks that need to be referenced inside `vi.mock` factories. See lines 9–19 of `useContractFunction.spec.ts` for the exact shape.
 
-- Full user journeys
-- Cross-browser compatibility
-- Real blockchain interaction testing
+Toast notifications use Nuxt UI's `useToast()`. Mock it once per spec (auto-import path varies per setup — usually `#imports`):
 
-## Test Naming Conventions
+```ts
+const { mockToast } = vi.hoisted(() => ({ mockToast: { add: vi.fn() } }));
+vi.mock("#imports", () => ({ useToast: () => mockToast }));
 
-### File Naming
-
-- **Basic tests**: `ComponentName.spec.ts`
-- **Advanced tests**: `ComponentName.advanced.spec.ts`
-- **Integration tests**: `ComponentName.integration.spec.ts`
-- **E2E tests**: `component-name.e2e.spec.ts`
-
-### Test Structure
-
-```typescript
-describe('ComponentName', () => {
-  describe('Component Rendering', () => {
-    // Basic rendering tests
-  })
-
-  describe('User Interactions', () => {
-    // Click, keyboard, form interactions
-  })
-
-  describe('State Management', () => {
-    // Props, emits, reactive state
-  })
-
-  describe('Loading States', () => {
-    // Async operations and loading indicators
-  })
-
-  describe('Error Handling', () => {
-    // Error scenarios and fallbacks
-  })
-
-  describe('Edge Cases', () => {
-    // Boundary conditions and unusual inputs
-  })
-})
+// assertion
+expect(mockToast.add).toHaveBeenCalledWith(
+  expect.objectContaining({ title: "Saved", color: "success" }),
+);
 ```
 
-## Test Data Management
+For wagmi, mock `@wagmi/core` directly:
 
-### Mock Data Organization
-
-```typescript
-// Constants for reusable test data
-const MOCK_DATA = {
-  validAddress: '0x1234567890123456789012345678901234567890',
-  invalidAddress: 'invalid-address',
-  options: [
-    { value: 'ETH', label: 'Ethereum' },
-    { value: 'USDC', label: 'USD Coin' }
-  ],
-  userProfiles: [
-    { id: 1, name: 'John Doe', address: '0x123...' },
-    { id: 2, name: 'Jane Doe', address: '0x456...' }
-  ]
-} as const
-```
-
-### Test Selectors
-
-```typescript
-// Centralized selectors for consistent element targeting
-const SELECTORS = {
-  trigger: '[data-test="component-trigger"]',
-  dropdown: '[data-test="options-dropdown"]',
-  submitBtn: '[data-test="submit-btn"]',
-  loadingSpinner: '[data-test="loading-spinner"]',
-  errorMessage: '[data-test="error-message"]'
-} as const
-```
-
-## Testing Principles
-
-### 1. Test Behavior, Not Implementation
-
-```typescript
-// ❌ Bad: Testing internal state
-expect(wrapper.vm.internalValue).toBe('expected')
-
-// ✅ Good: Testing user-visible behavior
-expect(wrapper.find('[data-test="display-value"]').text()).toBe('Expected Value')
-```
-
-### 2. Use Data-Test Attributes
-
-```typescript
-// ❌ Bad: Fragile selectors
-wrapper.find('.btn-primary')
-wrapper.find('div > ul > li:first-child')
-
-// ✅ Good: Stable test attributes
-wrapper.find('[data-test="submit-button"]')
-wrapper.find('[data-test="first-option"]')
-```
-
-### 3. Descriptive Test Names
-
-```typescript
-// ❌ Bad: Generic descriptions
-it('works correctly', () => {})
-it('handles events', () => {})
-
-// ✅ Good: Specific behavior descriptions
-it('should emit update:modelValue when option is selected', () => {})
-it('should disable submit button when form validation fails', () => {})
-```
-
-### 4. Single Responsibility Per Test
-
-```typescript
-// ❌ Bad: Multiple concerns
-it('should handle form submission and validation and error states', () => {
-  // Too many responsibilities
-})
-
-// ✅ Good: Single responsibility
-it('should validate required fields before submission', () => {})
-it('should show error message when submission fails', () => {})
-it('should reset form after successful submission', () => {})
-```
-
-## Test Coverage Requirements
-
-### Minimum Coverage Targets
-
-- **Unit Tests**: 90% line coverage
-- **Component Tests**: 85% line coverage
-- **Integration Tests**: 70% line coverage
-
-### Required Test Areas
-
-For every component, ensure coverage of:
-
-1. **Initial Rendering** - Component displays correctly with different props
-2. **User Interactions** - Clicks, keyboard navigation, form submissions
-3. **State Changes** - Reactive updates and prop changes
-4. **Event Emissions** - Correct events with proper payloads
-5. **Error Handling** - Error states and fallback behaviors
-6. **Loading States** - Async operations and loading indicators
-7. **Accessibility** - ARIA attributes and keyboard support
-8. **Edge Cases** - Empty data, invalid inputs, boundary conditions
-9. **Component Communication** - Parent-child component interaction
-10. **Conditional Rendering** - Dynamic content based on state/props
-
-## Testing Tools and Utilities
-
-### Component Test Helpers
-
-```typescript
-// Reusable component mounting function
-const mountComponent = (props = {}, options = {}) => {
-  return mount(Component, {
-    props: { ...defaultProps, ...props },
-    global: {
-      components: { RequiredChildComponent },
-      plugins: [createTestingPinia({ createSpy: vi.fn })],
-      ...options.global
-    }
-  })
-}
-
-// Async operation helpers
-const waitForAsyncOperation = async () => {
-  await nextTick()
-  await flushPromises()
-}
-
-// Toast verification (Nuxt UI useToast)
-const expectToast = (color: 'success' | 'error', title: string) => {
-  expect(mockToast.add).toHaveBeenCalledWith(
-    expect.objectContaining({ title, color })
-  )
-}
-```
-
-### Mock Management
-
-```typescript
-// Hoisted mock variables for consistency
-const { mockReadContract, mockWriteContract, mockToast } = vi.hoisted(() => ({
+```ts
+const { mockReadContract, mockWriteContract } = vi.hoisted(() => ({
   mockReadContract: vi.fn(),
   mockWriteContract: vi.fn(),
-  mockToast: { add: vi.fn() }
-}))
-
-// Stub Nuxt UI's auto-imported `useToast` (adjust the import path
-// to match the project's setup, e.g. '#imports' or '@nuxt/ui')
-vi.mock('#imports', () => ({ useToast: () => mockToast }))
-
-// Proper mock setup and cleanup
-beforeEach(() => {
-  vi.clearAllMocks()
-})
-
-afterEach(() => {
-  if (wrapper) wrapper.unmount()
-})
+}));
+vi.mock("@wagmi/core", () => ({
+  readContract: mockReadContract,
+  writeContract: mockWriteContract,
+}));
 ```
 
-## Performance Considerations
+Reset between tests:
 
-### Test Performance Best Practices
+```ts
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => wrapper?.unmount());
+```
 
-- Use `shallowMount` for isolated component testing
-- Mock heavy dependencies and external services
-- Reuse component instances when testing multiple scenarios
-- Clean up properly to prevent memory leaks
-- Use `vi.clearAllMocks()` instead of recreating mocks
+## Coverage targets
 
-### Parallel Test Execution
+- Unit: ~90% line
+- Component: ~85% line
+- Integration: ~70% line
 
-- Design tests to be independent and stateless
-- Avoid shared global state between tests
-- Use unique test data for each test case
-- Properly clean up after each test
+Coverage is a smell detector, not a goal. A 95%-covered component with no behavioral assertions is worse than 70% coverage that exercises the contract.
 
-## Quality Assurance
+## Local quality gate
 
-### Local quality gate
+Before pushing, run the per-subproject lint / type-check / test commands documented in [`AGENTS.md`](../../AGENTS.md). The repo does not configure husky/commitlint, so this gate is enforced manually plus by CI on PRs.
 
-Before pushing, run the per-subproject lint/type-check/test commands documented in `AGENTS.md`. The repository does not currently configure husky/commitlint, so this gate is enforced manually plus by CI on PRs.
+## Performance hygiene
 
-### CI/CD Integration
-
-- Tests run on all pull requests
-- Coverage reports are generated and tracked
-- E2E tests run on staging deployments
-- Test results are reported in PR comments
-
-## Documentation Standards
-
-### Test Documentation
-
-- Include JSDoc comments for complex test setups
-- Document the purpose of unusual mock configurations
-- Explain business logic being tested
-- Provide examples for reusable test utilities
-
-### README Updates
-
-- Update component README files with testing examples
-- Document testing patterns for new features
-- Include troubleshooting guides for common test issues
-- Maintain examples of proper test structure
+- Mock heavy deps; don't network in unit tests.
+- Tests must be independent — no shared mutable state across files.
+- Use `vi.clearAllMocks()` in `beforeEach`, not full re-creation.
+- For very heavy components, `shallowMount` is acceptable when you're only testing the wrapper's contract.

--- a/.github/copilot-instructions/testing-overview.md
+++ b/.github/copilot-instructions/testing-overview.md
@@ -222,13 +222,11 @@ const waitForAsyncOperation = async () => {
   await flushPromises()
 }
 
-// Toast message verification
-const expectToastMessage = (type: 'success' | 'error', message: string) => {
-  if (type === 'success') {
-    expect(mockToastStore.addSuccessToast).toHaveBeenCalledWith(message)
-  } else {
-    expect(mockToastStore.addErrorToast).toHaveBeenCalledWith(message)
-  }
+// Toast verification (Nuxt UI useToast)
+const expectToast = (color: 'success' | 'error', title: string) => {
+  expect(mockToast.add).toHaveBeenCalledWith(
+    expect.objectContaining({ title, color })
+  )
 }
 ```
 
@@ -236,14 +234,15 @@ const expectToastMessage = (type: 'success' | 'error', message: string) => {
 
 ```typescript
 // Hoisted mock variables for consistency
-const { mockReadContract, mockWriteContract, mockToastStore } = vi.hoisted(() => ({
+const { mockReadContract, mockWriteContract, mockToast } = vi.hoisted(() => ({
   mockReadContract: vi.fn(),
   mockWriteContract: vi.fn(),
-  mockToastStore: {
-    addErrorToast: vi.fn(),
-    addSuccessToast: vi.fn()
-  }
+  mockToast: { add: vi.fn() }
 }))
+
+// Stub Nuxt UI's auto-imported `useToast` (adjust the import path
+// to match the project's setup, e.g. '#imports' or '@nuxt/ui')
+vi.mock('#imports', () => ({ useToast: () => mockToast }))
 
 // Proper mock setup and cleanup
 beforeEach(() => {
@@ -274,14 +273,9 @@ afterEach(() => {
 
 ## Quality Assurance
 
-### Pre-commit Hooks
+### Local quality gate
 
-Tests are automatically run before commits to ensure:
-
-- All tests pass
-- Code coverage thresholds are met
-- No lint errors in test files
-- TypeScript compilation succeeds
+Before pushing, run the per-subproject lint/type-check/test commands documented in `AGENTS.md`. The repository does not currently configure husky/commitlint, so this gate is enforced manually plus by CI on PRs.
 
 ### CI/CD Integration
 

--- a/.github/copilot-instructions/testing-patterns.md
+++ b/.github/copilot-instructions/testing-patterns.md
@@ -58,7 +58,7 @@ describe('ComponentName', () => {
 
 ```typescript
 // Hoisted variables for mocks (before vi.mock calls)
-const { mockReadContract, mockWriteContract, mockTeamStore, mockToastStore } = vi.hoisted(() => ({
+const { mockReadContract, mockWriteContract, mockTeamStore, mockToast } = vi.hoisted(() => ({
   mockReadContract: vi.fn(),
   mockWriteContract: vi.fn(),
   mockTeamStore: {
@@ -67,10 +67,7 @@ const { mockReadContract, mockWriteContract, mockTeamStore, mockToastStore } = v
       return undefined
     })
   },
-  mockToastStore: {
-    addErrorToast: vi.fn(),
-    addSuccessToast: vi.fn()
-  }
+  mockToast: { add: vi.fn() }
 }))
 
 // Mock external dependencies
@@ -80,9 +77,11 @@ vi.mock('@wagmi/core', () => ({
 }))
 
 vi.mock('@/stores', () => ({
-  useTeamStore: vi.fn(() => mockTeamStore),
-  useToastStore: vi.fn(() => mockToastStore)
+  useTeamStore: vi.fn(() => mockTeamStore)
 }))
+
+// Stub Nuxt UI's auto-imported `useToast` (adjust import path to match project setup)
+vi.mock('#imports', () => ({ useToast: () => mockToast }))
 
 // Reset mocks between tests
 beforeEach(() => {
@@ -246,8 +245,8 @@ describe('Error Handling', () => {
       'Error message prefix:',
       expect.any(Error)
     )
-    expect(mockToastStore.addErrorToast).toHaveBeenCalledWith(
-      'User-friendly error message'
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'User-friendly error message', color: 'error' })
     )
     
     consoleErrorSpy.mockRestore()
@@ -504,13 +503,10 @@ const waitForAsyncOperation = async () => {
   await flushPromises()
 }
 
-const expectToastMessage = (type: 'success' | 'error', message: string) => {
-  if (type === 'success') {
-    expect(mockToastStore.addSuccessToast).toHaveBeenCalledWith(message)
-  } else {
-    expect(mockToastStore.addErrorToast).toHaveBeenCalledWith(message)
-  }
-}
+const expectToast = (color: 'success' | 'error', title: string) =>
+  expect(mockToast.add).toHaveBeenCalledWith(
+    expect.objectContaining({ title, color })
+  )
 
 // Component mounting with defaults
 const createWrapper = (props = {}, options = {}) => {

--- a/.github/copilot-instructions/testing-patterns.md
+++ b/.github/copilot-instructions/testing-patterns.md
@@ -1,551 +1,96 @@
 # Testing Patterns
 
-## Core Testing Patterns
+> **Read first**: [`testing-overview.md`](./testing-overview.md) for principles and the canonical-reference list.
+>
+> This file lists patterns by name and points to a real, currently-passing test that demonstrates each. Snippets here are deliberately small — the _full_ shape lives in the linked file, which CI keeps correct.
 
-This document contains the essential testing patterns used throughout the CNC Portal project. Each pattern includes examples and explanations of when to use them.
+## Component rendering with `data-test`
 
-## Component Testing Structure
+→ `app/src/components/__tests__/SelectComponent.spec.ts` — full mount + selectors + props/emits.
 
-### Basic Test Structure
+Key shape (mirror this in new specs):
 
-```typescript
-describe('ComponentName', () => {
-  let wrapper: ReturnType<typeof mount>
-
-  // Test data constants
-  const mockOptions = [
-    { value: 'ETH', label: 'Ethereum' },
-    { value: 'USDC', label: 'USD Coin' }
-  ]
-
-  // Test selectors
-  const SELECTORS = {
-    trigger: '[data-test="component-trigger"]',
-    dropdown: '[data-test="component-dropdown"]',
-    submitBtn: '[data-test="submit-btn"]'
-  } as const
-
-  // Setup and cleanup
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  afterEach(() => {
-    if (wrapper) wrapper.unmount()
-  })
-
-  // Helper function for component creation
-  const mountComponent = (props = {}) => {
-    return mount(Component, {
-      props: { ...defaultProps, ...props },
-      global: {
-        components: { ChildComponent },
-        plugins: [createTestingPinia({ createSpy: vi.fn })]
-      }
-    })
-  }
-
-  describe('Component Rendering', () => {
-    it('should render the component with all required elements', () => {
-      wrapper = mountComponent()
-      expect(wrapper.find('[data-test="main-element"]').exists()).toBe(true)
-    })
-  })
-})
-```
-
-### Mock Management with Hoisted Variables
-
-```typescript
-// Hoisted variables for mocks (before vi.mock calls)
-const { mockReadContract, mockWriteContract, mockTeamStore, mockToast } = vi.hoisted(() => ({
-  mockReadContract: vi.fn(),
-  mockWriteContract: vi.fn(),
-  mockTeamStore: {
-    getContractAddressByType: vi.fn((type) => {
-      if (type === 'InvestorV1') return '0x1234567890123456789012345678901234567890'
-      return undefined
-    })
-  },
-  mockToast: { add: vi.fn() }
-}))
-
-// Mock external dependencies
-vi.mock('@wagmi/core', () => ({
-  readContract: mockReadContract,
-  writeContract: mockWriteContract
-}))
-
-vi.mock('@/stores', () => ({
-  useTeamStore: vi.fn(() => mockTeamStore)
-}))
-
-// Stub Nuxt UI's auto-imported `useToast` (adjust import path to match project setup)
-vi.mock('#imports', () => ({ useToast: () => mockToast }))
-
-// Reset mocks between tests
-beforeEach(() => {
-  vi.clearAllMocks()
-})
-```
-
-## Component Testing Patterns
-
-### Initial Rendering Tests
-
-```typescript
-describe('Initial Rendering and Value Handling', () => {
-  it('should emit initial value when no modelValue is provided', async () => {
-    const wrapper = mountComponent({ options: mockOptions })
-    await nextTick()
-
-    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
-    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['ETH'])
-    expect(wrapper.text()).toContain('Ethereum')
-  })
-
-  it('should not emit initial value when modelValue is explicitly provided', async () => {
-    const wrapper = mountComponent({
-      options: mockOptions,
-      modelValue: 'BTC'
-    })
-    await nextTick()
-
-    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
-    expect(wrapper.text()).toContain('Bitcoin')
-  })
-
-  it('should react to external modelValue changes', async () => {
-    const wrapper = mountComponent({
-      options: mockOptions,
-      modelValue: 'ETH'
-    })
-
-    expect(wrapper.text()).toContain('Ethereum')
-
-    await wrapper.setProps({ modelValue: 'BTC' })
-    await nextTick()
-
-    expect(wrapper.text()).toContain('Bitcoin')
-  })
-})
-```
-
-### User Interaction Testing
-
-```typescript
-describe('User Interactions', () => {
-  it('should emit correct events when button is clicked', async () => {
-    wrapper = mountComponent()
-    await wrapper.find(SELECTORS.submitBtn).trigger('click')
-    expect(wrapper.emitted('submit')).toBeTruthy()
-  })
-
-  it('should show dropdown when trigger is clicked', async () => {
-    const wrapper = mountComponent()
-
-    await wrapper.find(SELECTORS.trigger).trigger('click')
-    await nextTick()
-
-    expect(wrapper.find(SELECTORS.dropdown).exists()).toBe(true)
-  })
-
-  it('should close dropdown after option selection', async () => {
-    const wrapper = mountComponent()
-
-    await wrapper.find(SELECTORS.trigger).trigger('click')
-    await wrapper.findAll('[data-test="option"]')[0].trigger('click')
-    await nextTick()
-
-    expect(wrapper.find(SELECTORS.dropdown).exists()).toBe(false)
-  })
-})
-```
-
-### Form Input Testing
-
-```typescript
-describe('Form Input Handling', () => {
-  it('should update model value when input changes', async () => {
-    const wrapper = mountComponent()
-    const input = wrapper.find('[data-test="address-input"]')
-    
-    await input.setValue('0x1234567890123456789012345678901234567890')
-    
-    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
-    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['0x1234567890123456789012345678901234567890'])
-  })
-
-  it('should validate input on blur', async () => {
-    const wrapper = mountComponent()
-    const input = wrapper.find('[data-test="address-input"]')
-    
-    await input.setValue('invalid-address')
-    await input.trigger('blur')
-    await nextTick()
-    
-    expect(wrapper.find('[data-test="error-message"]').exists()).toBe(true)
-    expect(wrapper.find('[data-test="error-message"]').text()).toBe('Invalid address')
-  })
-})
-```
-
-### Async Operation Testing
-
-```typescript
-describe('Async Operations', () => {
-  it('should handle async operations correctly', async () => {
-    mockAsyncFunction.mockResolvedValue(expectedResult)
-    wrapper = mountComponent()
-    
-    await wrapper.find('[data-test="submit-btn"]').trigger('click')
-    await nextTick()
-    await flushPromises()
-    
-    expect(wrapper.emitted('submit')).toBeTruthy()
-    expect(mockAsyncFunction).toHaveBeenCalledWith(expectedArgs)
-  })
-
-  it('should show loading state during async operations', async () => {
-    let resolvePromise: (value: unknown) => void
-    const pendingPromise = new Promise((resolve) => {
-      resolvePromise = resolve
-    })
-    mockAsyncFunction.mockReturnValue(pendingPromise)
-
-    wrapper = mountComponent()
-    const button = wrapper.find('[data-test="submit-btn"]')
-    await button.trigger('click')
-
-    // Check loading state
-    expect(wrapper.findComponent(ButtonUI).props('loading')).toBe(true)
-    
-    resolvePromise!({})
-    await flushPromises()
-    
-    // Check loading state is cleared
-    expect(wrapper.findComponent(ButtonUI).props('loading')).toBe(false)
-  })
-})
-```
-
-### Error Handling Testing
-
-```typescript
-describe('Error Handling', () => {
-  it('should handle contract errors gracefully', async () => {
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    mockWriteContract.mockRejectedValue(new Error('Transaction failed'))
-    
-    wrapper = mountComponent()
-    await wrapper.find('[data-test="submit-btn"]').trigger('click')
-    await flushPromises()
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Error message prefix:',
-      expect.any(Error)
-    )
-    expect(mockToast.add).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'User-friendly error message', color: 'error' })
-    )
-    
-    consoleErrorSpy.mockRestore()
-  })
-
-  it('should handle function errors gracefully with fallbacks', () => {
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    
-    wrapper = mountComponent({
-      formatValue: () => { throw new Error('Format error') }
-    })
-    
-    expect(wrapper.text()).toContain('fallback-value')
-    expect(consoleSpy).toHaveBeenCalledWith(
-      'Error formatting select value:', 
-      expect.any(Error)
-    )
-    
-    consoleSpy.mockRestore()
-  })
-})
-```
-
-## Keyboard Navigation Testing
-
-```typescript
-describe('Keyboard Navigation', () => {
-  it('should open dropdown when Enter key is pressed', async () => {
-    const wrapper = mountComponent()
-
-    await wrapper.find(SELECTORS.trigger).trigger('keydown.enter')
-    await nextTick()
-
-    expect(wrapper.find(SELECTORS.dropdown).exists()).toBe(true)
-  })
-
-  it('should navigate options with arrow keys', async () => {
-    const wrapper = mountComponent()
-
-    await wrapper.find(SELECTORS.trigger).trigger('click')
-    await nextTick()
-
-    // Navigate down to second option
-    await wrapper.find(SELECTORS.trigger).trigger('keydown', { key: 'ArrowDown' })
-    await nextTick()
-
-    const anchors = wrapper.findAll('[data-test="option-anchor"]')
-    expect(anchors[1].classes()).toContain('focus')
-  })
-
-  it('should respect option boundaries during navigation', async () => {
-    const wrapper = mountComponent()
-    await wrapper.find(SELECTORS.trigger).trigger('click')
-    await nextTick()
-
-    const anchors = wrapper.findAll('[data-test="option-anchor"]')
-    const trigger = wrapper.find(SELECTORS.trigger)
-
-    // Try to navigate above first option - should stay at first
-    await trigger.trigger('keydown', { key: 'ArrowUp' })
-    await nextTick()
-    expect(anchors[0].classes()).toContain('focus')
-
-    // Navigate to last option and try to go beyond
-    for (let i = 0; i < anchors.length; i++) {
-      await trigger.trigger('keydown', { key: 'ArrowDown' })
-    }
-    await nextTick()
-
-    expect(anchors[anchors.length - 1].classes()).toContain('focus')
-  })
-})
-```
-
-## Component Communication Testing
-
-```typescript
-describe('Component Communication', () => {
-  it('should pass correct props to child components', () => {
-    wrapper = mountComponent({ options: mockOptions })
-    const selectComponent = wrapper.findComponent(SelectComponent)
-    
-    expect(selectComponent.exists()).toBe(true)
-    expect(selectComponent.props('options')).toEqual(mockOptions)
-  })
-
-  it('should handle child component events', async () => {
-    wrapper = mountComponent()
-    const selectComponent = wrapper.findComponent(SelectComponent)
-    
-    // Simulate child component emitting event
-    await selectComponent.vm.$emit('update:modelValue', 'new-value')
-    await nextTick()
-    
-    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
-  })
-
-  it('should render conditional child components', async () => {
-    wrapper = mountComponent({ showChild: false })
-    expect(wrapper.findComponent(ChildComponent).exists()).toBe(false)
-
-    await wrapper.setProps({ showChild: true })
-    await nextTick()
-    
-    expect(wrapper.findComponent(ChildComponent).exists()).toBe(true)
-  })
-})
-```
-
-## State Management Testing
-
-```typescript
-describe('State Management', () => {
-  it('should react to external prop changes', async () => {
-    wrapper = mountComponent({ modelValue: 'initial' })
-    expect(wrapper.text()).toContain('Initial Value')
-
-    await wrapper.setProps({ modelValue: 'updated' })
-    await nextTick()
-    
-    expect(wrapper.text()).toContain('Updated Value')
-  })
-
-  it('should enable button when form is valid', async () => {
-    wrapper = mountComponent()
-    
-    await wrapper.setProps({
-      formData: { 
-        requiredField: 'valid-value',
-        addressField: '0x1234567890123456789012345678901234567890'
-      }
-    })
-    await nextTick()
-    
-    expect(wrapper.findComponent(ButtonUI).props('disabled')).toBe(false)
-  })
-})
-```
-
-## Loading States Testing
-
-```typescript
-describe('Loading States', () => {
-  it('should show loading spinner when data is fetching', () => {
-    wrapper = mountComponent({ loading: true })
-    expect(wrapper.find('[data-test="loading-spinner"]').exists()).toBe(true)
-  })
-
-  it('should hide content during loading', () => {
-    wrapper = mountComponent({ loading: true })
-    expect(wrapper.find('[data-test="main-content"]').exists()).toBe(false)
-  })
-
-  it('should show content after loading completes', async () => {
-    wrapper = mountComponent({ loading: true })
-    
-    await wrapper.setProps({ loading: false })
-    await nextTick()
-    
-    expect(wrapper.find('[data-test="loading-spinner"]').exists()).toBe(false)
-    expect(wrapper.find('[data-test="main-content"]').exists()).toBe(true)
-  })
-})
-```
-
-## Edge Cases and Boundary Testing
-
-```typescript
-describe('Edge Cases and Boundaries', () => {
-  it('should handle empty options array gracefully', () => {
-    wrapper = mountComponent({ options: [] })
-    expect(wrapper.text()).toBe('')
-  })
-
-  it('should handle invalid addresses', () => {
-    wrapper = mountComponent({ address: 'invalid-address' })
-    expect(wrapper.find('[data-test="error-message"]').exists()).toBe(true)
-  })
-
-  it('should handle undefined/null values safely', () => {
-    wrapper = mountComponent({ value: null })
-    expect(wrapper.text()).toContain('No value selected')
-  })
-
-  it('should maintain component stability during rapid prop changes', async () => {
-    wrapper = mountComponent({ value: 'initial' })
-
-    // Rapidly change props
-    for (let i = 0; i < 10; i++) {
-      await wrapper.setProps({ value: `value-${i}` })
-    }
-    await nextTick()
-
-    expect(wrapper.text()).toContain('value-9')
-  })
-})
-```
-
-## Disabled State Testing
-
-```typescript
-describe('Disabled State Behavior', () => {
-  it('should prevent all interactions when disabled', async () => {
-    wrapper = mountComponent({ disabled: true })
-    
-    // Test click interaction
-    await wrapper.find(SELECTORS.trigger).trigger('click')
-    await nextTick()
-    expect(wrapper.find(SELECTORS.dropdown).exists()).toBe(false)
-    
-    // Test keyboard interactions
-    await wrapper.find(SELECTORS.trigger).trigger('keydown.enter')
-    await nextTick()
-    expect(wrapper.find(SELECTORS.dropdown).exists()).toBe(false)
-  })
-
-  it('should show disabled styling', () => {
-    wrapper = mountComponent({ disabled: true })
-    const trigger = wrapper.find(SELECTORS.trigger)
-    
-    expect(trigger.classes()).toContain('disabled')
-    expect(trigger.attributes('aria-disabled')).toBe('true')
-  })
-})
-```
-
-## Utility Functions for Testing
-
-### Common Test Helpers
-
-```typescript
-// Centralized test selectors and constants
+```ts
 const SELECTORS = {
-  trigger: '[data-test="generic-selector"]',
-  dropdown: '[data-test="options-dropdown"]',
-  options: 'li',
-  optionAnchors: 'a',
-  submitBtn: '[data-test="submit-btn"]',
-  loadingSpinner: '[data-test="loading-spinner"]'
+  trigger: '[data-test="component-trigger"]',
+  submit: '[data-test="submit-btn"]'
 } as const
 
-const MOCK_DATA = {
-  validAddress: '0x1234567890123456789012345678901234567890',
-  invalidAddress: 'invalid-address',
-  options: [
-    { value: 'ETH', label: 'Ethereum' },
-    { value: 'USDC', label: 'USD Coin' }
-  ]
-} as const
-
-// Reusable test helpers
-const waitForAsyncOperation = async () => {
-  await nextTick()
-  await flushPromises()
-}
-
-const expectToast = (color: 'success' | 'error', title: string) =>
-  expect(mockToast.add).toHaveBeenCalledWith(
-    expect.objectContaining({ title, color })
-  )
-
-// Component mounting with defaults
-const createWrapper = (props = {}, options = {}) => {
-  return mount(Component, {
-    props: { ...defaultProps, ...props },
-    global: {
-      components: { RequiredChildComponent },
-      plugins: [createTestingPinia({ createSpy: vi.fn })],
-      ...options.global
-    }
-  })
-}
+const wrapper = mount(Component, { props: { ... } })
+expect(wrapper.find(SELECTORS.submit).exists()).toBe(true)
 ```
 
-### Form Testing Helpers
+## Hoisted mocks for composables and stores
 
-```typescript
-// Form interaction helpers
-const fillForm = async (wrapper: any, formData: Record<string, any>) => {
-  for (const [field, value] of Object.entries(formData)) {
-    const input = wrapper.find(`[data-test="${field}-input"]`)
-    await input.setValue(value)
-  }
-}
+→ `app/src/composables/__tests__/useContractFunction.spec.ts` lines 9–19 — canonical `vi.hoisted` block.
 
-const submitForm = async (wrapper: any) => {
-  await wrapper.find('[data-test="submit-btn"]').trigger('click')
-  await waitForAsyncOperation()
-}
+Rule: anything referenced inside a `vi.mock` factory must be declared with `vi.hoisted`, otherwise it's a `ReferenceError` at module-load time.
 
-// Validation helpers
-const expectFormError = (wrapper: any, field: string, message: string) => {
-  const errorElement = wrapper.find(`[data-test="error-${field}"]`)
-  expect(errorElement.exists()).toBe(true)
-  expect(errorElement.text()).toBe(message)
-}
-
-const expectFormValid = (wrapper: any) => {
-  expect(wrapper.find('[data-test="submit-btn"]').props('disabled')).toBe(false)
-  expect(wrapper.findAll('[data-test^="error-"]')).toHaveLength(0)
-}
+```ts
+const { mockTeamStore } = vi.hoisted(() => ({
+  mockTeamStore: {
+    getContractAddressByType: vi.fn(() => "0x1234…"),
+  },
+}));
+vi.mock("@/stores", () => ({ useTeamStore: () => mockTeamStore }));
 ```
+
+## Mutation composables (`useXxxMutation` + TanStack Query)
+
+→ `app/src/queries/__tests__/weeklyClaim.queries.spec.ts` (lines ~170–220) — file upload + invalidation + error.
+
+Test the composable, not the component that uses it. Assert: `mutate(payload)` triggers the underlying call, `error` is reactive on failure, the right query keys are invalidated on success.
+
+## Toast assertions
+
+Mock `useToast()` once and assert on `mockToast.add`:
+
+```ts
+expect(mockToast.add).toHaveBeenCalledWith(
+  expect.objectContaining({ color: "error", title: "Network error" }),
+);
+```
+
+See [`testing-overview.md`](./testing-overview.md#mocking-conventions) for the full mock setup.
+
+## Pure utilities
+
+→ `app/src/utils/__tests__/currencyUtil.spec.ts` — short, no mocks, boundary cases (negative, zero, large numbers).
+
+If your utility test needs mocks, the function is impure — push the side-effects out into a composable and re-test the pure part directly.
+
+## Async / reactive assertions
+
+```ts
+await wrapper.find(SELECTORS.submit).trigger("click");
+await flushPromises(); // pending promises (network, mutations)
+await nextTick(); // pending Vue reactivity
+```
+
+`flushPromises` from `@vue/test-utils` is the right tool 95% of the time. Avoid arbitrary `setTimeout`-based waits.
+
+## Error-path assertions
+
+When testing error handling:
+
+```ts
+const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+// trigger error path…
+expect(mockToast.add).toHaveBeenCalledWith(
+  expect.objectContaining({ color: "error", title: "User-friendly message" }),
+);
+consoleSpy.mockRestore();
+```
+
+## Helpers worth extracting
+
+If you find yourself repeating mount setup across specs, factor a `mountComponent(props, options)` helper at the top of the file. Don't extract to a shared `test-utils/` module unless 3+ specs need the exact same helper — premature shared helpers hide intent.
+
+## Anti-patterns
+
+See [`testing-anti-patterns.md`](./testing-anti-patterns.md). The most common ones:
+
+- Asserting on `wrapper.vm.internalState`
+- CSS-class or nth-child selectors
+- Tests that pass when the component is removed entirely (no real assertion)
+- Mocking the system under test

--- a/.github/copilot-instructions/testing-web3.md
+++ b/.github/copilot-instructions/testing-web3.md
@@ -121,8 +121,8 @@ describe('Contract State Reading', () => {
       'Error checking token support:',
       expect.any(Error)
     )
-    expect(mockToastStore.addErrorToast).toHaveBeenCalledWith(
-      'Failed to check token support status'
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'error', title: 'Failed to check token support status' })
     )
     
     consoleErrorSpy.mockRestore()
@@ -162,8 +162,8 @@ describe('Contract Write Operations', () => {
       }
     )
 
-    expect(mockToastStore.addSuccessToast).toHaveBeenCalledWith(
-      'Token support added successfully'
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'success', title: 'Token support added successfully' })
     )
   })
 
@@ -192,8 +192,8 @@ describe('Contract Write Operations', () => {
       }
     )
 
-    expect(mockToastStore.addSuccessToast).toHaveBeenCalledWith(
-      'Token support removed successfully'
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'success', title: 'Token support removed successfully' })
     )
   })
 })
@@ -251,8 +251,8 @@ describe('Transaction State Management', () => {
       expect.any(Object),
       { hash: '0xabcdef1234567890' }
     )
-    expect(mockToastStore.addSuccessToast).toHaveBeenCalledWith(
-      'Transaction confirmed successfully'
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'success', title: 'Transaction confirmed successfully' })
     )
   })
 })
@@ -318,8 +318,8 @@ describe('Contract Error Handling', () => {
       'Error Updating token support:',
       expect.any(Error)
     )
-    expect(mockToastStore.addErrorToast).toHaveBeenCalledWith(
-      'Failed to add token support: Transaction reverted: insufficient funds'
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'error', title: 'Failed to add token support: Transaction reverted: insufficient funds' })
     )
     
     consoleErrorSpy.mockRestore()
@@ -335,8 +335,8 @@ describe('Contract Error Handling', () => {
     await wrapper.vm.checkTokenSupport('0x1234567890123456789012345678901234567890')
     await flushPromises()
 
-    expect(mockToastStore.addErrorToast).toHaveBeenCalledWith(
-      'Failed to check token support status'
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'error', title: 'Failed to check token support status' })
     )
     
     consoleErrorSpy.mockRestore()
@@ -350,8 +350,8 @@ describe('Contract Error Handling', () => {
     await wrapper.vm.performTransaction()
     await flushPromises()
 
-    expect(mockToastStore.addErrorToast).toHaveBeenCalledWith(
-      'Transaction was cancelled by user'
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'error', title: 'Transaction was cancelled by user' })
     )
   })
 })
@@ -392,8 +392,8 @@ describe('Gas and Fee Handling', () => {
     await wrapper.vm.performTransaction()
     await flushPromises()
 
-    expect(mockToastStore.addErrorToast).toHaveBeenCalledWith(
-      'Insufficient funds for transaction'
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'error', title: 'Insufficient funds for transaction' })
     )
   })
 })
@@ -433,8 +433,8 @@ describe('Multi-step Transactions', () => {
       })
     )
 
-    expect(mockToastStore.addSuccessToast).toHaveBeenCalledWith(
-      'Approve and transfer completed successfully'
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'success', title: 'Approve and transfer completed successfully' })
     )
   })
 
@@ -447,8 +447,8 @@ describe('Multi-step Transactions', () => {
 
     // Should only attempt approve, not transfer
     expect(mockWriteContract).toHaveBeenCalledTimes(1)
-    expect(mockToastStore.addErrorToast).toHaveBeenCalledWith(
-      'Failed to approve token: Approve failed'
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'error', title: 'Failed to approve token: Approve failed' })
     )
   })
 })
@@ -496,8 +496,8 @@ describe('Contract Events', () => {
     wrapper.vm.handleTokenSupportEvent([eventData])
     await nextTick()
 
-    expect(mockToastStore.addSuccessToast).toHaveBeenCalledWith(
-      'Token support updated via blockchain event'
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'success', title: 'Token support updated via blockchain event' })
     )
   })
 })

--- a/.github/copilot-instructions/testing-web3.md
+++ b/.github/copilot-instructions/testing-web3.md
@@ -1,641 +1,144 @@
-# Web3 Testing Patterns
+# Web3 / Contract Testing Patterns
 
-## Web3/Contract Testing Overview
+> **Read first**: [`testing-overview.md`](./testing-overview.md) and [`testing-patterns.md`](./testing-patterns.md).
+>
+> **Canonical references**:
+>
+> - `app/src/__tests__/wagmi.spec.ts` — wagmi config + transport
+> - `app/src/composables/__tests__/useContractFunction.spec.ts` — canonical `vi.hoisted` mock block for wagmi
+>
+> Snippets below are minimal patterns. For full, current shapes, read the linked specs.
 
-Testing Web3 interactions requires special consideration for blockchain-specific patterns, error handling, and asynchronous operations. This document outlines patterns specific to testing smart contract interactions in the CNC Portal.
+## Mock `@wagmi/core` directly
 
-## Mock Setup for Web3 Testing
+```ts
+const { mockReadContract, mockWriteContract, mockWaitForTransactionReceipt } =
+  vi.hoisted(() => ({
+    mockReadContract: vi.fn(),
+    mockWriteContract: vi.fn(),
+    mockWaitForTransactionReceipt: vi.fn(),
+  }));
 
-### Wagmi Mocking Pattern
-
-```typescript
-// Hoisted mock variables for Web3 functions
-const { 
-  mockReadContract, 
-  mockWriteContract, 
-  mockWaitForTransactionReceipt,
-  mockUseAccount,
-  mockUseBalance
-} = vi.hoisted(() => ({
-  mockReadContract: vi.fn(),
-  mockWriteContract: vi.fn(),
-  mockWaitForTransactionReceipt: vi.fn(),
-  mockUseAccount: vi.fn(() => ({
-    address: '0x1234567890123456789012345678901234567890',
-    isConnected: true
-  })),
-  mockUseBalance: vi.fn(() => ({
-    data: { formatted: '1.0', symbol: 'ETH' },
-    isLoading: false
-  }))
-}))
-
-// Mock wagmi core functions
-vi.mock('@wagmi/core', () => ({
+vi.mock("@wagmi/core", () => ({
   readContract: mockReadContract,
   writeContract: mockWriteContract,
-  waitForTransactionReceipt: mockWaitForTransactionReceipt
-}))
-
-// Mock wagmi Vue composables
-vi.mock('@wagmi/vue', () => ({
-  useAccount: mockUseAccount,
-  useBalance: mockUseBalance,
-  useReadContract: vi.fn(),
-  useWriteContract: vi.fn()
-}))
-
-// Mock viem utilities
-vi.mock('viem', async (importOriginal) => {
-  const actual: object = await importOriginal()
-  return {
-    ...actual,
-    isAddress: vi.fn((address: string) => {
-      return /^0x[a-fA-F0-9]{40}$/.test(address)
-    }),
-    parseEther: vi.fn((value: string) => BigInt(value) * BigInt(10 ** 18)),
-    formatEther: vi.fn((value: bigint) => (Number(value) / 10 ** 18).toString())
-  }
-})
+  waitForTransactionReceipt: mockWaitForTransactionReceipt,
+}));
 ```
 
-### Contract ABI Mocking
+Don't mock viem — mock the wagmi layer the app actually calls. If you find yourself reaching for `viem` mocks, the production code is probably bypassing wagmi's abstraction.
 
-```typescript
-// Mock contract ABI imports
-vi.mock('@/artifacts/abi/CashRemunerationEIP712.json', () => ({
-  default: [
-    {
-      type: 'function',
-      name: 'addTokenSupport',
-      inputs: [{ name: 'token', type: 'address' }]
-    },
-    {
-      type: 'function',
-      name: 'removeTokenSupport',
-      inputs: [{ name: 'token', type: 'address' }]
-    },
-    {
-      type: 'function',
-      name: 'supportedTokens',
-      inputs: [{ name: 'token', type: 'address' }],
-      outputs: [{ name: '', type: 'bool' }]
-    }
-  ]
-}))
+## Address constants
+
+Use deterministic placeholder addresses; don't generate them:
+
+```ts
+const MOCK_ADDR = "0x1234567890123456789012345678901234567890";
 ```
 
-## Contract Interaction Testing
+Helper for assertion when you don't care about the exact value:
 
-### Reading Contract State
-
-```typescript
-describe('Contract State Reading', () => {
-  it('should check token support correctly', async () => {
-    mockReadContract.mockResolvedValue(true)
-    wrapper = mountComponent()
-    
-    await wrapper.vm.checkTokenSupport('0x1234567890123456789012345678901234567890')
-    await flushPromises()
-
-    expect(mockReadContract).toHaveBeenCalledWith(
-      expect.any(Object), // config
-      {
-        address: expect.stringMatching(/^0x[a-fA-F0-9]{40}$/),
-        abi: expect.any(Array),
-        functionName: 'supportedTokens',
-        args: ['0x1234567890123456789012345678901234567890']
-      }
-    )
-  })
-
-  it('should handle contract read errors gracefully', async () => {
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    mockReadContract.mockRejectedValue(new Error('Contract not found'))
-    
-    wrapper = mountComponent()
-    await wrapper.vm.checkTokenSupport('0x1234567890123456789012345678901234567890')
-    await flushPromises()
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Error checking token support:',
-      expect.any(Error)
-    )
-    expect(mockToast.add).toHaveBeenCalledWith(
-      expect.objectContaining({ color: 'error', title: 'Failed to check token support status' })
-    )
-    
-    consoleErrorSpy.mockRestore()
-  })
-})
+```ts
+expect.stringMatching(/^0x[a-fA-F0-9]{40}$/);
 ```
 
-### Writing to Contracts
-
-```typescript
-describe('Contract Write Operations', () => {
-  it('should add token support successfully', async () => {
-    mockReadContract.mockResolvedValue(false) // Token not supported
-    mockWriteContract.mockResolvedValue({
-      hash: '0xabcdef...',
-      blockNumber: 12345n
-    })
-    
-    wrapper = mountComponent()
-    const selectComponent = wrapper.findComponent(SelectComponent)
-
-    await selectComponent.setValue('0x1234567890123456789012345678901234567890')
-    await nextTick()
-    await flushPromises()
-
-    const button = wrapper.find('[data-test="add-token-button"]')
-    await button.trigger('click')
-    await flushPromises()
-
-    expect(mockWriteContract).toHaveBeenCalledWith(
-      expect.any(Object), // config
-      {
-        address: expect.stringMatching(/^0x[a-fA-F0-9]{40}$/),
-        abi: expect.any(Array),
-        functionName: 'addTokenSupport',
-        args: ['0x1234567890123456789012345678901234567890']
-      }
-    )
-
-    expect(mockToast.add).toHaveBeenCalledWith(
-      expect.objectContaining({ color: 'success', title: 'Token support added successfully' })
-    )
-  })
-
-  it('should remove token support successfully', async () => {
-    mockReadContract.mockResolvedValue(true) // Token is supported
-    mockWriteContract.mockResolvedValue({})
-    
-    wrapper = mountComponent()
-    const selectComponent = wrapper.findComponent(SelectComponent)
-
-    await selectComponent.setValue('0x1234567890123456789012345678901234567890')
-    await nextTick()
-    await flushPromises()
-
-    const button = wrapper.find('[data-test="add-token-button"]')
-    await button.trigger('click')
-    await flushPromises()
-
-    expect(mockWriteContract).toHaveBeenCalledWith(
-      expect.any(Object),
-      {
-        address: expect.stringMatching(/^0x[a-fA-F0-9]{40}$/),
-        abi: expect.any(Array),
-        functionName: 'removeTokenSupport',
-        args: ['0x1234567890123456789012345678901234567890']
-      }
-    )
-
-    expect(mockToast.add).toHaveBeenCalledWith(
-      expect.objectContaining({ color: 'success', title: 'Token support removed successfully' })
-    )
-  })
-})
-```
-
-### Transaction State Management
-
-```typescript
-describe('Transaction State Management', () => {
-  it('should show loading state during transaction', async () => {
-    let resolveWriteContract: (value: unknown) => void
-    const writeContractPromise = new Promise((resolve) => {
-      resolveWriteContract = resolve
-    })
-    
-    mockReadContract.mockResolvedValue(false)
-    mockWriteContract.mockReturnValue(writeContractPromise)
-
-    wrapper = mountComponent()
-    const selectComponent = wrapper.findComponent(SelectComponent)
-
-    await selectComponent.setValue('0x1234567890123456789012345678901234567890')
-    await nextTick()
-    await flushPromises()
-
-    const button = wrapper.find('[data-test="add-token-button"]')
-    await button.trigger('click')
-
-    // Check loading state
-    const buttonComponent = wrapper.findComponent(ButtonUI)
-    expect(buttonComponent.props('loading')).toBe(true)
-    expect(buttonComponent.props('disabled')).toBe(true)
-
-    resolveWriteContract!({})
-    await flushPromises()
-
-    // Check loading state is cleared
-    expect(buttonComponent.props('loading')).toBe(false)
-  })
-
-  it('should handle transaction confirmation', async () => {
-    mockWriteContract.mockResolvedValue({
-      hash: '0xabcdef1234567890'
-    })
-    mockWaitForTransactionReceipt.mockResolvedValue({
-      status: 'success',
-      blockNumber: 12345n
-    })
-
-    wrapper = mountComponent()
-    await wrapper.vm.performTransaction()
-    await flushPromises()
-
-    expect(mockWaitForTransactionReceipt).toHaveBeenCalledWith(
-      expect.any(Object),
-      { hash: '0xabcdef1234567890' }
-    )
-    expect(mockToast.add).toHaveBeenCalledWith(
-      expect.objectContaining({ color: 'success', title: 'Transaction confirmed successfully' })
-    )
-  })
-})
-```
-
-## Address Validation Testing
-
-```typescript
-describe('Address Validation', () => {
-  it('should validate Ethereum addresses correctly', () => {
-    const validAddresses = [
-      '0x1234567890123456789012345678901234567890',
-      '0xabcdefABCDEF1234567890123456789012345678'
-    ]
-
-    const invalidAddresses = [
-      'invalid-address',
-      '0x123', // Too short
-      '1234567890123456789012345678901234567890', // Missing 0x prefix
-      '0xGHIJKL1234567890123456789012345678901234' // Invalid hex characters
-    ]
-
-    validAddresses.forEach(address => {
-      expect(isAddress(address)).toBe(true)
-    })
-
-    invalidAddresses.forEach(address => {
-      expect(isAddress(address)).toBe(false)
-    })
-  })
-
-  it('should not check token support for invalid addresses', async () => {
-    wrapper = mountComponent()
-    const selectComponent = wrapper.findComponent(SelectComponent)
-
-    await selectComponent.setValue('invalid-address')
-    await nextTick()
-    await flushPromises()
-
-    expect(mockReadContract).not.toHaveBeenCalled()
-    expect(wrapper.findComponent(ButtonUI).props('disabled')).toBe(true)
-  })
-})
-```
-
-## Error Handling Patterns
-
-### Contract Error Types
-
-```typescript
-describe('Contract Error Handling', () => {
-  it('should handle contract revert errors', async () => {
-    const revertError = new Error('Transaction reverted: insufficient funds')
-    mockWriteContract.mockRejectedValue(revertError)
-    
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    wrapper = mountComponent()
-    
-    await wrapper.vm.performTransaction()
-    await flushPromises()
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Error Updating token support:',
-      expect.any(Error)
-    )
-    expect(mockToast.add).toHaveBeenCalledWith(
-      expect.objectContaining({ color: 'error', title: 'Failed to add token support: Transaction reverted: insufficient funds' })
-    )
-    
-    consoleErrorSpy.mockRestore()
-  })
-
-  it('should handle network errors', async () => {
-    const networkError = new Error('Network request failed')
-    mockReadContract.mockRejectedValue(networkError)
-    
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    wrapper = mountComponent()
-    
-    await wrapper.vm.checkTokenSupport('0x1234567890123456789012345678901234567890')
-    await flushPromises()
-
-    expect(mockToast.add).toHaveBeenCalledWith(
-      expect.objectContaining({ color: 'error', title: 'Failed to check token support status' })
-    )
-    
-    consoleErrorSpy.mockRestore()
-  })
-
-  it('should handle user rejection errors', async () => {
-    const userRejectionError = new Error('User rejected the request')
-    mockWriteContract.mockRejectedValue(userRejectionError)
-    
-    wrapper = mountComponent()
-    await wrapper.vm.performTransaction()
-    await flushPromises()
-
-    expect(mockToast.add).toHaveBeenCalledWith(
-      expect.objectContaining({ color: 'error', title: 'Transaction was cancelled by user' })
-    )
-  })
-})
-```
-
-## Gas and Fee Testing
-
-```typescript
-describe('Gas and Fee Handling', () => {
-  it('should estimate gas for transaction', async () => {
-    const mockEstimateGas = vi.fn().mockResolvedValue(21000n)
-    
-    vi.mock('@wagmi/core', async (importOriginal) => {
-      const actual: object = await importOriginal()
-      return {
-        ...actual,
-        estimateGas: mockEstimateGas
-      }
-    })
-
-    wrapper = mountComponent()
-    await wrapper.vm.estimateTransactionGas()
-
-    expect(mockEstimateGas).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.objectContaining({
-        address: expect.stringMatching(/^0x[a-fA-F0-9]{40}$/),
-        functionName: expect.any(String)
-      })
-    )
-  })
-
-  it('should handle insufficient funds error', async () => {
-    const insufficientFundsError = new Error('Insufficient funds for gas')
-    mockWriteContract.mockRejectedValue(insufficientFundsError)
-    
-    wrapper = mountComponent()
-    await wrapper.vm.performTransaction()
-    await flushPromises()
-
-    expect(mockToast.add).toHaveBeenCalledWith(
-      expect.objectContaining({ color: 'error', title: 'Insufficient funds for transaction' })
-    )
-  })
-})
-```
-
-## Multi-step Transaction Testing
-
-```typescript
-describe('Multi-step Transactions', () => {
-  it('should handle approve and transfer sequence', async () => {
-    // First approve
-    mockWriteContract
-      .mockResolvedValueOnce({ hash: '0xapprove123' })
-      .mockResolvedValueOnce({ hash: '0xtransfer456' })
-    
-    mockWaitForTransactionReceipt
-      .mockResolvedValueOnce({ status: 'success' })
-      .mockResolvedValueOnce({ status: 'success' })
-
-    wrapper = mountComponent()
-    await wrapper.vm.performApproveAndTransfer()
-    await flushPromises()
-
-    // Verify approve call
-    expect(mockWriteContract).toHaveBeenNthCalledWith(1,
-      expect.any(Object),
-      expect.objectContaining({
-        functionName: 'approve'
-      })
-    )
-
-    // Verify transfer call
-    expect(mockWriteContract).toHaveBeenNthCalledWith(2,
-      expect.any(Object),
-      expect.objectContaining({
-        functionName: 'transfer'
-      })
-    )
-
-    expect(mockToast.add).toHaveBeenCalledWith(
-      expect.objectContaining({ color: 'success', title: 'Approve and transfer completed successfully' })
-    )
-  })
-
-  it('should handle failure in first step of multi-step transaction', async () => {
-    mockWriteContract.mockRejectedValueOnce(new Error('Approve failed'))
-    
-    wrapper = mountComponent()
-    await wrapper.vm.performApproveAndTransfer()
-    await flushPromises()
-
-    // Should only attempt approve, not transfer
-    expect(mockWriteContract).toHaveBeenCalledTimes(1)
-    expect(mockToast.add).toHaveBeenCalledWith(
-      expect.objectContaining({ color: 'error', title: 'Failed to approve token: Approve failed' })
-    )
-  })
-})
-```
-
-## Contract Event Testing
-
-```typescript
-describe('Contract Events', () => {
-  it('should listen for contract events', async () => {
-    const mockWatchContractEvent = vi.fn()
-    
-    vi.mock('@wagmi/core', async (importOriginal) => {
-      const actual: object = await importOriginal()
-      return {
-        ...actual,
-        watchContractEvent: mockWatchContractEvent
-      }
-    })
-
-    wrapper = mountComponent()
-    await wrapper.vm.startEventListening()
-
-    expect(mockWatchContractEvent).toHaveBeenCalledWith(
-      expect.any(Object),
-      {
-        address: expect.stringMatching(/^0x[a-fA-F0-9]{40}$/),
-        abi: expect.any(Array),
-        eventName: 'TokenSupportAdded',
-        onLogs: expect.any(Function)
-      }
-    )
-  })
-
-  it('should handle contract events correctly', async () => {
-    const eventData = {
-      args: {
-        token: '0x1234567890123456789012345678901234567890',
-        added: true
-      },
-      blockNumber: 12345n
-    }
-
-    wrapper = mountComponent()
-    wrapper.vm.handleTokenSupportEvent([eventData])
-    await nextTick()
-
-    expect(mockToast.add).toHaveBeenCalledWith(
-      expect.objectContaining({ color: 'success', title: 'Token support updated via blockchain event' })
-    )
-  })
-})
-```
-
-## Balance and Token Testing
-
-```typescript
-describe('Balance and Token Operations', () => {
-  it('should fetch user balance correctly', async () => {
-    mockUseBalance.mockReturnValue({
-      data: { 
-        formatted: '10.5',
-        symbol: 'ETH',
-        value: BigInt('10500000000000000000')
-      },
-      isLoading: false,
-      error: null
-    })
-
-    wrapper = mountComponent()
-    await nextTick()
-
-    expect(wrapper.find('[data-test="balance-display"]').text()).toContain('10.5 ETH')
-  })
-
-  it('should handle balance loading state', () => {
-    mockUseBalance.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      error: null
-    })
-
-    wrapper = mountComponent()
-    
-    expect(wrapper.find('[data-test="balance-loading"]').exists()).toBe(true)
-    expect(wrapper.find('[data-test="balance-display"]').exists()).toBe(false)
-  })
-
-  it('should handle balance fetch errors', () => {
-    mockUseBalance.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('Failed to fetch balance')
-    })
-
-    wrapper = mountComponent()
-    
-    expect(wrapper.find('[data-test="balance-error"]').exists()).toBe(true)
-    expect(wrapper.find('[data-test="balance-error"]').text()).toContain('Failed to load balance')
-  })
-})
-```
-
-## Wallet Connection Testing
-
-```typescript
-describe('Wallet Connection', () => {
-  it('should handle connected wallet state', () => {
-    mockUseAccount.mockReturnValue({
-      address: '0x1234567890123456789012345678901234567890',
-      isConnected: true,
-      isConnecting: false
-    })
-
-    wrapper = mountComponent()
-    
-    expect(wrapper.find('[data-test="wallet-address"]').text())
-      .toContain('0x1234...7890')
-    expect(wrapper.find('[data-test="connect-wallet-btn"]').exists()).toBe(false)
-  })
-
-  it('should handle disconnected wallet state', () => {
-    mockUseAccount.mockReturnValue({
-      address: undefined,
-      isConnected: false,
-      isConnecting: false
-    })
-
-    wrapper = mountComponent()
-    
-    expect(wrapper.find('[data-test="connect-wallet-btn"]').exists()).toBe(true)
-    expect(wrapper.find('[data-test="wallet-address"]').exists()).toBe(false)
-  })
-
-  it('should handle wallet connecting state', () => {
-    mockUseAccount.mockReturnValue({
-      address: undefined,
-      isConnected: false,
-      isConnecting: true
-    })
-
-    wrapper = mountComponent()
-    
-    expect(wrapper.find('[data-test="connecting-indicator"]').exists()).toBe(true)
-    expect(wrapper.find('[data-test="connect-wallet-btn"]').props('loading')).toBe(true)
-  })
-})
-```
-
-## Test Utilities for Web3
-
-```typescript
-// Web3-specific test utilities
-export const WEB3_TEST_UTILS = {
-  // Generate valid test addresses
-  generateAddress: (seed = '1234') => `0x${seed.padEnd(40, '0')}`,
-  
-  // Mock transaction hash
-  generateTxHash: () => `0x${'a'.repeat(64)}`,
-  
-  // Mock block number
-  generateBlockNumber: () => BigInt(Math.floor(Math.random() * 1000000)),
-  
-  // Create mock contract call
-  createMockContractCall: (functionName: string, args: any[] = []) => ({
-    address: expect.stringMatching(/^0x[a-fA-F0-9]{40}$/),
-    abi: expect.any(Array),
-    functionName,
-    args
+## Read-then-write flows
+
+```ts
+mockReadContract.mockResolvedValue(false); // not yet supported
+mockWriteContract.mockResolvedValue("0xtxhash"); // tx submitted
+
+await wrapper.find('[data-test="add-token-button"]').trigger("click");
+await flushPromises();
+
+expect(mockWriteContract).toHaveBeenCalledWith(
+  expect.any(Object),
+  expect.objectContaining({
+    functionName: "addTokenSupport",
+    args: [MOCK_ADDR],
   }),
-  
-  // Expect valid transaction response
-  expectValidTransaction: (txResponse: any) => {
-    expect(txResponse).toMatchObject({
-      hash: expect.stringMatching(/^0x[a-fA-F0-9]{64}$/),
-      blockNumber: expect.any(BigInt)
-    })
-  }
-}
-
-// Common Web3 test constants
-export const WEB3_TEST_CONSTANTS = {
-  VALID_ADDRESS: '0x1234567890123456789012345678901234567890',
-  INVALID_ADDRESS: 'invalid-address',
-  ZERO_ADDRESS: '0x0000000000000000000000000000000000000000',
-  TEST_TOKEN_ADDRESS: '0xA0b86a33E6441bB7bE6d0B9EB5Bbf26b2d60C1cd',
-  MOCK_TX_HASH: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
-  MOCK_BLOCK_NUMBER: 12345n
-} as const
+);
+expect(mockToast.add).toHaveBeenCalledWith(
+  expect.objectContaining({
+    color: "success",
+    title: "Token support added successfully",
+  }),
+);
 ```
+
+## Transaction receipt waits
+
+```ts
+mockWriteContract.mockResolvedValue("0xabcdef…");
+mockWaitForTransactionReceipt.mockResolvedValue({ status: "success" });
+
+// trigger…
+await flushPromises();
+
+expect(mockWaitForTransactionReceipt).toHaveBeenCalledWith(expect.any(Object), {
+  hash: "0xabcdef…",
+});
+expect(mockToast.add).toHaveBeenCalledWith(
+  expect.objectContaining({
+    color: "success",
+    title: "Transaction confirmed successfully",
+  }),
+);
+```
+
+## Failure paths
+
+Cover at minimum:
+
+- **User-rejected** (wallet popup dismissed) — wagmi throws `UserRejectedRequestError`. Map to a non-error toast (info / silent), never a red error toast.
+- **Insufficient funds** — surface a useful message ("Insufficient funds for transaction"), not the raw RPC string.
+- **Revert with reason** — extract the reason; assert the user-friendly mapping.
+
+```ts
+mockWriteContract.mockRejectedValueOnce(new Error("Insufficient funds"));
+// trigger…
+expect(mockToast.add).toHaveBeenCalledWith(
+  expect.objectContaining({
+    color: "error",
+    title: "Insufficient funds for transaction",
+  }),
+);
+```
+
+## Multi-step transactions (approve + transfer)
+
+When the second call depends on the first:
+
+```ts
+mockWriteContract.mockRejectedValueOnce(new Error("Approve failed"));
+
+await wrapper.vm.performApproveAndTransfer();
+await flushPromises();
+
+// Approve was attempted, transfer was not
+expect(mockWriteContract).toHaveBeenCalledTimes(1);
+expect(mockToast.add).toHaveBeenCalledWith(
+  expect.objectContaining({
+    color: "error",
+    title: "Failed to approve token: Approve failed",
+  }),
+);
+```
+
+## Contract events
+
+Don't subscribe to live logs in unit tests. Inject the event payload directly into the handler:
+
+```ts
+wrapper.vm.handleTokenSupportEvent([{ args: { … } }])
+await nextTick()
+expect(mockToast.add).toHaveBeenCalledWith(
+  expect.objectContaining({ color: 'success', title: 'Token support updated via blockchain event' })
+)
+```
+
+## What NOT to do
+
+- Don't run a real local node in unit tests (that's E2E territory — Hardhat in `contract/`, or Synpress in `app/test/e2e/`).
+- Don't assert on tx hashes byte-for-byte; use `expect.stringMatching(/^0x[a-fA-F0-9]+$/)`.
+- Don't mock `useToast` per-test — once at the top of the file is enough.

--- a/.github/copilot-instructions/vue-component-standards.md
+++ b/.github/copilot-instructions/vue-component-standards.md
@@ -132,25 +132,43 @@ const doubledCount = computed(() => count.value * 2)
 
 ## Error Handling in Components
 
-### Toast Notifications
+### Notifications
+
+Two complementary surfaces — pick the right one:
+
+- **`useToast()` (Nuxt UI)** for transient, global notifications (success after an action, network/wallet failures the user must notice). Auto-imported. Reference call sites: `app/src/composables/useSiwe.ts`, `app/src/App.vue`.
+- **`<UAlert />`** for inline, reactive errors scoped to a form or section. Reference: `app/src/components/sections/ContractManagementView/forms/TransferOwnershipForm.vue`.
+
+Prefer `<UAlert />` over `try/catch + toast` when the error is tied to a specific form field or mutation — it composes naturally with the TanStack Query mutation pattern (see `AGENTS.md`).
 
 ```typescript
-import { useToastStore } from '@/stores'
-
-const { addSuccessToast, addErrorToast } = useToastStore()
+// Global notification
+const toast = useToast()
 
 const handleSubmit = async () => {
-  try {
-    loading.value = true
-    await submitForm()
-    addSuccessToast('Form submitted successfully')
-  } catch (error) {
-    console.error('Form submission failed:', error)
-    addErrorToast('Failed to submit form. Please try again.')
-  } finally {
-    loading.value = false
-  }
+  loading.value = true
+  await submitForm()
+  toast.add({ title: 'Form submitted successfully', color: 'success' })
+  loading.value = false
 }
+```
+
+```vue
+<!-- Inline reactive error -->
+<UAlert v-if="errorMessage" color="error" :description="errorMessage" />
+```
+
+For mutations, surface `mutation.error` reactively via `<UAlert />` rather than wrapping `mutateAsync` in `try/catch`:
+
+```vue
+<script setup lang="ts">
+const { mutate, error, isPending } = useSubmitFormMutation()
+</script>
+
+<template>
+  <UAlert v-if="error" color="error" :description="error.message" />
+  <UButton :loading="isPending" @click="mutate(payload)">Submit</UButton>
+</template>
 ```
 
 ## Accessibility Standards

--- a/.github/copilot-instructions/vue-component-standards.md
+++ b/.github/copilot-instructions/vue-component-standards.md
@@ -1,168 +1,88 @@
-# Vue.js Component Standards
+# Vue Component Standards
 
-## Composition API Standards
+> **Canonical reference**: `app/src/components/__tests__/SelectComponent.spec.ts` shows the props/emits/data-test contract from the test side.
+>
+> See [`AGENTS.md`](../../AGENTS.md) §"Frontend authoring" for the leanness rule (extract logic into utils + composables, search before creating).
 
-Always use Composition API with `<script setup lang="ts">` syntax for all new components.
+## Composition API only
 
-### Component Structure
+`<script setup lang="ts">` for every new component. No Options API, no JS-only files.
 
-## Props and Events
+## Props
 
-### Props Definition
+Define with TypeScript interface; use `withDefaults` for optionals:
 
-Always define props with TypeScript interfaces and provide defaults where appropriate:
-
-```typescript
+```ts
 interface Props {
-  // Required props (no default value)
-  options: Array<{ value: string; label: string }>
-  
-  // Optional props (with defaults)
-  modelValue?: string
-  disabled?: boolean
-  placeholder?: string
-  
-  // Complex types
-  validator?: (value: string) => boolean
-  formatValue?: (value: string) => string
+  options: Array<{ value: string; label: string }>;
+  modelValue?: string;
+  disabled?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  modelValue: '',
+  modelValue: "",
   disabled: false,
-  placeholder: 'Select an option'
-})
+});
 ```
 
-### Event Emissions
+Avoid `Object as PropType<…>` runtime declarations — strict TS interfaces are clearer and catch more.
 
-Use `defineEmits` with proper TypeScript typing:
+## Emits
 
-```typescript
+Type emits, don't rely on string-only signatures:
+
+```ts
 const emit = defineEmits<{
-  'update:modelValue': [value: string]
-  submit: [data: FormData]
-  close: []
-  error: [error: Error]
-}>()
-
-// Usage
-emit('update:modelValue', newValue)
-emit('submit', formData)
-emit('close')
-emit('error', new Error('Something went wrong'))
+  "update:modelValue": [value: string];
+  submit: [data: FormData];
+  close: [];
+}>();
 ```
 
-## Data-Test Attributes
+## `data-test` is mandatory on interactive elements
 
-All interactive elements must have `data-test` attributes for testing:
+Buttons, inputs, error messages, dropdowns — anything a test needs to find. CSS classes change; `data-test` is a contract.
 
-```html
-<template>
-  <div class="component">
-    <button 
-      data-test="submit-button"
-      :disabled="!isValid"
-      @click="handleSubmit"
-    >
-      Submit
-    </button>
-    
-    <input 
-      data-test="email-input"
-      v-model="email"
-      type="email"
-    />
-    
-    <div 
-      data-test="error-message"
-      v-if="hasError"
-    >
-      {{ errorMessage }}
-    </div>
-  </div>
-</template>
+```vue
+<button data-test="submit-button" :disabled="!isValid" @click="handleSubmit">
+  Submit
+</button>
+<UAlert
+  v-if="errorMessage"
+  data-test="error-message"
+  color="error"
+  :description="errorMessage"
+/>
 ```
 
-## Reactivity Best Practices
+## Reactivity
 
-### Use Appropriate Reactivity APIs
+- `ref()` for primitives.
+- `reactive()` only when you genuinely need a deeply-reactive object (rare — most cases are better as multiple `ref`s or `computed`).
+- `computed()` for derived values. **Never** mirror with a `watch` what `computed` can do.
+- `shallowRef()` for large frozen datasets you'll replace wholesale.
 
-```typescript
-// Use ref() for primitive values
-const count = ref(0)
-const message = ref('Hello')
-const isVisible = ref(true)
+## Notifications & errors
 
-// Use reactive() for objects that need deep reactivity
-const user = reactive({
-  name: 'John',
-  email: 'john@example.com',
-  preferences: {
-    theme: 'dark',
-    notifications: true
-  }
-})
+Two surfaces, pick the right one:
 
-// Use shallowRef() for large objects that don't need deep reactivity
-const largeDataset = shallowRef([])
+- **`useToast()`** (Nuxt UI, auto-imported) for transient global notifications. Reference: `app/src/composables/useSiwe.ts`, `app/src/App.vue`.
+- **`<UAlert />`** for inline reactive errors scoped to a form / section. Reference: `app/src/components/sections/ContractManagementView/forms/TransferOwnershipForm.vue`.
 
-// Use computed() for derived state
-const fullName = computed(() => `${user.firstName} ${user.lastName}`)
-const isFormValid = computed(() => {
-  return email.value.includes('@') && password.value.length >= 8
-})
-```
-
-### Avoid Unnecessary Watchers
-
-```typescript
-// ❌ Bad: Unnecessary watcher
-const count = ref(0)
-const doubledCount = ref(0)
-
-watch(count, (newCount) => {
-  doubledCount.value = newCount * 2
-})
-
-// ✅ Good: Use computed instead
-const count = ref(0)
-const doubledCount = computed(() => count.value * 2)
-```
-
-## Error Handling in Components
-
-### Notifications
-
-Two complementary surfaces — pick the right one:
-
-- **`useToast()` (Nuxt UI)** for transient, global notifications (success after an action, network/wallet failures the user must notice). Auto-imported. Reference call sites: `app/src/composables/useSiwe.ts`, `app/src/App.vue`.
-- **`<UAlert />`** for inline, reactive errors scoped to a form or section. Reference: `app/src/components/sections/ContractManagementView/forms/TransferOwnershipForm.vue`.
-
-Prefer `<UAlert />` over `try/catch + toast` when the error is tied to a specific form field or mutation — it composes naturally with the TanStack Query mutation pattern (see `AGENTS.md`).
-
-```typescript
-// Global notification
-const toast = useToast()
-
-const handleSubmit = async () => {
-  loading.value = true
-  await submitForm()
-  toast.add({ title: 'Form submitted successfully', color: 'success' })
-  loading.value = false
-}
+```ts
+const toast = useToast();
+toast.add({ title: "Saved", color: "success" });
 ```
 
 ```vue
-<!-- Inline reactive error -->
 <UAlert v-if="errorMessage" color="error" :description="errorMessage" />
 ```
 
-For mutations, surface `mutation.error` reactively via `<UAlert />` rather than wrapping `mutateAsync` in `try/catch`:
+For mutations, surface `mutation.error` reactively via `<UAlert />` rather than wrapping `mutateAsync` in `try/catch` — this composes with the documented mutation pattern in [`AGENTS.md`](../../AGENTS.md):
 
 ```vue
 <script setup lang="ts">
-const { mutate, error, isPending } = useSubmitFormMutation()
+const { mutate, error, isPending } = useSubmitFormMutation();
 </script>
 
 <template>
@@ -171,123 +91,27 @@ const { mutate, error, isPending } = useSubmitFormMutation()
 </template>
 ```
 
-## Accessibility Standards
+## Accessibility
 
-### ARIA Attributes
+ARIA + semantic HTML + keyboard support. The tests must reach every interactive element via keyboard, and screen-readers must announce state changes.
 
-```html
-<template>
-  <button
-    data-test="dropdown-trigger"
-    :aria-expanded="isOpen"
-    :aria-describedby="errorId"
-    aria-haspopup="true"
-    :aria-label="ariaLabel"
-    role="button"
-    tabindex="0"
-    @click="toggleDropdown"
-    @keydown.enter="toggleDropdown"
-    @keydown.space.prevent="toggleDropdown"
-    @keydown.escape="closeDropdown"
-  >
-    {{ displayValue }}
-  </button>
-  
-  <ul
-    v-if="isOpen"
-    data-test="dropdown-options"
-    role="listbox"
-    :aria-activedescendant="focusedOptionId"
-  >
-    <li
-      v-for="(option, index) in options"
-      :key="option.value"
-      :id="`option-${index}`"
-      role="option"
-      :aria-selected="option.value === modelValue"
-      @click="selectOption(option.value)"
-    >
-      {{ option.label }}
-    </li>
-  </ul>
-</template>
-```
+Minimum for a custom dropdown / disclosure:
 
-## Performance Optimization
+- `aria-expanded` reflects open state
+- `aria-haspopup` set
+- `Enter`, `Space`, and `Escape` handled
+- `role="listbox"` / `role="option"` + `aria-selected` for option lists
+- `aria-describedby` for error messages
 
-### Lazy Loading Components
+## Performance
 
-```typescript
-// Use defineAsyncComponent for heavy components
-import { defineAsyncComponent } from 'vue'
+- `defineAsyncComponent(() => import('./Heavy.vue'))` for heavy / rarely-used components.
+- Don't memoize prematurely. `computed` is already memoized; don't wrap it in `useMemo`-like helpers.
+- Clean up listeners and intervals in `onUnmounted` — every `addEventListener` needs a partner `removeEventListener`.
 
-const HeavyComponent = defineAsyncComponent(
-  () => import('./HeavyComponent.vue')
-)
-```
+## Anti-patterns
 
-## Component Testing Helpers
-
-### Component Props Interface for Testing
-
-```typescript
-// Export interfaces for testing
-export interface ComponentProps {
-  modelValue?: string
-  options: Array<{ value: string; label: string }>
-  disabled?: boolean
-}
-
-export interface ComponentData {
-  isOpen: boolean
-  focusedIndex: number
-  loading: boolean
-}
-
-export interface ComponentMethods {
-  toggleDropdown: () => void
-  selectOption: (value: string) => void
-  validateInput: () => boolean
-}
-```
-
-## Common Anti-Patterns to Avoid
-
-### Avoid Memory Leaks
-
-```typescript
-// ❌ Bad: Not cleaning up event listeners
-onMounted(() => {
-  window.addEventListener('scroll', handleScroll)
-})
-
-// ✅ Good: Clean up in onUnmounted
-onMounted(() => {
-  window.addEventListener('scroll', handleScroll)
-})
-
-onUnmounted(() => {
-  window.removeEventListener('scroll', handleScroll)
-})
-```
-
-### Don't Use v-if and v-for Together
-
-```html
-<!-- ❌ Bad: v-if and v-for on same element -->
-<li v-for="user in users" v-if="user.isActive" :key="user.id">
-  {{ user.name }}
-</li>
-
-<!-- ✅ Good: Use computed property or template wrapper -->
-<li v-for="user in activeUsers" :key="user.id">
-  {{ user.name }}
-</li>
-
-<!-- Or use template wrapper -->
-<template v-for="user in users" :key="user.id">
-  <li v-if="user.isActive">
-    {{ user.name }}
-  </li>
-</template>
-```
+- **`v-if` + `v-for` on the same element.** Use a `computed` filtered list, or `<template v-for>` wrapping a `<li v-if>`.
+- **Watchers as substitutes for `computed`.** If a watcher only sets one value from another, it's a `computed`.
+- **Inline business logic.** If the script block grows past ~50 lines or you have multiple unrelated `try/catch`, extract a composable. See [`AGENTS.md`](../../AGENTS.md) §"Frontend authoring".
+- **`wrapper.vm.foo` in tests.** Test the rendered DOM, not internals.

--- a/.github/workflows/docs-drift-scheduled.yml
+++ b/.github/workflows/docs-drift-scheduled.yml
@@ -1,0 +1,87 @@
+name: Docs drift (scheduled)
+permissions:
+  contents: read
+  issues: write
+
+on:
+  schedule:
+    # Every Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛫 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🔍 Run drift audit (capture output)
+        id: audit
+        shell: bash
+        run: |
+          set +e
+          out=$(bash scripts/audit-doc-drift.sh 2>&1)
+          status=$?
+          # strip ANSI colour codes for issue body
+          clean=$(printf '%s' "$out" | sed -E $'s/\x1B\\[[0-9;]*[a-zA-Z]//g')
+          {
+            echo "status=$status"
+            echo 'output<<__AUDIT_EOF__'
+            echo "$clean"
+            echo '__AUDIT_EOF__'
+          } >> "$GITHUB_OUTPUT"
+          # echo to job log too
+          printf '%s\n' "$out"
+          exit 0
+
+      - name: 📨 Open / update drift issue on failure
+        if: steps.audit.outputs.status != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '📝 AI-agent docs drift detected';
+            const body = [
+              'The scheduled drift audit (`scripts/audit-doc-drift.sh`) failed.',
+              '',
+              'Output:',
+              '```',
+              `${{ steps.audit.outputs.output }}`,
+              '```',
+              '',
+              `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              'Fix the items above (or update the audit script if a forbidden term is now legitimate again), then close this issue.'
+            ].join('\n');
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'docs-drift',
+              per_page: 50
+            });
+            const found = existing.find(i => i.title === title);
+
+            if (found) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: found.number,
+                body
+              });
+              core.info(`Updated existing drift issue #${found.number}`);
+            } else {
+              const { data: created } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['docs-drift', 'documentation']
+              });
+              core.info(`Opened new drift issue #${created.number}`);
+            }
+
+      - name: ❌ Fail the job if drift detected
+        if: steps.audit.outputs.status != '0'
+        run: exit 1

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -1,0 +1,25 @@
+name: Docs drift check
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: ["**"]
+    paths:
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - ".github/copilot-instructions.md"
+      - ".github/copilot-instructions/**"
+      - "scripts/audit-doc-drift.sh"
+      - ".github/workflows/docs-drift.yml"
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛫 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🔍 Audit AI-agent docs for drift
+        run: bash scripts/audit-doc-drift.sh

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ app/.env.production
 /reviews/
 /archi-update.md
 .claude/
+
+# Local working todolist shared between dev and AI agents (never committed)
+/todolist.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 Guidance for AI coding agents (GitHub Copilot, Cursor, Codex, Claude Code, etc.) working in this repository. Human contributors should read `README.md` and `CONTRIBUTION.md`.
 
 > Detailed area guides live in `.github/copilot-instructions/` (Vue standards, testing patterns, Web3 testing anti-patterns, review checklist, commit conventions). Consult them for specifics; this file is the orientation layer.
-
+>
 > **Working todolist**: a gitignored `todolist.md` at the repo root is the shared working list between the dev and any AI agent. Read it at the start of a session, keep it accurate as you work (mark items in_progress / done, add discoveries, remove stale items). Don't commit it. If it doesn't exist, create one with the same convention.
 
 ## Repository layout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,14 @@ After cloning: `npm install` in each subproject you'll touch (`app/`, `backend/`
 - **One responsibility per composable / util.** Name it for what it returns (`useTeamRoster`, `formatTokenAmount`) — if you can't name it cleanly, it's doing too much.
 - **Keep the mutation pattern**: pure async fn (often a util) + `useXxxMutation` composable. Components consume them; they don't orchestrate fetch/mutate logic inline.
 
+**Surface drift proactively.** When you open a file to do work and notice it doesn't follow the rules above (oversized component, inline try/catch around mutations, duplicated util, denormalized state, dead `useToastStore` references, etc.), **don't silently ignore it and don't unilaterally rewrite the whole file either**. Tell the developer:
+
+1. What you noticed (be specific — file + the rule it violates).
+2. Why fixing it now is worth it (concrete DX/reviewability/maintenance benefit, not generic platitudes).
+3. That these are exactly the items reviewers check during PR review per `.github/copilot-instructions/review-checklist.md` — fixing in the same PR avoids a follow-up round.
+
+Then ask whether to do it now (scoped to this PR), defer (open a tracking issue), or skip. Default to *proposing*, not *imposing* — but always raise it.
+
 ## Conventions
 
 - **Conventional Commits with gitmoji**: `<type><emoji>: <subject>` — `feat: ✨ ...`, `fix: 🐛 ...`, `refactor: ♻️ ...`, `docs: 📝 ...`, `test: ✅ ...`, `chore: 🔧 ...`, `perf: ⚡️ ...`, `build: 📦 ...`, `ci: 👷 ...`, `style: 💄 ...`. Same format for issue and PR titles. See `.github/copilot-instructions/commit-conventions.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,14 @@ npm run test
 
 Run whatever lint / type-check / test scripts the subproject's `package.json` exposes. If a script exists, it must pass.
 
+### Docs (if you touched any `.md` agent-instruction file)
+
+```bash
+bash scripts/audit-doc-drift.sh
+```
+
+Greps for known-stale terms, broken intra-doc links, and missing canonical reference files. Runs in CI on every PR that touches agent docs.
+
 ## Before opening a PR
 
 1. The code quality gate above passed in every touched subproject.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ Guidance for AI coding agents (GitHub Copilot, Cursor, Codex, Claude Code, etc.)
 
 > Detailed area guides live in `.github/copilot-instructions/` (Vue standards, testing patterns, Web3 testing anti-patterns, review checklist, commit conventions). Consult them for specifics; this file is the orientation layer.
 
+> **Working todolist**: a gitignored `todolist.md` at the repo root is the shared working list between the dev and any AI agent. Read it at the start of a session, keep it accurate as you work (mark items in_progress / done, add discoveries, remove stale items). Don't commit it. If it doesn't exist, create one with the same convention.
+
 ## Repository layout
 
 Monorepo without a workspace tool — each subproject has its own `package.json` and `node_modules`. Run commands from the relevant subdirectory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI coding agents (GitHub Copilot, Cursor, Codex, Claude Code, etc.)
 
 > Detailed area guides live in `.github/copilot-instructions/` (Vue standards, testing patterns, Web3 testing anti-patterns, review checklist, commit conventions). Consult them for specifics; this file is the orientation layer.
 >
-> **Working todolist**: a gitignored `todolist.md` at the repo root is the shared working list between the dev and any AI agent. Read it at the start of a session, keep it accurate as you work (mark items in_progress / done, add discoveries, remove stale items). Don't commit it. If it doesn't exist, create one with the same convention.
+> **Working todolist**: a gitignored `todolist.md` at the repo root is the shared working list between the dev and any AI agent. Read it at the start of a session, keep it accurate as you work (mark items in_progress / done, add discoveries, remove stale items). Don't commit it. If it doesn't exist, create one with the same convention. **Respect dependencies**: tasks marked `(blocked by: …)` must not be started until their blocker is `[x]`; do not fan blocked tasks out in parallel with their blockers.
 
 ## Repository layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,14 @@ After cloning: `npm install` in each subproject you'll touch (`app/`, `backend/`
 
 **Web3 stack.** wagmi + viem for chain reads/writes, Apollo Client for subgraph queries, Safe SDK (`@safe-global/*`) for multisig flows.
 
+**Frontend authoring — keep components small and readable (DX-first).** A component should fit on a screen and read like a description of the UI, not like a script. Whenever you edit a Vue file, take it as an opportunity to make it leaner.
+
+- **Extract logic, not just markup.** Push pure data shaping into `app/src/utils/` (utility functions) and stateful/reactive logic into `app/src/composables/` (`useXxx`). The component is left declaring *what* it shows — the *how* lives outside.
+- **Search before you create.** Before adding a new utility, grep `app/src/utils/` for one that already does the job (or can be generalized). Same rule for composables in `app/src/composables/` — reuse `useXxxMutation`, `useSiwe`, formatters, address/amount helpers, etc. rather than reinventing them. Prefer extending an existing helper to introducing a near-duplicate.
+- **Split when a component grows.** Signs that it's time to refactor: the `<script setup>` block is longer than the `<template>`, multiple unrelated `ref`s/`watch`es, more than one `try/catch`, repeated bits of logic that could be a composable, or formatting/derivation work inline that belongs in a util.
+- **One responsibility per composable / util.** Name it for what it returns (`useTeamRoster`, `formatTokenAmount`) — if you can't name it cleanly, it's doing too much.
+- **Keep the mutation pattern**: pure async fn (often a util) + `useXxxMutation` composable. Components consume them; they don't orchestrate fetch/mutate logic inline.
+
 ## Conventions
 
 - **Conventional Commits with gitmoji**: `<type><emoji>: <subject>` — `feat: ✨ ...`, `fix: 🐛 ...`, `refactor: ♻️ ...`, `docs: 📝 ...`, `test: ✅ ...`, `chore: 🔧 ...`, `perf: ⚡️ ...`, `build: 📦 ...`, `ci: 👷 ...`, `style: 💄 ...`. Same format for issue and PR titles. See `.github/copilot-instructions/commit-conventions.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,130 @@
+# AGENTS.md
+
+Guidance for AI coding agents (GitHub Copilot, Cursor, Codex, Claude Code, etc.) working in this repository. Human contributors should read `README.md` and `CONTRIBUTION.md`.
+
+> Detailed area guides live in `.github/copilot-instructions/` (Vue standards, testing patterns, Web3 testing anti-patterns, review checklist, commit conventions). Consult them for specifics; this file is the orientation layer.
+
+## Repository layout
+
+Monorepo without a workspace tool — each subproject has its own `package.json` and `node_modules`. Run commands from the relevant subdirectory.
+
+- `app/` — **active** Vue 3 SPA. TypeScript, Vite, Pinia, wagmi/viem, TanStack Query, Apollo Client, Tailwind v4, Nuxt UI v4. The main user-facing product.
+- `dashboard/` — separate Nuxt app for stats/dashboards (not the SPA).
+- `backend/` — Express + TypeScript REST API, Prisma ORM (PostgreSQL), JWT auth. Bruno collections in `backend/bruno/`.
+- `contract/` — Hardhat + Solidity. Deployed addresses are mirrored from `contract/ignition/deployments/` into `app/src/artifacts/deployed_addresses/chain-*.json` and `dashboard/app/artifacts/deployed_addresses/`.
+- `ponder/` — Ponder indexer.
+- `the-graph/` — The Graph subgraph.
+
+Frontend talks to backend over REST and to chain via wagmi/viem. Backend is a thin auth + data gateway; on-chain governance/contribution logic lives in `contract/`.
+
+## Setup
+
+- Node.js v22.18.0+
+- PostgreSQL (or `docker-compose -f docker-compose.dev.yml up` to get one)
+- Required env vars:
+  - Backend: `SECRET_KEY`, `DATABASE_URL`, `FRONTEND_URL`, `CHAIN_ID`
+  - Frontend: `VITE_APP_BACKEND_URL`, `VITE_APP_NETWORK_ALIAS`, `VITE_APP_ETHERSCAN_URL`
+  - Contracts: `ALCHEMY_API_KEY`, `ALCHEMY_HTTP`, `PRIVATE_KEY`
+
+After cloning: `npm install` in each subproject you'll touch (`app/`, `backend/`, `contract/`, etc.).
+
+## Commands
+
+### Frontend (`app/`)
+
+- `npm run dev` — Vite dev server
+- `npm run build` — `type-check` + `build-only` in parallel
+- `npm run type-check` — `vue-tsc --build tsconfig.app.json --force`
+- `npm run lint` — `eslint . --fix`
+- `npm run format` / `format-check`
+- `npm run test:unit` — Vitest. Single file: `npx vitest run path/to/file.spec.ts`. Single test: append `-t "name"`.
+- `npm run test:e2e` (`:headed`, `:ui`, `:debug`) — Playwright + Synpress. `npm run test:build:cache` prebuilds the MetaMask cache.
+
+### Backend (`backend/`)
+
+- `npm run start` — nodemon on `src/index.ts`
+- `npm run build` — `tsc` + Sentry sourcemap upload (Sentry creds required; run `tsc` directly for plain local builds)
+- `npm run test` / `test:unit` / `test:e2e` — Vitest (separate configs)
+- `npm run test:bruno` — runs the Bruno API collection (auto-runs auth setup)
+- `npx prisma generate` — required after editing the schema
+- `npm run prisma:migrate` / `npm run seed` (`:dev` / `:test` / `:staging` / `:reset`)
+- `npm run lint` / `lint:fix`
+
+### Contracts (`contract/`)
+
+- `npm run compile`, `npm run test` (single file: `npx hardhat test test/Foo.test.ts`), `npm run coverage`
+- `npm run deploy` (localhost) / `npm run deploy:polygon`
+- `npm run validate-upgrade[:polygon|:local]` — OpenZeppelin upgrade safety check
+- `npm run update-abi` — copies ABIs into the frontend
+- `npm run lint` (solhint + eslint), `npm run format`
+
+### Whole stack
+
+- `docker-compose -f docker-compose.dev.yml up` — dev stack including Postgres
+- `docker-compose up` — full stack
+
+## Architecture notes
+
+**Frontend mutation pattern.** Mutations are a pure async function plus a `useXxxMutation` composable wrapping `@tanstack/vue-query`. Use `onSuccess` / `onError` callbacks rather than awaiting + try/catch in components. Surface errors reactively via `UAlert`. Issue #1776 documents the canonical pattern.
+
+**Single source of truth.** Prefer deriving values (computed / selectors) over denormalizing or duplicating state. Don't mirror server data into Pinia stores when a query already owns it — even if the refactor is non-trivial.
+
+**Chain config.** Deployed contract addresses are per-chain JSON files committed under `app/src/artifacts/deployed_addresses/`. After local deploys, `app/package.json` exposes `git:ignore-locally` to keep local-only `chain-31337.json` edits out of commits.
+
+**Auth.** Backend issues JWTs; frontend stores via Pinia.
+
+**Web3 stack.** wagmi + viem for chain reads/writes, Apollo Client for subgraph queries, Safe SDK (`@safe-global/*`) for multisig flows.
+
+## Conventions
+
+- **Conventional Commits with gitmoji**: `<type><emoji>: <subject>` — `feat: ✨ ...`, `fix: 🐛 ...`, `refactor: ♻️ ...`, `docs: 📝 ...`, `test: ✅ ...`, `chore: 🔧 ...`, `perf: ⚡️ ...`, `build: 📦 ...`, `ci: 👷 ...`, `style: 💄 ...`. Same format for issue and PR titles. See `.github/copilot-instructions/commit-conventions.md`.
+- **Atomic commits** — commit each logical change as it lands. Don't squash an entire PR into one commit at the end.
+- Issues, PRs, commit messages, and user-facing UI strings/toasts are **English**.
+- Vue components: `<script setup lang="ts">` Composition API. Pinia for global state, TanStack Query for server state.
+- TypeScript strict mode across frontend and backend.
+
+## Code quality gate (mandatory before pushing)
+
+Every subproject ships its own quality checks and CI runs them. **Before pushing to GitHub, run the full check set in every subproject you touched and make sure all of them pass with zero errors.** Do not push with a failing or skipped check — fix the root cause.
+
+Per-subproject checklist:
+
+### `app/`
+
+```bash
+cd app
+npm run lint
+npm run format-check
+npm run type-check
+npm run test:unit -- --run
+```
+
+### `backend/`
+
+```bash
+cd backend
+npm run lint
+npm run format:check
+npx prisma generate   # if you touched prisma/schema.prisma
+npm run test:unit -- --run
+```
+
+### `contract/`
+
+```bash
+cd contract
+npm run lint           # solhint + eslint
+npm run format-check   # sol + ts
+npm run compile
+npm run test
+```
+
+### `dashboard/`, `ponder/`, `the-graph/`
+
+Run whatever lint / type-check / test scripts the subproject's `package.json` exposes. If a script exists, it must pass.
+
+## Before opening a PR
+
+1. The code quality gate above passed in every touched subproject.
+2. Reviewed against `.github/copilot-instructions/review-checklist.md`.
+3. PR title follows Conventional Commits + gitmoji. Use the template in `.github/pull_request_template.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+This repository uses [`AGENTS.md`](./AGENTS.md) as the single source of truth for AI coding agents (Copilot, Cursor, Codex, Claude Code, …).
+
+**Read `AGENTS.md` first.** It covers repo layout, setup, per-subproject commands, architecture notes, conventions, and the mandatory code-quality gate before pushing.
+
+Anything Claude-Code-specific would go below this line — there is nothing at the moment.

--- a/scripts/audit-doc-drift.sh
+++ b/scripts/audit-doc-drift.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Audit AI-agent docs for drift against the current codebase.
+# Usage:  scripts/audit-doc-drift.sh
+# Exits non-zero if drift is detected, so it's safe to wire into CI.
+
+set -u
+cd "$(dirname "$0")/.."
+
+YELLOW='\033[1;33m'; RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+fail=0
+warn=0
+
+DOC_PATHS=(
+  "AGENTS.md"
+  "CLAUDE.md"
+  ".github/copilot-instructions.md"
+  ".github/copilot-instructions"
+)
+
+# 1. Forbidden / stale terms ----------------------------------------------------
+# When a pattern is removed from the codebase, add its name here so the docs
+# can never silently re-introduce it. Keep this list short and intentional.
+FORBIDDEN=(
+  'useToastStore'
+  'addSuccessToast'
+  'addErrorToast'
+  'daisyUI'
+  'commitlint'
+  '163 tests'
+  '350+ tests'
+)
+
+echo "── Forbidden terms ──────────────────────────────────────────"
+section_fail=0
+for term in "${FORBIDDEN[@]}"; do
+  hits=$(grep -rn --include='*.md' -- "$term" "${DOC_PATHS[@]}" 2>/dev/null \
+         | grep -v 'audit-doc-drift.sh' \
+         | grep -vE 'does not|no longer|removed|not currently|never|deprecated|\bdead\b|legacy' \
+         || true)
+  if [ -n "$hits" ]; then
+    echo -e "${RED}✖ '$term' found in docs:${NC}"
+    echo "$hits"
+    section_fail=1
+  fi
+done
+if [ $section_fail -eq 0 ]; then
+  echo -e "${GREEN}✓ no forbidden terms${NC}"
+else
+  fail=1
+fi
+
+# 2. Broken intra-doc links -----------------------------------------------------
+echo
+echo "── Broken markdown links ────────────────────────────────────"
+broken=0
+while IFS= read -r f; do
+  while IFS= read -r link; do
+    # strip ()
+    rel="${link#(}"; rel="${rel%)}"
+    # skip http(s), anchors, mailto
+    case "$rel" in http*|mailto*|'#'*) continue;; esac
+    # strip anchor
+    rel_path="${rel%%#*}"
+    [ -z "$rel_path" ] && continue
+    target="$(dirname "$f")/$rel_path"
+    if [ ! -e "$target" ]; then
+      echo -e "${RED}✖ $f → $rel${NC}"
+      broken=1
+    fi
+  done < <(grep -oE '\]\(([^)]+\.md[^)]*)\)' "$f" 2>/dev/null | sed 's/^\](//')
+done < <(find AGENTS.md CLAUDE.md .github/copilot-instructions.md .github/copilot-instructions -type f -name '*.md' 2>/dev/null)
+if [ $broken -eq 0 ]; then
+  echo -e "${GREEN}✓ no broken links${NC}"
+else
+  fail=1
+fi
+
+# 3. Canonical references must still exist --------------------------------------
+echo
+echo "── Canonical reference files ────────────────────────────────"
+CANONICAL=(
+  "app/src/components/__tests__/SelectComponent.spec.ts"
+  "app/src/composables/__tests__/useContractFunction.spec.ts"
+  "app/src/__tests__/wagmi.spec.ts"
+  "app/src/utils/__tests__/currencyUtil.spec.ts"
+  "app/src/composables/useSiwe.ts"
+)
+section_fail=0
+for f in "${CANONICAL[@]}"; do
+  if [ ! -e "$f" ]; then
+    echo -e "${RED}✖ canonical reference missing: $f${NC}"
+    echo "    → docs may point to a renamed/deleted file. Update the pointers."
+    section_fail=1
+  fi
+done
+if [ $section_fail -eq 0 ]; then
+  echo -e "${GREEN}✓ all canonical references exist${NC}"
+else
+  fail=1
+fi
+
+# 4. Soft warnings (non-blocking) ----------------------------------------------
+echo
+echo "── Soft warnings ────────────────────────────────────────────"
+# Hard-coded test counts (any "N tests" or "N+ tests" claim is suspicious)
+counts=$(grep -rnE --include='*.md' '\b[0-9]{2,}\+? tests\b' "${DOC_PATHS[@]}" 2>/dev/null \
+         | grep -v 'audit-doc-drift.sh' || true)
+if [ -n "$counts" ]; then
+  echo -e "${YELLOW}⚠ hard-coded test counts (drift-prone):${NC}"
+  echo "$counts"
+  warn=1
+fi
+
+# Toast pattern: any toast example must use color: success|error
+toast_calls=$(grep -rnE --include='*.md' "toast\.add\(\{.*color:" "${DOC_PATHS[@]}" 2>/dev/null \
+              | grep -vE "color: ['\"](success|error|info|warning|primary|neutral)['\"]" || true)
+if [ -n "$toast_calls" ]; then
+  echo -e "${YELLOW}⚠ toast.add examples without a recognised color:${NC}"
+  echo "$toast_calls"
+  warn=1
+fi
+
+[ $warn -eq 0 ] && echo -e "${GREEN}✓ no warnings${NC}"
+
+echo
+if [ $fail -ne 0 ]; then
+  echo -e "${RED}DRIFT DETECTED — fix the items above and re-run.${NC}"
+  exit 1
+fi
+if [ $warn -ne 0 ]; then
+  echo -e "${YELLOW}Audit passed with warnings.${NC}"
+  exit 0
+fi
+echo -e "${GREEN}Audit clean.${NC}"

--- a/scripts/audit-doc-drift.sh
+++ b/scripts/audit-doc-drift.sh
@@ -99,7 +99,64 @@ else
   fail=1
 fi
 
-# 4. Soft warnings (non-blocking) ----------------------------------------------
+# 4. Repo paths quoted in docs must exist --------------------------------------
+# Picks up references like `app/src/foo/bar.ts` in markdown and verifies them.
+echo
+echo "── Repo path references in docs ─────────────────────────────"
+section_fail=0
+# Match paths containing a slash + a known source extension, inside backticks.
+while IFS= read -r hit; do
+  [ -z "$hit" ] && continue
+  src_file="${hit%%:*}"
+  rest="${hit#*:}"
+  rest="${rest#*:}"
+  rel_path="${rest#\`}"; rel_path="${rel_path%\`}"
+  if [ ! -e "$rel_path" ]; then
+    echo -e "${RED}✖ $src_file references missing path: $rel_path${NC}"
+    section_fail=1
+  fi
+done < <(grep -rnoE --include='*.md' \
+  '`(app|backend|contract|dashboard|ponder|the-graph|scripts)/[A-Za-z0-9_./-]+\.(ts|tsx|vue|js|mjs|cjs|sol|json|md|sh|yml|yaml)`' \
+  "${DOC_PATHS[@]}" 2>/dev/null || true)
+if [ $section_fail -eq 0 ]; then
+  echo -e "${GREEN}✓ all referenced repo paths exist${NC}"
+else
+  fail=1
+fi
+
+# 5. Stack drift: docs claim a tool the project doesn't depend on ---------------
+# Format: "<label-found-in-docs>|<package-name-expected-in-app/package.json>"
+echo
+echo "── Stack claims vs package.json ─────────────────────────────"
+section_fail=0
+APP_PKG="app/package.json"
+STACK_CLAIMS=(
+  "Nuxt UI|@nuxt/ui"
+  "Tailwind v4|@tailwindcss/vite"
+  "TanStack Query|@tanstack/vue-query"
+  "wagmi|@wagmi/vue"
+  "Apollo Client|@apollo/client"
+  "Pinia|pinia"
+)
+if [ -f "$APP_PKG" ]; then
+  for entry in "${STACK_CLAIMS[@]}"; do
+    label="${entry%%|*}"
+    dep="${entry##*|}"
+    if grep -rln --include='*.md' -- "$label" "${DOC_PATHS[@]}" >/dev/null 2>&1; then
+      if ! grep -q "\"$dep\"" "$APP_PKG"; then
+        echo -e "${RED}✖ docs claim '$label' but $APP_PKG has no dep '$dep'${NC}"
+        section_fail=1
+      fi
+    fi
+  done
+fi
+if [ $section_fail -eq 0 ]; then
+  echo -e "${GREEN}✓ stack claims match dependencies${NC}"
+else
+  fail=1
+fi
+
+# 6. Soft warnings (non-blocking) ----------------------------------------------
 echo
 echo "── Soft warnings ────────────────────────────────────────────"
 # Hard-coded test counts (any "N tests" or "N+ tests" claim is suspicious)


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` as the cross-tool orientation entry point for AI coding agents (Copilot, Cursor, Codex, Claude Code) — covers repo layout, setup, per-subproject commands, architecture notes, conventions, and the mandatory pre-push code-quality gate.
- Reduce `CLAUDE.md` to a one-line pointer to `AGENTS.md` (single source of truth).
- Reconcile `.github/copilot-instructions(.md|/)` with the current codebase: drop 8 dead links, fix daisyUI → Nuxt UI v4, replace ~20 stale `useToastStore`/`addSuccessToast` references with the canonical Nuxt UI `useToast()` + `<UAlert />` pattern across 4 files, rewrite commit-conventions to match the project's gitmoji rule, remove fictitious commitlint/husky claims.
- Refactor the heaviest instruction files to point at canonical reference test specs in `app/src` instead of inlining ~1640 lines of snippets — drift surface reduced.
- New rules in `AGENTS.md`: leanness for Vue components (extract utils + composables, search before creating); proactively flag drift to the dev when seen; gitignored `todolist.md` shared between dev and agents.
- New `scripts/audit-doc-drift.sh` — checks forbidden terms, broken markdown links, presence of canonical reference files, repo paths quoted in docs, and stack claims vs `app/package.json`.
- New `.github/workflows/docs-drift.yml` — runs the audit on every PR that touches agent docs.
- New `.github/workflows/docs-drift-scheduled.yml` — weekly cron (Mon 06:00 UTC) that runs the audit and opens/updates a `docs-drift` issue when it fails.

## Test plan

- [ ] Drift audit passes locally (`bash scripts/audit-doc-drift.sh`)
- [ ] PR-triggered `docs-drift` workflow runs green on this PR
- [ ] Scheduled workflow can be triggered via `workflow_dispatch`
- [ ] Monthly remote routine `trig_014JT7qamxHZ59aBo1gwW7GS` exists
- [ ] `AGENTS.md` and `CLAUDE.md` render correctly on GitHub