### PR TITLE
docs: 📝 fix doc drift caught by monthly audit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,7 @@ The CNC Portal is a multi-component application enabling financial recognition o
 
 **Component Relationships:**
 
-- Frontend communicates with backend via REST API and directly with smart contracts via Web3
+- Frontend communicates with backend via REST (TanStack Query) and GraphQL (Apollo Client), and directly with smart contracts via Web3
 - Backend manages user data, authentication, and serves as API gateway
 - Smart contracts handle on-chain governance and contribution tracking
 

--- a/.github/copilot-instructions/README.md
+++ b/.github/copilot-instructions/README.md
@@ -20,7 +20,7 @@ CNC Portal is a Crypto Native Corporation Portal built with:
 
 For every feature create documentation in the `/docs` folder using Markdown files. Follow the existing structure and naming conventions.
 
-Try to keep each feature documentation short, and use mairmaid for diagrams where applicable.
+Try to keep each feature documentation short, and use mermaid for diagrams where applicable.
 
 ### Date Manipulation
 

--- a/dashboard/docs/functional-specifications.md
+++ b/dashboard/docs/functional-specifications.md
@@ -705,12 +705,12 @@ _Reports:_
 
 **Technology:**
 
-- Nuxt 3 (Vue 3 framework)
+- Nuxt 4 (Vue 3 framework)
 - TypeScript
 - Pinia for state management
 - Vue Router (built-in with Nuxt)
 - Chart.js or ApexCharts for visualizations
-- TailwindCSS + DaisyUI for styling
+- TailwindCSS + Nuxt UI v4 for styling
 - Viem for Ethereum address handling
 - Apollo Client for GraphQL queries
 
@@ -864,7 +864,7 @@ _Reports:_
 
 ### Phase 1: Foundation (Week 1-2)
 
-- [ ] Set up Nuxt 3 project structure
+- [ ] Set up Nuxt 4 project structure
 - [ ] Authentication system (wallet-based)
 - [ ] Admin dashboard layout and navigation
 - [ ] Overview dashboard with basic stats


### PR DESCRIPTION
Closes #1822.

## Summary

Three small fixes from the 2026-04 monthly docs-drift audit:

- `mairmaid` → `mermaid` typo in `.github/copilot-instructions/README.md`
- Mention GraphQL/Apollo alongside REST in `.github/copilot-instructions.md` architecture overview — the frontend already uses Apollo Client for several heavy data views (`TransactionHistorySection.vue`, `ExpenseMonthSpent.vue`, `InvestorsTransactions.vue`).
- `dashboard/docs/functional-specifications.md`: `Nuxt 3` → `Nuxt 4`, `DaisyUI` → `Nuxt UI v4`, to match `dashboard/package.json` (`nuxt ^4.2.1`, `@nuxt/ui ^4.1.0`).

The other findings from the routine run were false positives caused by it auditing `origin/main` instead of `origin/develop`. Routine prompt has been updated to pin `develop`.

## Test plan
- [x] `bash scripts/audit-doc-drift.sh` passes locally
- [ ] CI green