### PR TITLE
docs: 📝 require every PR to be linked to a GitHub issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,3 +154,4 @@ Greps for known-stale terms, broken intra-doc links, and missing canonical refer
 1. The code quality gate above passed in every touched subproject.
 2. Reviewed against `.github/copilot-instructions/review-checklist.md`.
 3. PR title follows Conventional Commits + gitmoji. Use the template in `.github/pull_request_template.md`.
+4. **Every PR must be linked to a GitHub issue.** Search existing open issues first; if none fits, open one before (or alongside) the PR and reference it in the PR body with a closing keyword (`Closes #N`, `Fixes #N`). Trivial chores (typo fix, doc drift, dependency bump) follow the same rule — open a small tracking issue rather than skipping it. The issue is the "why"; the PR is the "how".


### PR DESCRIPTION
Closes #1823.

## Summary

Adds a fourth item to the 'Before opening a PR' checklist in `AGENTS.md`:

> Every PR must be linked to a GitHub issue. Search existing open issues first; if none fits, open one before (or alongside) the PR and reference it in the PR body with a closing keyword (`Closes #N`, `Fixes #N`). Trivial chores (typo fix, doc drift, dependency bump) follow the same rule — open a small tracking issue rather than skipping it. The issue is the "why"; the PR is the "how".

Applies to humans and AI agents.

## Test plan
- [x] `bash scripts/audit-doc-drift.sh` clean