### PR TITLE
chore: 🔧 bump actions/checkout to v6 and standardise on Node 24

### DIFF
--- a/.github/workflows/app-code-quality.yml
+++ b/.github/workflows/app-code-quality.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛫 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🏗 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/app-e2e.yml.new
+++ b/.github/workflows/app-e2e.yml.new
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: 🛫 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🏗 Set up Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24.x
           cache: "npm"
           cache-dependency-path: ./app/package-lock.json
 

--- a/.github/workflows/app-e2e.yml.new
+++ b/.github/workflows/app-e2e.yml.new
@@ -20,7 +20,7 @@ jobs:
       - name: 🛫 Checkout
         uses: actions/checkout@v6
 
-      - name: 🏗 Set up Node.js 22
+      - name: 🏗 Set up Node.js 24
         uses: actions/setup-node@v4
         with:
           node-version: 24.x

--- a/.github/workflows/app-vitest.yml
+++ b/.github/workflows/app-vitest.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛫 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🏗 Set up NodeJS 24.x
         uses: actions/setup-node@v6

--- a/.github/workflows/backend-code-quality.yml
+++ b/.github/workflows/backend-code-quality.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛫 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🏗 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/backend-vitest.yml
+++ b/.github/workflows/backend-vitest.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: 🛫 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🏗 Set up NodeJS 24.x
         uses: actions/setup-node@v6

--- a/.github/workflows/contract-code-quality.yml
+++ b/.github/workflows/contract-code-quality.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛫 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🏗 Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.10.0
+          node-version: 24.x
           cache: "npm"
           cache-dependency-path: ./contract/package-lock.json
 

--- a/.github/workflows/contract-vitest.yml
+++ b/.github/workflows/contract-vitest.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛫 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🏗 Set up NodeJS 20.10.0
         uses: actions/setup-node@v4
         with:
-          node-version: 20.10.0
+          node-version: 24.x
           cache: "npm"
           cache-dependency-path: ./contract/package-lock.json
 

--- a/.github/workflows/contract-vitest.yml
+++ b/.github/workflows/contract-vitest.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 🛫 Checkout
         uses: actions/checkout@v6
 
-      - name: 🏗 Set up NodeJS 20.10.0
+      - name: 🏗 Set up NodeJS 24.x
         uses: actions/setup-node@v4
         with:
           node-version: 24.x

--- a/.github/workflows/dashboard-code-quality.yml
+++ b/.github/workflows/dashboard-code-quality.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛫 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🏗 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/docs-drift-scheduled.yml
+++ b/.github/workflows/docs-drift-scheduled.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛫 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔍 Run drift audit (capture output)
         id: audit

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛫 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔍 Audit AI-agent docs for drift
         run: bash scripts/audit-doc-drift.sh

--- a/.github/workflows/ponder-code-quality.yml
+++ b/.github/workflows/ponder-code-quality.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛫 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🏗 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Extract version information


### PR DESCRIPTION
## Summary

- Bump `actions/checkout@v4` → `@v6` across every active workflow (12 files). `@v6` ships its JS on Node 24, which clears the deprecation warning currently logged on every CI run.
- Pin `node-version` to `24.x` (or `"24"`) everywhere. Node 20 (Iron LTS) hits EOL this month; Node 24 (Krypton) is the current Active LTS through April 2028.
- Includes `app-e2e.yml.new`. Leaves `app-e2e.yml.bak` alone (backup, doesn't run).

Closes #1819

## Out of scope (deliberate)

- Bumping `actions/setup-node` (mixed v4/v6 today), `actions/github-script`, `actions/upload-artifact`, `codecov/codecov-action`, `softprops/action-gh-release` — separate, larger surface.
- Removing the inert `app-e2e.yml.bak`.

## Test plan

- [ ] All workflows triggered by this PR run green.
- [ ] No `Node.js 20 actions are deprecated` warning appears in any of the runs.
- [ ] Hardhat-based jobs (`contract-vitest`, `contract-code-quality`) pass on Node 24 (locally confirmed by @hermanneho).