### PR TITLE
feat: ✨ smooth migration of WeeklyClaim signatures across cash-remuneration contract redeploy

### DIFF
--- a/app/src/components/sections/CashRemunerationView/CRSigne.vue
+++ b/app/src/components/sections/CashRemunerationView/CRSigne.vue
@@ -1,27 +1,37 @@
 <template>
-  <UButton
+  <UTooltip
     v-if="isCashRemunerationOwner && !isDropDown"
-    color="success"
-    data-test="approve-button"
-    :disabled="isLoad || disabled || isCurrentWeek || isSignFrozen"
-    :loading="isLoad"
-    size="sm"
-    @click="handleApprove"
+    :text="isSignFrozen ? frozenTooltip : undefined"
+    :content="{ side: 'top' }"
   >
-    Approve
-  </UButton>
-  <div
+    <UButton
+      color="success"
+      data-test="approve-button"
+      :disabled="isLoad || disabled || isCurrentWeek || isSignFrozen"
+      :loading="isLoad"
+      size="sm"
+      @click="handleApprove"
+    >
+      Approve
+    </UButton>
+  </UTooltip>
+  <UTooltip
     v-else-if="isDropDown"
-    data-test="sign-action"
-    :class="['text-sm', { disabled: isLoad || isSignFrozen }]"
-    :aria-disabled="isLoad || isSignFrozen"
-    :tabindex="isLoad || isSignFrozen ? -1 : 0"
-    :style="{ pointerEvents: isLoad || isSignFrozen ? 'none' : undefined }"
-    @click="handleDropdownClick"
+    :text="isSignFrozen ? frozenTooltip : undefined"
+    :content="{ side: 'top' }"
   >
-    <span v-if="isLoad" class="loading loading-spinner loading-xs mr-2"></span>
-    {{ isResign ? 'Resign' : 'Sign' }}
-  </div>
+    <div
+      data-test="sign-action"
+      :class="['text-sm', { disabled: isLoad || isSignFrozen }]"
+      :aria-disabled="isLoad || isSignFrozen"
+      :tabindex="isLoad || isSignFrozen ? -1 : 0"
+      :style="{ pointerEvents: isLoad ? 'none' : undefined }"
+      @click="handleDropdownClick"
+    >
+      <span v-if="isLoad" class="loading loading-spinner loading-xs mr-2"></span>
+      {{ isResign ? 'Resign' : 'Sign' }}
+    </div>
+  </UTooltip>
 </template>
 
 <script setup lang="ts">
@@ -83,6 +93,8 @@ const isCashRemunerationOwner = computed(() => cashRemunerationOwner.value === u
 // the explicit follow-up flow once the redeploy lands.
 const isTeamMigrated = computed(() => teamStore.currentTeamMeta.data?.isMigrated !== false)
 const isSignFrozen = computed(() => !isTeamMigrated.value)
+const frozenTooltip =
+  'Signing is disabled until your team migrates to the new CashRemuneration contract.'
 
 const { error: claimError, mutateAsync: executeUpdateClaim } = useUpdateWeeklyClaimMutation()
 
@@ -209,7 +221,7 @@ const handleApprove = async () => {
 }
 
 const handleDropdownClick = async () => {
-  if (isLoad.value) return
+  if (isLoad.value || isSignFrozen.value) return
 
   if (!isCashRemunerationOwner.value) {
     emit('close')

--- a/app/src/components/sections/CashRemunerationView/CRSigne.vue
+++ b/app/src/components/sections/CashRemunerationView/CRSigne.vue
@@ -3,7 +3,7 @@
     v-if="isCashRemunerationOwner && !isDropDown"
     color="success"
     data-test="approve-button"
-    :disabled="isLoad || disabled || isCurrentWeek"
+    :disabled="isLoad || disabled || isCurrentWeek || isSignFrozen"
     :loading="isLoad"
     size="sm"
     @click="handleApprove"
@@ -13,10 +13,10 @@
   <div
     v-else-if="isDropDown"
     data-test="sign-action"
-    :class="['text-sm', { disabled: isLoad }]"
-    :aria-disabled="isLoad"
-    :tabindex="isLoad ? -1 : 0"
-    :style="{ pointerEvents: isLoad ? 'none' : undefined }"
+    :class="['text-sm', { disabled: isLoad || isSignFrozen }]"
+    :aria-disabled="isLoad || isSignFrozen"
+    :tabindex="isLoad || isSignFrozen ? -1 : 0"
+    :style="{ pointerEvents: isLoad || isSignFrozen ? 'none' : undefined }"
     @click="handleDropdownClick"
   >
     <span v-if="isLoad" class="loading loading-spinner loading-xs mr-2"></span>
@@ -75,6 +75,14 @@ const { data: cashRemunerationOwner, error: cashRemunerationOwnerError } = useRe
 })
 
 const isCashRemunerationOwner = computed(() => cashRemunerationOwner.value === userStore.address)
+
+// Block sign actions while the team is on the previous Officer generation
+// (issue #1825). A new signature would be bound to the new contract typehash
+// while the team is still using the old contract on-chain — pointless and
+// confusing. Resigning a stale signature against the *current* contract is
+// the explicit follow-up flow once the redeploy lands.
+const isTeamMigrated = computed(() => teamStore.currentTeamMeta.data?.isMigrated !== false)
+const isSignFrozen = computed(() => !isTeamMigrated.value)
 
 const { error: claimError, mutateAsync: executeUpdateClaim } = useUpdateWeeklyClaimMutation()
 
@@ -153,10 +161,27 @@ const approveClaim = async () => {
     }
 
     await enableClaim(signature as `0x${string}`)
+    // Send the verifying contract + the typed-data envelope so the backend
+    // can authenticate the signature (recoverTypedDataAddress) and tag the
+    // row with the contract it was bound to. bigint fields (`date`,
+    // `hourlyRate`) are stringified — JSON can't carry bigints natively.
     await executeUpdateClaim({
       pathParams: { claimId: props.weeklyClaim.id },
       queryParams: { action: 'sign' },
-      body: { signature }
+      body: {
+        signature,
+        signedAgainstContractAddress: cashRemunerationAddress.value as Address,
+        chainId: chainId.value,
+        typedDataMessage: {
+          employeeAddress: typedDataMessage.value.employeeAddress,
+          minutesWorked: typedDataMessage.value.minutesWorked,
+          date: typedDataMessage.value.date.toString(),
+          wages: typedDataMessage.value.wages.map((w) => ({
+            hourlyRate: w.hourlyRate.toString(),
+            tokenAddress: w.tokenAddress
+          }))
+        }
+      }
     })
 
     if (claimError.value) {

--- a/app/src/components/sections/CashRemunerationView/SubmitClaims.vue
+++ b/app/src/components/sections/CashRemunerationView/SubmitClaims.vue
@@ -118,13 +118,11 @@ watch(
   { immediate: true }
 )
 
-// Freeze new submissions while the team is still on the previous Officer
-// generation (issue #1825). Withdrawals on already-signed rows remain
-// enabled because the old contract is still live on-chain.
-const isTeamMigrated = computed(() => teamStore.currentTeamMeta.data?.isMigrated !== false)
-
+// Submissions stay enabled while the team is on the previous Officer
+// generation (issue #1825): submitting only creates a `pending` row that
+// the approver can sign once the team migrates. Only the sign action is
+// frozen — see CRSigne.vue.
 const canSubmitClaim = computed(() => {
-  if (!isTeamMigrated.value) return false
   if (!props.weeklyClaim) return true
 
   return props.weeklyClaim.status === 'pending'

--- a/app/src/components/sections/CashRemunerationView/SubmitClaims.vue
+++ b/app/src/components/sections/CashRemunerationView/SubmitClaims.vue
@@ -118,7 +118,13 @@ watch(
   { immediate: true }
 )
 
+// Freeze new submissions while the team is still on the previous Officer
+// generation (issue #1825). Withdrawals on already-signed rows remain
+// enabled because the old contract is still live on-chain.
+const isTeamMigrated = computed(() => teamStore.currentTeamMeta.data?.isMigrated !== false)
+
 const canSubmitClaim = computed(() => {
+  if (!isTeamMigrated.value) return false
   if (!props.weeklyClaim) return true
 
   return props.weeklyClaim.status === 'pending'

--- a/app/src/components/sections/CashRemunerationView/__tests__/CRSigne.migration.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/__tests__/CRSigne.migration.spec.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import CRSigne from '../CRSigne.vue'
+import { createPinia, setActivePinia } from 'pinia'
+import type { WeeklyClaim, ContractType } from '@/types'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import isoWeek from 'dayjs/plugin/isoWeek'
+import {
+  mockCashRemunerationWrites,
+  mockTeamStore,
+  mockUserStore,
+  mockUseReadContract,
+  mockUseSignTypedData,
+  mockWagmiCore
+} from '@/tests/mocks'
+import { createMockMutationResponse } from '@/tests/mocks/query.mock'
+import { useUpdateWeeklyClaimMutation } from '@/queries'
+
+vi.mock('@/composables/cashRemuneration/writes', () => ({
+  useEnableClaim: vi.fn(() => mockCashRemunerationWrites.enableClaim),
+  useDisableClaim: vi.fn(() => mockCashRemunerationWrites.disableClaim),
+  useWithdraw: vi.fn(() => mockCashRemunerationWrites.ownerWithdrawAllToBank),
+  useOwnerWithdrawAllToBank: vi.fn(() => mockCashRemunerationWrites.ownerWithdrawAllToBank)
+}))
+
+dayjs.extend(utc)
+dayjs.extend(isoWeek)
+
+// Migration-specific assertions for CRSigne (issue #1825). Kept in a separate
+// file from CRSigne.spec.ts so that file stays under the max-lines lint
+// cap; the mock setup is intentionally duplicated rather than extracted
+// because the original spec is already at the line limit.
+describe('CRSigne — issue #1825 sign payload + migration freeze', () => {
+  let wrapper: ReturnType<typeof mount>
+
+  const MOCK_OWNER_ADDRESS = '0x1234567890123456789012345678901234567890'
+  const MOCK_CONTRACT_ADDRESS = '0x9876543210987654321098765432109876543210'
+
+  const mockClaim: WeeklyClaim = {
+    id: 1,
+    status: 'pending',
+    hoursWorked: 480,
+    minutesWorked: 480,
+    createdAt: '2024-01-01T00:00:00Z',
+    wage: {
+      userAddress: MOCK_OWNER_ADDRESS,
+      ratePerHour: [{ type: 'native', amount: 10 }],
+      id: 0,
+      teamId: 0,
+      cashRatePerHour: 0,
+      tokenRatePerHour: 0,
+      usdcRatePerHour: 0,
+      maximumHoursPerWeek: 0,
+      nextWageId: null,
+      createdAt: '',
+      updatedAt: '',
+      disabled: false
+    },
+    weekStart: '2024-01-01T00:00:00Z',
+    data: { ownerAddress: MOCK_OWNER_ADDRESS },
+    memberAddress: MOCK_OWNER_ADDRESS,
+    teamId: 0,
+    signature: null,
+    signedAgainstContractAddress: null,
+    wageId: 0,
+    updatedAt: '',
+    claims: []
+  }
+
+  type WrapperProps = {
+    weeklyClaim: WeeklyClaim
+    disabled?: boolean
+    isDropDown?: boolean
+    isResign?: boolean
+  }
+
+  const createWrapper = (props: Partial<WrapperProps> = {}) => {
+    wrapper = mount(CRSigne, {
+      props: { weeklyClaim: mockClaim, ...props }
+    })
+    return wrapper
+  }
+
+  const clickApprove = async () => {
+    await wrapper.find('[data-test="approve-button"]').trigger('click')
+    await flushPromises()
+  }
+
+  const setSignTypedDataResult = (signature: string | null) => {
+    mockUseSignTypedData.data.value = signature as string
+    if (signature) mockUseSignTypedData.mutateAsync.mockResolvedValue(signature)
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+
+    mockTeamStore.getContractAddressByType = vi.fn((type: ContractType) => {
+      if (type === 'CashRemunerationEIP712') return MOCK_CONTRACT_ADDRESS
+      if (type === 'InvestorV1') return '0x1111111111111111111111111111111111111111'
+      return ''
+    })
+    mockTeamStore.currentTeam = {
+      id: '1',
+      name: 'Test Team',
+      description: 'Test Description',
+      ownerAddress: MOCK_OWNER_ADDRESS,
+      members: [],
+      isMigrated: true,
+      teamContracts: [
+        {
+          type: 'CashRemunerationEIP712',
+          address: MOCK_CONTRACT_ADDRESS,
+          deployer: MOCK_OWNER_ADDRESS,
+          admins: []
+        }
+      ]
+    }
+    mockTeamStore.currentTeamMeta = {
+      isPending: false,
+      data: mockTeamStore.currentTeam
+    } as typeof mockTeamStore.currentTeamMeta
+
+    mockUserStore.address = MOCK_OWNER_ADDRESS
+    mockUseReadContract.data.value = MOCK_OWNER_ADDRESS
+    mockUseReadContract.error.value = null
+    setSignTypedDataResult('0xsignature')
+    mockWagmiCore.readContract.mockReset()
+  })
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount()
+  })
+
+  it('sends signedAgainstContractAddress + chainId + typedDataMessage with the sign request', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useUpdateWeeklyClaimMutation).mockReturnValueOnce({
+      ...createMockMutationResponse(),
+      mutateAsync
+    } as ReturnType<typeof useUpdateWeeklyClaimMutation>)
+
+    createWrapper()
+    await clickApprove()
+
+    expect(mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryParams: { action: 'sign' },
+        body: expect.objectContaining({
+          signature: '0xsignature',
+          signedAgainstContractAddress: MOCK_CONTRACT_ADDRESS,
+          chainId: expect.any(Number),
+          typedDataMessage: expect.objectContaining({
+            employeeAddress: MOCK_OWNER_ADDRESS,
+            minutesWorked: mockClaim.minutesWorked,
+            date: expect.stringMatching(/^\d+$/),
+            wages: expect.arrayContaining([
+              expect.objectContaining({
+                hourlyRate: expect.stringMatching(/^\d+$/),
+                tokenAddress: expect.any(String)
+              })
+            ])
+          })
+        })
+      })
+    )
+  })
+
+  it('disables the approve button when the team is not migrated', () => {
+    mockTeamStore.currentTeamMeta = {
+      isPending: false,
+      data: { ...mockTeamStore.currentTeam, isMigrated: false }
+    } as typeof mockTeamStore.currentTeamMeta
+
+    createWrapper()
+    const button = wrapper.find('[data-test="approve-button"]')
+    expect(button.exists()).toBe(true)
+    expect(button.attributes('disabled')).toBeDefined()
+  })
+
+  it('marks the dropdown sign action aria-disabled when the team is not migrated', () => {
+    mockTeamStore.currentTeamMeta = {
+      isPending: false,
+      data: { ...mockTeamStore.currentTeam, isMigrated: false }
+    } as typeof mockTeamStore.currentTeamMeta
+
+    createWrapper({ isDropDown: true })
+    const action = wrapper.find('[data-test="sign-action"]')
+    expect(action.attributes('aria-disabled')).toBe('true')
+  })
+})

--- a/app/src/components/sections/CashRemunerationView/__tests__/SubmitClaims.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/__tests__/SubmitClaims.spec.ts
@@ -65,7 +65,7 @@ describe('SubmitClaims', () => {
     expect(submitButton.attributes('disabled')).toBeDefined()
   })
 
-  it('disables submit button when the team is not migrated (issue #1825)', () => {
+  it('keeps submit enabled on un-migrated teams (issue #1825 — submission is not frozen, only signing)', () => {
     const previous = mockTeamStore.currentTeamMeta
     mockTeamStore.currentTeamMeta = {
       isPending: false,
@@ -75,7 +75,7 @@ describe('SubmitClaims', () => {
     try {
       const wrapper = createComponent({ weeklyClaim: { status: 'pending' } })
       const submitButton = wrapper.find('[data-test="modal-submit-hours-button"]')
-      expect(submitButton.attributes('disabled')).toBeDefined()
+      expect(submitButton.attributes('disabled')).toBeUndefined()
     } finally {
       mockTeamStore.currentTeamMeta = previous
     }

--- a/app/src/components/sections/CashRemunerationView/__tests__/SubmitClaims.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/__tests__/SubmitClaims.spec.ts
@@ -65,6 +65,22 @@ describe('SubmitClaims', () => {
     expect(submitButton.attributes('disabled')).toBeDefined()
   })
 
+  it('disables submit button when the team is not migrated (issue #1825)', () => {
+    const previous = mockTeamStore.currentTeamMeta
+    mockTeamStore.currentTeamMeta = {
+      isPending: false,
+      data: { ...previous.data, isMigrated: false }
+    } as typeof mockTeamStore.currentTeamMeta
+
+    try {
+      const wrapper = createComponent({ weeklyClaim: { status: 'pending' } })
+      const submitButton = wrapper.find('[data-test="modal-submit-hours-button"]')
+      expect(submitButton.attributes('disabled')).toBeDefined()
+    } finally {
+      mockTeamStore.currentTeamMeta = previous
+    }
+  })
+
   it('shows success toast and resets form after successful claim submission', async () => {
     const wrapper = createComponent()
 

--- a/app/src/components/sections/WeeklyClaimView/WeeklyClaim.vue
+++ b/app/src/components/sections/WeeklyClaimView/WeeklyClaim.vue
@@ -88,6 +88,16 @@
           >
             {{ row.status.charAt(0).toUpperCase() + row.status.slice(1) }}
           </span>
+          <!-- Surface stale signatures (signed against a previous Officer's
+               CashRemunerationEIP712) so the approver knows a Re-sign is
+               required before withdrawal works on the current contract. -->
+          <span
+            v-if="isStaleSignature(row)"
+            class="ml-2 rounded-2xl border-2 border-amber-500 bg-amber-50 px-3 py-1 text-sm text-amber-700"
+            data-test="needs-resigning-badge"
+          >
+            Needs re-signing
+          </span>
         </template>
         <template v-else-if="!row.status || row.status === 'pending'">
           <span
@@ -149,6 +159,20 @@ const props = defineProps<{
 
 function assertWeeklyClaimRow(row: unknown): WeeklyClaim {
   return row as WeeklyClaim
+}
+
+const currentCashRemunerationAddress = computed(() =>
+  teamStore.getContractAddressByType('CashRemunerationEIP712')
+)
+
+// True iff the row's stored verifying contract diverges from the team's
+// current CashRemunerationEIP712. Drives the "needs re-signing" badge —
+// see WeeklyClaimActionDropdown.vue for the matching action swap.
+function isStaleSignature(row: WeeklyClaim): boolean {
+  const signedAgainst = row.signedAgainstContractAddress
+  const current = currentCashRemunerationAddress.value
+  if (!signedAgainst || !current) return false
+  return signedAgainst.toLowerCase() !== current.toLowerCase()
 }
 
 const { data: fetchedData, error } = useGetTeamWeeklyClaimsQuery({

--- a/app/src/components/sections/WeeklyClaimView/WeeklyClaimActionDropdown.vue
+++ b/app/src/components/sections/WeeklyClaimView/WeeklyClaimActionDropdown.vue
@@ -23,9 +23,24 @@
         </li>
       </template>
 
-      <!-- Signed status: Withdraw and Disable -->
+      <!-- Signed status: Withdraw and Disable.
+           If the row's signature is bound to a stale CashRemunerationEIP712
+           (post-redeploy), withdraw is meaningless on the new contract — show
+           Re-sign instead so the approver re-binds against the current one. -->
       <template v-else-if="status === 'signed'">
-        <li data-test="signed-withdraw" :class="{ disabled: !isClaimOwner }">
+        <li
+          v-if="isStaleSignature"
+          data-test="signed-resign"
+          :class="{ disabled: !isCashRemunerationOwner }"
+        >
+          <CRSigne
+            :weekly-claim="weeklyClaim"
+            :is-drop-down="true"
+            :is-resign="true"
+            @close="isOpen = false"
+          />
+        </li>
+        <li v-else data-test="signed-withdraw" :class="{ disabled: !isClaimOwner }">
           <CRWithdrawClaim
             :weekly-claim="weeklyClaim"
             :is-drop-down="true"
@@ -153,6 +168,19 @@ const {
 })
 
 const isCashRemunerationOwner = computed(() => userStore.address === cashRemunerationOwner.value)
+
+// A `signed` row whose stored verifying contract no longer matches the
+// team's current CashRemunerationEIP712 was bound to a pre-redeploy
+// generation. The on-chain contract for that signature is still live (so
+// in theory withdrawable), but for issue #1825 the UX choice is: surface
+// stale rows as "needs re-signing" and route the action to Re-sign instead
+// of Withdraw, so the approver re-binds against the current contract.
+const isStaleSignature = computed(() => {
+  const signedAgainst = props.weeklyClaim.signedAgainstContractAddress
+  const current = cashRemunerationAddress.value
+  if (!signedAgainst || !current) return false
+  return signedAgainst.toLowerCase() !== current.toLowerCase()
+})
 
 const { mutateAsync: syncWeeklyClaim } = useSyncWeeklyClaimsMutation()
 

--- a/app/src/components/sections/WeeklyClaimView/__tests__/WeeklyClaimActionDropdown.spec.ts
+++ b/app/src/components/sections/WeeklyClaimView/__tests__/WeeklyClaimActionDropdown.spec.ts
@@ -69,11 +69,11 @@ describe('WeeklyClaimActionDropdown', () => {
     )
   }
 
-  const createWrapper = (status: Status = 'pending') => {
+  const createWrapper = (status: Status = 'pending', overrides: Partial<WeeklyClaim> = {}) => {
     return mount(DropdownActions, {
       props: {
         status,
-        weeklyClaim
+        weeklyClaim: { ...weeklyClaim, ...overrides }
       },
       global: {
         stubs: {
@@ -182,6 +182,30 @@ describe('WeeklyClaimActionDropdown', () => {
 
     await wrapper.find('[data-test="withdraw-action"]').trigger('click')
     expect(wrapper.find('ul').exists()).toBe(false)
+  })
+
+  it('swaps Withdraw → Re-sign for stale signed rows (issue #1825)', async () => {
+    // Stored signature is bound to a contract that doesn't match the team's
+    // current CashRemunerationEIP712 — Re-sign is the only meaningful action.
+    const wrapper = createWrapper('signed', {
+      signedAgainstContractAddress: '0x000000000000000000000000000000000000dead'
+    })
+    await wrapper.find('button').trigger('click')
+
+    expect(wrapper.find('[data-test="signed-resign"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="signed-withdraw"]').exists()).toBe(false)
+  })
+
+  it('keeps Withdraw on signed rows whose signature matches the current contract', async () => {
+    const current = '0x6666666666666666666666666666666666666666'
+    mockTeamStore.getContractAddressByType.mockReturnValue(current)
+    const wrapper = createWrapper('signed', {
+      signedAgainstContractAddress: current
+    })
+    await wrapper.find('button').trigger('click')
+
+    expect(wrapper.find('[data-test="signed-resign"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="signed-withdraw"]').exists()).toBe(true)
   })
 
   it('closes menu when the disabled resign child emits close', async () => {

--- a/app/src/queries/weeklyClaim.queries.ts
+++ b/app/src/queries/weeklyClaim.queries.ts
@@ -157,6 +157,21 @@ export interface UpdateWeeklyClaimParams {
   body?: {
     /** Signature (required only for 'sign' action) */
     signature?: string
+    /**
+     * EIP-712 verifyingContract address that the signature was produced
+     * against. Required for 'sign' so the backend can authenticate the
+     * signature and tag the row for stale-detection (issue #1825).
+     */
+    signedAgainstContractAddress?: Address
+    /** Signed typed-data message envelope (required for 'sign'). */
+    typedDataMessage?: {
+      employeeAddress: Address
+      minutesWorked: number
+      date: string
+      wages: Array<{ hourlyRate: string; tokenAddress: Address }>
+    }
+    /** Chain ID the signature was produced on (required for 'sign'). */
+    chainId?: number
   }
 }
 

--- a/app/src/tests/mocks/query.mock.ts
+++ b/app/src/tests/mocks/query.mock.ts
@@ -55,10 +55,12 @@ export const mockTeamData: Team = {
     deployBlockNumber: null,
     deployedAt: null,
     previousOfficerId: null,
+    version: 'v0.10',
     previousOfficer: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString()
-  }
+  },
+  isMigrated: true
 }
 
 export const mockTeamsData: Team[] = [mockTeamData]
@@ -138,6 +140,7 @@ export const mockWeeklyClaimData: WeeklyClaim[] = [
     minutesWorked: 2400,
     data: {},
     signature: null,
+    signedAgainstContractAddress: null,
     wageId: 1,
     wage: mockWageData[0] as Wage,
     claims: [

--- a/app/src/types/cash-remuneration.ts
+++ b/app/src/types/cash-remuneration.ts
@@ -76,6 +76,13 @@ export interface WeeklyClaim {
   memberAddress: Address
   teamId: number
   signature: string | null
+  /**
+   * EIP-712 verifying contract address the signature was bound to. Set at
+   * sign time and compared against the team's current CashRemunerationEIP712
+   * to detect stale signatures after a contract redeploy. Null on legacy
+   * rows signed before this column existed.
+   */
+  signedAgainstContractAddress: Address | null
   wageId: number
   createdAt: string // ISO date string
   updatedAt: string // ISO date string

--- a/app/src/types/team.ts
+++ b/app/src/types/team.ts
@@ -16,6 +16,12 @@ export interface CurrentOfficer {
   deployedAt: string | null
   previousOfficerId: number | null
   /**
+   * Officer-generation tag stamped at deploy time. 'v0.10' means the team
+   * was deployed against the current CashRemunerationEIP712 typehash;
+   * 'legacy' means it predates that. Drives `Team.isMigrated`.
+   */
+  version: string | null
+  /**
    * Minimal ref to the Officer the current one points back to. Use
    * `previousOfficer.address` to read state off the old Officer generation
    * (e.g. shareholder migration).
@@ -32,6 +38,13 @@ export interface Team {
   members: Member[]
   ownerAddress: Address
   currentOfficer?: CurrentOfficer | null
+  /**
+   * True iff `currentOfficer.version === 'v0.10'`. Derived backend-side and
+   * surfaced here so the UI can freeze new sign/submit flows while a team
+   * is still on the previous CashRemunerationEIP712 contract version
+   * (issue #1825).
+   */
+  isMigrated?: boolean
   safeAddress?: Address
   teamContracts: TeamContract[]
   _count?: { members: number }

--- a/app/src/views/team/[id]/Accounts/CashRemunerationView.vue
+++ b/app/src/views/team/[id]/Accounts/CashRemunerationView.vue
@@ -1,5 +1,15 @@
 <template>
   <div class="flex flex-col gap-6">
+    <UAlert
+      v-if="showMigrationBanner"
+      color="warning"
+      variant="subtle"
+      icon="i-heroicons-exclamation-triangle"
+      title="This team is on the previous contract version"
+      description="Redeploy the team contracts to enable new claim signatures. Existing signed claims can still be withdrawn."
+      data-test="cash-remuneration-migration-banner"
+    />
+
     <CashRemunerationOverview />
 
     <div class="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
@@ -41,4 +51,13 @@ const teamStore = useTeamStore()
 const cashRemunerationAddress = computed(() =>
   teamStore.getContractAddressByType('CashRemunerationEIP712')
 )
+
+// Surface the migration warning only once we have a team payload — the banner
+// would otherwise flash on initial load before isMigrated resolves. Teams
+// with no Officer at all also report `isMigrated: false`; we still want the
+// banner there so the owner is nudged to deploy contracts.
+const showMigrationBanner = computed(() => {
+  const team = teamStore.currentTeamMeta.data
+  return team !== undefined && team !== null && team.isMigrated === false
+})
 </script>

--- a/app/src/views/team/[id]/__tests__/CashRemunerationView.spec.ts
+++ b/app/src/views/team/[id]/__tests__/CashRemunerationView.spec.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { shallowMount } from '@vue/test-utils'
 import CashRemunerationView from '../Accounts/CashRemunerationView.vue'
 import { createTestingPinia } from '@pinia/testing'
+import { mockTeamStore } from '@/tests/mocks'
 
 describe('CashRemunerationView.vue', () => {
   const createComponent = () => {
@@ -11,6 +12,12 @@ describe('CashRemunerationView.vue', () => {
       }
     })
   }
+
+  const originalTeamMeta = mockTeamStore.currentTeamMeta
+
+  afterEach(() => {
+    mockTeamStore.currentTeamMeta = originalTeamMeta
+  })
 
   it('should pass correct props to GenericTokenHoldingsSection', () => {
     const wrapper = createComponent()
@@ -29,5 +36,20 @@ describe('CashRemunerationView.vue', () => {
     const overview = wrapper.findComponent({ name: 'CashRemunerationOverview' })
 
     expect(overview.exists()).toBeTruthy()
+  })
+
+  it('hides the migration banner when the team is migrated', () => {
+    const wrapper = createComponent()
+    expect(wrapper.find('[data-test="cash-remuneration-migration-banner"]').exists()).toBe(false)
+  })
+
+  it('shows the migration banner when the team is not migrated (issue #1825)', () => {
+    mockTeamStore.currentTeamMeta = {
+      isPending: false,
+      data: { ...originalTeamMeta.data, isMigrated: false }
+    } as typeof mockTeamStore.currentTeamMeta
+
+    const wrapper = createComponent()
+    expect(wrapper.find('[data-test="cash-remuneration-migration-banner"]').exists()).toBe(true)
   })
 })

--- a/backend/prisma/migrations/20260427120000_officer_version_and_signed_against_address/migration.sql
+++ b/backend/prisma/migrations/20260427120000_officer_version_and_signed_against_address/migration.sql
@@ -1,0 +1,22 @@
+-- Smooth-migration support for the v0.10 CashRemunerationEIP712 redeploy
+-- (issue #1825). Two concerns are folded into one migration because they
+-- ship as a single feature:
+--
+-- 1) `TeamOfficer.version` tags an Officer generation. New deploys (created
+--    via createOfficer / syncContracts after this migration lands) are
+--    stamped 'v0.10'. Pre-existing rows are backfilled to 'legacy' so the
+--    UI can derive `isMigrated = currentOfficer.version === 'v0.10'` and
+--    freeze new sign/submit flows on un-migrated teams.
+--
+-- 2) `WeeklyClaim.signedAgainstContractAddress` captures the EIP-712
+--    verifyingContract that a signature was bound to. With this column, a
+--    `signed` row whose stored address no longer matches the team's current
+--    CashRemunerationEIP712 is trivially derivable as stale, surfaced as
+--    "needs re-signing" in the UI, and re-signed against the new contract
+--    without a transactional sweep at redeploy time.
+
+ALTER TABLE "TeamOfficer" ADD COLUMN "version" TEXT;
+
+UPDATE "TeamOfficer" SET "version" = 'legacy' WHERE "version" IS NULL;
+
+ALTER TABLE "WeeklyClaim" ADD COLUMN "signedAgainstContractAddress" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -132,6 +132,11 @@ model WeeklyClaim {
   teamId        Int
   team          Team     @relation(fields: [teamId], references: [id], onDelete: Cascade)
   signature     String?
+  // EIP-712 verifying contract address the signature was bound to. Populated
+  // at sign time so `signed` rows can be classified as stale (and surfaced
+  // for re-signing) when the team's CashRemunerationEIP712 contract is later
+  // redeployed. Nullable for legacy rows signed before this column existed.
+  signedAgainstContractAddress String?
   claims        Claim[]  @relation("WeeklyClaimToClaims")
   wageId        Int
   wage          Wage     @relation(fields: [wageId], references: [id], onDelete: Cascade)
@@ -181,6 +186,12 @@ model TeamOfficer {
   deployer          String
   deployBlockNumber BigInt?
   deployedAt        DateTime?
+  // Officer-generation tag. New deploys land as 'v0.10' (the
+  // CashRemunerationEIP712 minutesWorked typehash); legacy rows backfilled
+  // to 'legacy'. Used to derive `isMigrated` on the Team payload so the UI
+  // can freeze new sign/submit flows on teams still on the previous
+  // contract version. Nullable to keep schema rollouts safe.
+  version           String?
   // Linked list: each row points back to its predecessor. The current Officer
   // for a team is the row with no nextOfficer (no successor exists).
   previousOfficerId Int?           @unique

--- a/backend/src/controllers/__tests__/contractController.test.ts
+++ b/backend/src/controllers/__tests__/contractController.test.ts
@@ -488,6 +488,7 @@ describe('contractController', () => {
             teamId: 1,
             deployBlockNumber: 12345,
             previousOfficerId: 7,
+            version: 'v0.10',
           }),
         })
       );

--- a/backend/src/controllers/__tests__/teamController.test.ts
+++ b/backend/src/controllers/__tests__/teamController.test.ts
@@ -286,6 +286,61 @@ describe('Team Controller', () => {
       // expect(response.body).toEqual(teamMockResolve);
     });
 
+    it('exposes isMigrated=true when current officer is on CURRENT_OFFICER_VERSION', async () => {
+      vi.spyOn(prisma.team, 'findUnique').mockResolvedValue({
+        ...teamMockResolve,
+        teamOfficers: [
+          {
+            id: 7,
+            address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            teamId: 1,
+            deployer: mockOwner.address,
+            deployBlockNumber: null,
+            deployedAt: null,
+            previousOfficerId: null,
+            version: 'v0.10',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            previousOfficer: null,
+            contracts: [],
+          },
+        ],
+        teamContracts: [],
+      } as never);
+
+      const response = await request(app).get('/1');
+      expect(response.status).toBe(200);
+      expect(response.body.isMigrated).toBe(true);
+      expect(response.body.currentOfficer?.version).toBe('v0.10');
+    });
+
+    it('exposes isMigrated=false when current officer is legacy', async () => {
+      vi.spyOn(prisma.team, 'findUnique').mockResolvedValue({
+        ...teamMockResolve,
+        teamOfficers: [
+          {
+            id: 7,
+            address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            teamId: 1,
+            deployer: mockOwner.address,
+            deployBlockNumber: null,
+            deployedAt: null,
+            previousOfficerId: null,
+            version: 'legacy',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            previousOfficer: null,
+            contracts: [],
+          },
+        ],
+        teamContracts: [],
+      } as never);
+
+      const response = await request(app).get('/1');
+      expect(response.status).toBe(200);
+      expect(response.body.isMigrated).toBe(false);
+    });
+
     it('should return 500 if an exception is thrown', async () => {
       vi.spyOn(prisma.team, 'findUnique').mockRejectedValue(new Error('DB failure'));
 
@@ -336,7 +391,11 @@ describe('Team Controller', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(
-        mockTeams.map(({ teamOfficers: _teamOfficers, ...t }) => ({ ...t, currentOfficer: null }))
+        mockTeams.map(({ teamOfficers: _teamOfficers, ...t }) => ({
+          ...t,
+          currentOfficer: null,
+          isMigrated: false,
+        }))
       );
       expect(prisma.team.findMany).toHaveBeenCalledWith({
         include: {
@@ -376,7 +435,11 @@ describe('Team Controller', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(
-        mockTeams.map(({ teamOfficers: _teamOfficers, ...t }) => ({ ...t, currentOfficer: null }))
+        mockTeams.map(({ teamOfficers: _teamOfficers, ...t }) => ({
+          ...t,
+          currentOfficer: null,
+          isMigrated: false,
+        }))
       );
       expect(prisma.team.findMany).toHaveBeenCalledWith({
         where: { members: { some: { address: mockOwner.address } } },

--- a/backend/src/controllers/__tests__/weeklyClaimController.test.ts
+++ b/backend/src/controllers/__tests__/weeklyClaimController.test.ts
@@ -4,9 +4,28 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import weeklyClaimRoutes from '../../routes/weeklyClaimRoute';
 import { prisma } from '../../utils';
 import { isCashRemunerationOwner } from '../../utils/cashRemunerationUtil';
-import type { Address } from 'viem';
+import { recoverTypedDataAddress, type Address } from 'viem';
 
 const CALLER = '0x1234567890123456789012345678901234567890';
+const CASH_REMUNERATION_ADDRESS = '0xcacacacacacacacacacacacacacacacacacacaca';
+// Valid EIP-712 sign body. Tests start from this and override fields to
+// exercise individual validation branches.
+const VALID_SIGN_BODY = {
+  signature: '0xabc',
+  signedAgainstContractAddress: CASH_REMUNERATION_ADDRESS,
+  chainId: 31337,
+  typedDataMessage: {
+    employeeAddress: '0x1111111111111111111111111111111111111111',
+    minutesWorked: 60,
+    date: '1700000000',
+    wages: [
+      {
+        hourlyRate: '1000000000000000000',
+        tokenAddress: '0x0000000000000000000000000000000000000000',
+      },
+    ],
+  },
+};
 
 const { mockGetPresignedDownloadUrl } = vi.hoisted(() => ({
   mockGetPresignedDownloadUrl: vi.fn(
@@ -39,6 +58,19 @@ vi.mock('../../utils/cashRemunerationUtil', () => ({
 vi.mock('../../utils/viem.config', () => ({
   default: { readContract: readContractMock },
 }));
+
+// Mock viem's recoverTypedDataAddress so tests can drive the recovery result
+// (matching CALLER vs mismatch vs throw) without producing real signatures.
+// vi.mock is hoisted; the inline 0x1234...7890 mirrors the CALLER constant.
+vi.mock('viem', async () => {
+  const actual = await vi.importActual<typeof import('viem')>('viem');
+  return {
+    ...actual,
+    recoverTypedDataAddress: vi
+      .fn()
+      .mockResolvedValue('0x1234567890123456789012345678901234567890'),
+  };
+});
 
 vi.mock('../../utils', async () => {
   const actual = await vi.importActual('../../utils');
@@ -89,13 +121,25 @@ const weeklyClaimFactory = (overrides: Record<string, unknown> = {}) => ({
 const putAction = (
   action: string,
   id = '1',
-  body: Record<string, unknown> = { signature: '0xabc' }
+  body: Record<string, unknown> = action === 'sign' ? VALID_SIGN_BODY : { signature: '0xabc' }
 ) => request(app).put(`/${id}?action=${action}`).send(body);
 
 describe('Weekly Claim Controller', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(isCashRemunerationOwner).mockResolvedValue(true);
+    // Default: the team's current CashRemunerationEIP712 matches what the
+    // sign body declares it signed against. Individual tests can override
+    // to exercise the mismatch branch.
+    vi.mocked(prisma.teamContract.findFirst).mockResolvedValue({
+      id: 1,
+      teamId: 1,
+      type: 'CashRemunerationEIP712',
+      address: CASH_REMUNERATION_ADDRESS,
+    } as never);
+    // Default: signature recovers to the caller. Individual tests override
+    // to exercise the mismatch / throw branches.
+    vi.mocked(recoverTypedDataAddress).mockResolvedValue(CALLER as Address);
   });
 
   describe('PUT /:id', () => {
@@ -220,9 +264,93 @@ describe('Weekly Claim Controller', () => {
     });
 
     it('should return 400 for missing signature on sign', async () => {
-      const response = await putAction('sign', '1', {});
+      const response = await putAction('sign', '1', { ...VALID_SIGN_BODY, signature: undefined });
       expect(response.status).toBe(400);
-      expect(response.body).toEqual({ message: 'Missing or invalid signature' });
+      expect(response.body.message).toContain('Missing or invalid signature');
+    });
+
+    it.each([
+      {
+        title: 'missing signedAgainstContractAddress',
+        body: { ...VALID_SIGN_BODY, signedAgainstContractAddress: undefined },
+        message: 'Missing or invalid signedAgainstContractAddress',
+      },
+      {
+        title: 'missing typedDataMessage',
+        body: { ...VALID_SIGN_BODY, typedDataMessage: undefined },
+        message: 'Missing typedDataMessage',
+      },
+      {
+        title: 'missing chainId',
+        body: { ...VALID_SIGN_BODY, chainId: undefined },
+        message: 'Missing or invalid chainId',
+      },
+    ])('should return 400 on sign for $title', async ({ body, message }) => {
+      const response = await putAction('sign', '1', body);
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain(message);
+    });
+
+    it('should return 400 on sign when signedAgainstContractAddress does not match team current', async () => {
+      vi.spyOn(prisma.weeklyClaim, 'findUnique').mockResolvedValue(
+        weeklyClaimFactory({ status: 'pending' }) as any
+      );
+      vi.mocked(prisma.teamContract.findFirst).mockResolvedValue({
+        id: 1,
+        teamId: 1,
+        type: 'CashRemunerationEIP712',
+        address: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      } as never);
+      const response = await putAction('sign');
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain(
+        'signedAgainstContractAddress does not match the team current CashRemunerationEIP712'
+      );
+    });
+
+    it('should return 400 on sign when recovered signer does not match caller', async () => {
+      vi.spyOn(prisma.weeklyClaim, 'findUnique').mockResolvedValue(
+        weeklyClaimFactory({ status: 'pending' }) as any
+      );
+      vi.mocked(recoverTypedDataAddress).mockResolvedValue(
+        '0x9999999999999999999999999999999999999999' as Address
+      );
+      const response = await putAction('sign');
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain('Recovered signer does not match the caller');
+    });
+
+    it('should return 400 on sign when recoverTypedDataAddress throws', async () => {
+      vi.spyOn(prisma.weeklyClaim, 'findUnique').mockResolvedValue(
+        weeklyClaimFactory({ status: 'pending' }) as any
+      );
+      vi.mocked(recoverTypedDataAddress).mockRejectedValue(new Error('bad sig'));
+      const response = await putAction('sign');
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain('Failed to verify signature');
+    });
+
+    it('should persist signedAgainstContractAddress on successful sign', async () => {
+      vi.spyOn(prisma.weeklyClaim, 'findUnique').mockResolvedValue(
+        weeklyClaimFactory({ status: 'pending' }) as any
+      );
+      const updateSpy = vi
+        .spyOn(prisma, '$transaction')
+        .mockResolvedValue([weeklyClaimFactory({ status: 'signed' }) as any]);
+      const updateMock = vi.spyOn(prisma.weeklyClaim, 'update').mockReturnValue({} as never);
+
+      const response = await putAction('sign');
+      expect(response.status).toBe(200);
+      expect(updateSpy).toHaveBeenCalled();
+      expect(updateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 1 },
+          data: expect.objectContaining({
+            status: 'signed',
+            signedAgainstContractAddress: CASH_REMUNERATION_ADDRESS,
+          }),
+        })
+      );
     });
 
     it('should return 404 if weekly claim is not found', async () => {

--- a/backend/src/controllers/__tests__/weeklyClaimController.test.ts
+++ b/backend/src/controllers/__tests__/weeklyClaimController.test.ts
@@ -760,9 +760,7 @@ describe('Weekly Claim Controller', () => {
       ] as any);
 
       readContractMock.mockReset();
-      const updateSpy = vi
-        .spyOn(prisma.weeklyClaim, 'update')
-        .mockResolvedValue({} as any);
+      const updateSpy = vi.spyOn(prisma.weeklyClaim, 'update').mockResolvedValue({} as any);
 
       const response = await request(app).post('/sync?teamId=1');
 

--- a/backend/src/controllers/__tests__/weeklyClaimController.test.ts
+++ b/backend/src/controllers/__tests__/weeklyClaimController.test.ts
@@ -3,7 +3,10 @@ import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import weeklyClaimRoutes from '../../routes/weeklyClaimRoute';
 import { prisma } from '../../utils';
-import { isCashRemunerationOwner } from '../../utils/cashRemunerationUtil';
+import {
+  getCurrentCashRemunerationContract,
+  isCashRemunerationOwner,
+} from '../../utils/cashRemunerationUtil';
 import { recoverTypedDataAddress, type Address } from 'viem';
 
 const CALLER = '0x1234567890123456789012345678901234567890';
@@ -53,6 +56,15 @@ vi.mock('../../middleware/authMiddleware', () => ({
 
 vi.mock('../../utils/cashRemunerationUtil', () => ({
   isCashRemunerationOwner: vi.fn().mockResolvedValue(true),
+  // Default: helper returns the team's current CashRemunerationEIP712 — the
+  // address the sign body declares it signed against. Individual tests
+  // override to exercise the mismatch / missing branches.
+  getCurrentCashRemunerationContract: vi.fn().mockResolvedValue({
+    id: 1,
+    teamId: 1,
+    type: 'CashRemunerationEIP712',
+    address: '0xcacacacacacacacacacacacacacacacacacacaca',
+  }),
 }));
 
 vi.mock('../../utils/viem.config', () => ({
@@ -131,7 +143,7 @@ describe('Weekly Claim Controller', () => {
     // Default: the team's current CashRemunerationEIP712 matches what the
     // sign body declares it signed against. Individual tests can override
     // to exercise the mismatch branch.
-    vi.mocked(prisma.teamContract.findFirst).mockResolvedValue({
+    vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue({
       id: 1,
       teamId: 1,
       type: 'CashRemunerationEIP712',
@@ -295,12 +307,25 @@ describe('Weekly Claim Controller', () => {
       vi.spyOn(prisma.weeklyClaim, 'findUnique').mockResolvedValue(
         weeklyClaimFactory({ status: 'pending' }) as any
       );
-      vi.mocked(prisma.teamContract.findFirst).mockResolvedValue({
+      // Helper returns a different address than what the body declares.
+      vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue({
         id: 1,
         teamId: 1,
         type: 'CashRemunerationEIP712',
         address: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
       } as never);
+      const response = await putAction('sign');
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain(
+        'signedAgainstContractAddress does not match the team current CashRemunerationEIP712'
+      );
+    });
+
+    it('should return 400 on sign when there is no current CashRemunerationEIP712 (helper returns null)', async () => {
+      vi.spyOn(prisma.weeklyClaim, 'findUnique').mockResolvedValue(
+        weeklyClaimFactory({ status: 'pending' }) as any
+      );
+      vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(null);
       const response = await putAction('sign');
       expect(response.status).toBe(400);
       expect(response.body.message).toContain(
@@ -600,7 +625,7 @@ describe('Weekly Claim Controller', () => {
         contract: { ...validContract, address: 'not-an-eth-address' },
       },
     ])('should return 404 when $title', async ({ contract }) => {
-      vi.spyOn(prisma.teamContract, 'findFirst').mockResolvedValue(contract as any);
+      vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(contract as any);
       const response = await request(app).post('/sync?teamId=1');
       expect(response.status).toBe(404);
       expect(response.body).toEqual({
@@ -609,7 +634,7 @@ describe('Weekly Claim Controller', () => {
     });
 
     it('should return empty sync result when no weekly claims', async () => {
-      vi.spyOn(prisma.teamContract, 'findFirst').mockResolvedValue(validContract as any);
+      vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(validContract as any);
       vi.spyOn(prisma.weeklyClaim, 'findMany').mockResolvedValue([] as any);
 
       const response = await request(app).post('/sync?teamId=1');
@@ -618,7 +643,7 @@ describe('Weekly Claim Controller', () => {
     });
 
     it('should update status from signed to withdrawn when paid on-chain', async () => {
-      vi.spyOn(prisma.teamContract, 'findFirst').mockResolvedValue(validContract as any);
+      vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(validContract as any);
 
       vi.spyOn(prisma.weeklyClaim, 'findMany').mockResolvedValue([
         { id: 1, status: 'signed', signature: 'not-hex' },
@@ -642,7 +667,7 @@ describe('Weekly Claim Controller', () => {
     });
 
     it('should keep signed status when neither paid nor disabled', async () => {
-      vi.spyOn(prisma.teamContract, 'findFirst').mockResolvedValue(validContract as any);
+      vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(validContract as any);
       vi.spyOn(prisma.weeklyClaim, 'findMany').mockResolvedValue([
         { id: 7, status: 'signed', signature: '0xfeed' },
       ] as any);
@@ -657,7 +682,7 @@ describe('Weekly Claim Controller', () => {
     });
 
     it('should update with unknown previous status when claim.status is null', async () => {
-      vi.spyOn(prisma.teamContract, 'findFirst').mockResolvedValue(validContract as any);
+      vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(validContract as any);
       vi.spyOn(prisma.weeklyClaim, 'findMany').mockResolvedValue([
         { id: 8, status: null, signature: '0xface' },
       ] as any);
@@ -677,7 +702,7 @@ describe('Weekly Claim Controller', () => {
     });
 
     it('should skip claim on readContract error', async () => {
-      vi.spyOn(prisma.teamContract, 'findFirst').mockResolvedValue(validContract as any);
+      vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(validContract as any);
       vi.spyOn(prisma.weeklyClaim, 'findMany').mockResolvedValue([
         { id: 5, status: 'signed', signature: '0xdeadbeef' },
       ] as any);
@@ -692,7 +717,7 @@ describe('Weekly Claim Controller', () => {
     });
 
     it('should return 500 when sync setup throws', async () => {
-      vi.spyOn(prisma.teamContract, 'findFirst').mockResolvedValue(validContract as any);
+      vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(validContract as any);
       vi.spyOn(prisma.weeklyClaim, 'findMany').mockRejectedValue(new Error('Database failure'));
 
       const response = await request(app).post('/sync?teamId=1');

--- a/backend/src/controllers/__tests__/weeklyClaimController.test.ts
+++ b/backend/src/controllers/__tests__/weeklyClaimController.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import weeklyClaimRoutes from '../../routes/weeklyClaimRoute';
 import { prisma } from '../../utils';
+import { Prisma } from '@prisma/client';
 import {
   getCurrentCashRemunerationContract,
   isCashRemunerationOwner,
@@ -646,8 +647,18 @@ describe('Weekly Claim Controller', () => {
       vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(validContract as any);
 
       vi.spyOn(prisma.weeklyClaim, 'findMany').mockResolvedValue([
-        { id: 1, status: 'signed', signature: 'not-hex' },
-        { id: 2, status: 'signed', signature: '0xabcdef' },
+        {
+          id: 1,
+          status: 'signed',
+          signature: 'not-hex',
+          signedAgainstContractAddress: validContract.address,
+        },
+        {
+          id: 2,
+          status: 'signed',
+          signature: '0xabcdef',
+          signedAgainstContractAddress: validContract.address,
+        },
       ] as any);
 
       readContractMock.mockReset();
@@ -669,7 +680,12 @@ describe('Weekly Claim Controller', () => {
     it('should keep signed status when neither paid nor disabled', async () => {
       vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(validContract as any);
       vi.spyOn(prisma.weeklyClaim, 'findMany').mockResolvedValue([
-        { id: 7, status: 'signed', signature: '0xfeed' },
+        {
+          id: 7,
+          status: 'signed',
+          signature: '0xfeed',
+          signedAgainstContractAddress: validContract.address,
+        },
       ] as any);
 
       readContractMock.mockReset();
@@ -684,7 +700,12 @@ describe('Weekly Claim Controller', () => {
     it('should update with unknown previous status when claim.status is null', async () => {
       vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(validContract as any);
       vi.spyOn(prisma.weeklyClaim, 'findMany').mockResolvedValue([
-        { id: 8, status: null, signature: '0xface' },
+        {
+          id: 8,
+          status: null,
+          signature: '0xface',
+          signedAgainstContractAddress: validContract.address,
+        },
       ] as any);
 
       readContractMock.mockReset();
@@ -704,7 +725,12 @@ describe('Weekly Claim Controller', () => {
     it('should skip claim on readContract error', async () => {
       vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(validContract as any);
       vi.spyOn(prisma.weeklyClaim, 'findMany').mockResolvedValue([
-        { id: 5, status: 'signed', signature: '0xdeadbeef' },
+        {
+          id: 5,
+          status: 'signed',
+          signature: '0xdeadbeef',
+          signedAgainstContractAddress: validContract.address,
+        },
       ] as any);
 
       readContractMock.mockReset();
@@ -714,6 +740,76 @@ describe('Weekly Claim Controller', () => {
       expect(response.status).toBe(200);
       expect(response.body.updated).toEqual([]);
       expect(response.body.skipped).toEqual([{ id: 5, reason: 'Failed to read contract state' }]);
+    });
+
+    it('should reset to pending when claim was signed against a previous contract', async () => {
+      vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(validContract as any);
+      vi.spyOn(prisma.weeklyClaim, 'findMany').mockResolvedValue([
+        {
+          id: 21,
+          status: 'signed',
+          signature: '0xabcd',
+          signedAgainstContractAddress: '0x9999999999999999999999999999999999999999',
+        },
+        {
+          id: 22,
+          status: 'disabled',
+          signature: '0xef01',
+          signedAgainstContractAddress: null,
+        },
+      ] as any);
+
+      readContractMock.mockReset();
+      const updateSpy = vi
+        .spyOn(prisma.weeklyClaim, 'update')
+        .mockResolvedValue({} as any);
+
+      const response = await request(app).post('/sync?teamId=1');
+
+      expect(response.status).toBe(200);
+      expect(response.body.updated).toEqual([
+        { id: 21, previousStatus: 'signed', newStatus: 'pending' },
+        { id: 22, previousStatus: 'disabled', newStatus: 'pending' },
+      ]);
+      expect(readContractMock).not.toHaveBeenCalled();
+      expect(updateSpy).toHaveBeenCalledWith({
+        where: { id: 21 },
+        data: {
+          status: 'pending',
+          signature: null,
+          signedAgainstContractAddress: null,
+          data: Prisma.JsonNull,
+        },
+      });
+      expect(updateSpy).toHaveBeenCalledWith({
+        where: { id: 22 },
+        data: {
+          status: 'pending',
+          signature: null,
+          signedAgainstContractAddress: null,
+          data: Prisma.JsonNull,
+        },
+      });
+    });
+
+    it('should match signedAgainstContractAddress case-insensitively', async () => {
+      vi.mocked(getCurrentCashRemunerationContract).mockResolvedValue(validContract as any);
+      vi.spyOn(prisma.weeklyClaim, 'findMany').mockResolvedValue([
+        {
+          id: 30,
+          status: 'signed',
+          signature: '0xabcd',
+          signedAgainstContractAddress: validContract.address.toUpperCase(),
+        },
+      ] as any);
+
+      readContractMock.mockReset();
+      readContractMock.mockResolvedValueOnce(false).mockResolvedValueOnce(false);
+
+      const response = await request(app).post('/sync?teamId=1');
+      expect(response.status).toBe(200);
+      expect(response.body.updated).toEqual([]);
+      expect(readContractMock).toHaveBeenCalled();
     });
 
     it('should return 500 when sync setup throws', async () => {

--- a/backend/src/controllers/contractController.ts
+++ b/backend/src/controllers/contractController.ts
@@ -17,6 +17,13 @@ type SyncContractsBody = z.infer<typeof syncContractsBodySchema>;
 type CreateOfficerBody = z.infer<typeof createOfficerBodySchema>;
 type GetContractsQuery = z.infer<typeof getContractsQuerySchema>;
 
+// Officer-generation tag stamped on freshly registered Officers. Bumped when
+// the CashRemunerationEIP712 (or any other Officer-governed contract) ships a
+// breaking on-chain change — currently the WageClaim.hoursWorked →
+// minutesWorked typehash from PR #1816. The frontend reads this off the team
+// payload as `isMigrated` (true iff currentOfficer.version === this value).
+export const CURRENT_OFFICER_VERSION = 'v0.10';
+
 // Look up the head of a team's Officer linked list — the row with no
 // successor pointing back to it. Returns null if the team has never had an
 // Officer deployed.
@@ -48,6 +55,11 @@ const upsertOfficerAndSyncContracts = async (
   // registered to a different team (createOfficer performs that guard and
   // returns 409 explicitly; syncContracts passes the team's own current Officer
   // address, so a mismatch is impossible there).
+  //
+  // version: stamped 'v0.10' on insert. Existing rows (`update: {}`) keep
+  // whatever generation tag they already have — pre-feature rows backfilled
+  // to 'legacy' by the migration stay 'legacy' until a fresh Officer is
+  // deployed. This is what flips `isMigrated` for the team.
   const officer = await prisma.teamOfficer.upsert({
     where: { address: officerAddress },
     create: {
@@ -57,6 +69,7 @@ const upsertOfficerAndSyncContracts = async (
       deployBlockNumber: deployBlockNumber ?? null,
       deployedAt: deployedAt ?? null,
       previousOfficerId,
+      version: CURRENT_OFFICER_VERSION,
     },
     update: {},
   });

--- a/backend/src/controllers/teamController.ts
+++ b/backend/src/controllers/teamController.ts
@@ -4,6 +4,7 @@ import { isAddress } from 'viem';
 import { addNotification, prisma } from '../utils';
 import { errorResponse } from '../utils/utils';
 import { resolveStorageImageUrl } from '../utils/profileImage.util';
+import { CURRENT_OFFICER_VERSION } from './contractController';
 
 // Shared: include the immediate predecessor (id + address only) so clients
 // can walk one step back for copy-forward flows (e.g. shareholder migration)
@@ -53,14 +54,24 @@ export const serializeOfficer = (o: TeamOfficer | undefined | null) =>
       }
     : null;
 
+// True iff the current Officer was deployed with the CURRENT_OFFICER_VERSION
+// generation tag. Drives the frontend "team is on the previous contract
+// version" banner and freezes new-claim flows during the redeploy window
+// (issue #1825). Teams with no current Officer at all (never deployed)
+// surface `isMigrated: false`.
+const deriveIsMigrated = (officer: { version?: string | null } | null | undefined) =>
+  officer?.version === CURRENT_OFFICER_VERSION;
+
 // Pulls the head of the linked list out of an `include: currentOfficerInclude`
 // result and exposes it as `currentOfficer`. Removes the raw `teamOfficers`
 // array so consumers don't accidentally rely on the implementation detail.
 const withCurrentOfficer = <T extends { teamOfficers?: TeamOfficer[] }>(team: T) => {
   const { teamOfficers, ...rest } = team;
+  const head = teamOfficers?.[0] ?? null;
   return {
     ...rest,
-    currentOfficer: serializeOfficer(teamOfficers?.[0]),
+    currentOfficer: serializeOfficer(head),
+    isMigrated: deriveIsMigrated(head),
   };
 };
 
@@ -81,6 +92,7 @@ const withCurrentOfficerAndContracts = <
   return {
     ...rest,
     currentOfficer: serializeOfficer(head ? (headWithoutContracts as TeamOfficer) : null),
+    isMigrated: deriveIsMigrated(head ?? null),
     // Merge the current Officer's contracts with officer-less contracts
     // (Safe / SafeDepositRouter) so the client sees the full live set.
     teamContracts: [...contracts, ...(teamContracts ?? [])],

--- a/backend/src/controllers/weeklyClaimController.ts
+++ b/backend/src/controllers/weeklyClaimController.ts
@@ -3,7 +3,10 @@ import { errorResponse, getMondayStart, prisma } from '../utils';
 import { Prisma } from '@prisma/client';
 import { Address, Hex, isAddress, isHex, keccak256, recoverTypedDataAddress } from 'viem';
 import CASH_REMUNERATION_ABI from '../artifacts/cash_remuneration_eip712_abi.json';
-import { isCashRemunerationOwner } from '../utils/cashRemunerationUtil';
+import {
+  getCurrentCashRemunerationContract,
+  isCashRemunerationOwner,
+} from '../utils/cashRemunerationUtil';
 import publicClient from '../utils/viem.config';
 import { refreshAttachmentUrls } from '../services/attachmentService';
 
@@ -56,7 +59,7 @@ export const updateWeeklyClaims = async (req: Request, res: Response) => {
   // Validation stricte des actions autorisées
   const errors: string[] = [];
   if (!action || !isValidWeeklyClaimAction(action))
-    errors.push('Invalid action. Allowed actions are: sign, withdraw');
+    errors.push('Invalid action. Allowed actions are: sign, withdraw, disable, enable');
 
   if (action == 'sign') {
     if (!signature || !isHex(signature)) errors.push('Missing or invalid signature');
@@ -194,11 +197,17 @@ export const updateWeeklyClaims = async (req: Request, res: Response) => {
         }
 
         // The signed-against contract must be the team's current
-        // CashRemunerationEIP712. Reject otherwise so the row is never
-        // persisted with a signature bound to a stale or foreign contract.
-        const currentCashRemunerationContract = await prisma.teamContract.findFirst({
-          where: { teamId: weeklyClaim.wage.team.id, type: 'CashRemunerationEIP712' },
-        });
+        // CashRemunerationEIP712 — the one governed by the current Officer
+        // (linked-list head). Scoping via the helper rather than an
+        // unscoped findFirst is required because after an Officer redeploy
+        // the team has multiple TeamContract rows of this type and we
+        // would otherwise non-deterministically pick an archived one.
+        // `isCashRemunerationOwner` reads from the same helper, so the
+        // owner check above and this contract-match check are guaranteed
+        // to be looking at the same generation of the contract.
+        const currentCashRemunerationContract = await getCurrentCashRemunerationContract(
+          weeklyClaim.wage.team.id
+        );
         if (
           !currentCashRemunerationContract ||
           currentCashRemunerationContract.address.toLowerCase() !==
@@ -410,13 +419,10 @@ export const syncWeeklyClaims = async (req: Request, res: Response) => {
   const teamId = Number(req.query.teamId);
 
   try {
-    // authz enforced by requireTeamMember middleware
-    const teamContract = await prisma.teamContract.findFirst({
-      where: {
-        teamId,
-        type: 'CashRemunerationEIP712',
-      },
-    });
+    // authz enforced by requireTeamMember middleware. Scope to the current
+    // Officer so a redeployed team syncs against its live contract, not an
+    // archived one (multiple rows of the same type exist post-redeploy).
+    const teamContract = await getCurrentCashRemunerationContract(teamId);
 
     if (!teamContract || !teamContract.address || !isAddress(teamContract.address)) {
       return errorResponse(404, 'Cash Remuneration contract not found for the team', res);

--- a/backend/src/controllers/weeklyClaimController.ts
+++ b/backend/src/controllers/weeklyClaimController.ts
@@ -1,11 +1,28 @@
 import { Request, Response } from 'express';
 import { errorResponse, getMondayStart, prisma } from '../utils';
 import { Prisma } from '@prisma/client';
-import { Hex, isAddress, isHex, keccak256 } from 'viem';
+import { Address, Hex, isAddress, isHex, keccak256, recoverTypedDataAddress } from 'viem';
 import CASH_REMUNERATION_ABI from '../artifacts/cash_remuneration_eip712_abi.json';
 import { isCashRemunerationOwner } from '../utils/cashRemunerationUtil';
 import publicClient from '../utils/viem.config';
 import { refreshAttachmentUrls } from '../services/attachmentService';
+
+// EIP-712 typed-data envelope for the WageClaim signature, mirroring the
+// frontend definition in app/src/components/sections/CashRemunerationView/
+// CRSigne.vue. Mirrored (not imported) so a future tweak to the frontend
+// types triggers a backend change as well — that's the failure mode we want.
+const WAGE_CLAIM_TYPES = {
+  Wage: [
+    { name: 'hourlyRate', type: 'uint256' },
+    { name: 'tokenAddress', type: 'address' },
+  ],
+  WageClaim: [
+    { name: 'employeeAddress', type: 'address' },
+    { name: 'minutesWorked', type: 'uint16' },
+    { name: 'wages', type: 'Wage[]' },
+    { name: 'date', type: 'uint256' },
+  ],
+} as const;
 
 export type WeeklyClaimAction = 'sign' | 'withdraw' | 'disable' | 'enable';
 type statusType = 'pending' | 'signed' | 'withdrawn' | 'disabled';
@@ -24,15 +41,34 @@ export const updateWeeklyClaims = async (req: Request, res: Response) => {
   const callerAddress = req.address;
   const id = Number(req.params.id);
   const action = req.query.action as WeeklyClaimAction;
-  const { signature } = req.body;
+  const { signature, signedAgainstContractAddress, typedDataMessage, chainId } = req.body as {
+    signature?: string;
+    signedAgainstContractAddress?: string;
+    typedDataMessage?: {
+      employeeAddress: string;
+      minutesWorked: number;
+      date: string;
+      wages: { hourlyRate: string; tokenAddress: string }[];
+    };
+    chainId?: number;
+  };
 
   // Validation stricte des actions autorisées
   const errors: string[] = [];
   if (!action || !isValidWeeklyClaimAction(action))
     errors.push('Invalid action. Allowed actions are: sign, withdraw');
 
-  if (action == 'sign' && (!signature || !isHex(signature)))
-    errors.push('Missing or invalid signature');
+  if (action == 'sign') {
+    if (!signature || !isHex(signature)) errors.push('Missing or invalid signature');
+    // signedAgainstContractAddress + typedDataMessage + chainId are required
+    // for sign so the backend can authenticate the EIP-712 signature and
+    // tag the row with the verifying contract for stale-detection.
+    if (!signedAgainstContractAddress || !isAddress(signedAgainstContractAddress))
+      errors.push('Missing or invalid signedAgainstContractAddress');
+    if (!typedDataMessage) errors.push('Missing typedDataMessage');
+    if (!chainId || !Number.isInteger(chainId) || chainId <= 0)
+      errors.push('Missing or invalid chainId');
+  }
 
   if (!id || isNaN(id)) errors.push('Missing or invalid id');
 
@@ -157,9 +193,71 @@ export const updateWeeklyClaims = async (req: Request, res: Response) => {
           }
         }
 
+        // The signed-against contract must be the team's current
+        // CashRemunerationEIP712. Reject otherwise so the row is never
+        // persisted with a signature bound to a stale or foreign contract.
+        const currentCashRemunerationContract = await prisma.teamContract.findFirst({
+          where: { teamId: weeklyClaim.wage.team.id, type: 'CashRemunerationEIP712' },
+        });
+        if (
+          !currentCashRemunerationContract ||
+          currentCashRemunerationContract.address.toLowerCase() !==
+            (signedAgainstContractAddress as string).toLowerCase()
+        ) {
+          signErrors.push(
+            'signedAgainstContractAddress does not match the team current CashRemunerationEIP712'
+          );
+        }
+
+        // Authenticate the EIP-712 signature: rebuild the typed-data envelope
+        // from the body and recover the signer. Reject if it isn't the caller.
+        // viem's recoverTypedDataAddress handles the EIP-712 hash + ECDSA
+        // recovery; the bigint-coerced fields (`date`, `hourlyRate`) come back
+        // as strings on the wire.
+        let recovered: Address | null = null;
+        if (signErrors.length === 0) {
+          try {
+            recovered = await recoverTypedDataAddress({
+              domain: {
+                name: 'CashRemuneration',
+                version: '1',
+                chainId: chainId as number,
+                verifyingContract: signedAgainstContractAddress as Address,
+              },
+              types: WAGE_CLAIM_TYPES,
+              primaryType: 'WageClaim',
+              message: {
+                employeeAddress: typedDataMessage!.employeeAddress as Address,
+                minutesWorked: typedDataMessage!.minutesWorked,
+                wages: typedDataMessage!.wages.map((w) => ({
+                  hourlyRate: BigInt(w.hourlyRate),
+                  tokenAddress: w.tokenAddress as Address,
+                })),
+                date: BigInt(typedDataMessage!.date),
+              },
+              signature: signature as Hex,
+            });
+          } catch (err) {
+            console.error('Failed to recover signer for weeklyClaim sign:', err);
+            signErrors.push('Failed to verify signature');
+          }
+        }
+
+        if (
+          signErrors.length === 0 &&
+          (!recovered || recovered.toLowerCase() !== callerAddress.toLowerCase())
+        ) {
+          signErrors.push('Recovered signer does not match the caller');
+        }
+
         if (signErrors.length > 0) return errorResponse(400, signErrors.join('; '), res);
 
-        data = { signature, status: 'signed', data: { ownerAddress: callerAddress } };
+        data = {
+          signature,
+          status: 'signed',
+          data: { ownerAddress: callerAddress },
+          signedAgainstContractAddress,
+        };
         // singleClaimStatus = "signed";
         break;
       }

--- a/backend/src/controllers/weeklyClaimController.ts
+++ b/backend/src/controllers/weeklyClaimController.ts
@@ -439,6 +439,7 @@ export const syncWeeklyClaims = async (req: Request, res: Response) => {
         id: true,
         status: true,
         signature: true,
+        signedAgainstContractAddress: true,
       },
     });
 
@@ -454,9 +455,34 @@ export const syncWeeklyClaims = async (req: Request, res: Response) => {
     const updatedClaims: Array<{ id: number; previousStatus: string; newStatus: string }> = [];
     const skippedClaims: Array<{ id: number; reason: string }> = [];
 
+    const currentContractAddress = teamContract.address.toLowerCase();
+
     for (const claim of weeklyClaims) {
       if (!claim.signature || !isHex(claim.signature)) {
         skippedClaims.push({ id: claim.id, reason: 'Missing or invalid signature' });
+        continue;
+      }
+
+      // If the claim was signed against a previous CashRemuneration contract
+      // (Officer redeploy), the live contract has no record of it. Reset to
+      // pending and clear signature artifacts so the user re-signs against
+      // the current contract.
+      const signedAgainst = claim.signedAgainstContractAddress?.toLowerCase();
+      if (!signedAgainst || signedAgainst !== currentContractAddress) {
+        await prisma.weeklyClaim.update({
+          where: { id: claim.id },
+          data: {
+            status: 'pending',
+            signature: null,
+            signedAgainstContractAddress: null,
+            data: Prisma.JsonNull,
+          },
+        });
+        updatedClaims.push({
+          id: claim.id,
+          previousStatus: claim.status ?? 'unknown',
+          newStatus: 'pending',
+        });
         continue;
       }
 

--- a/backend/src/routes/weeklyClaimRoute.ts
+++ b/backend/src/routes/weeklyClaimRoute.ts
@@ -6,12 +6,13 @@ import {
 } from '../controllers/weeklyClaimController';
 import { requireTeamMember } from '../middleware/teamAuthzMiddleware';
 import {
+  validate,
   validateQuery,
-  validateParamsAndQuery,
   getWeeklyClaimsQuerySchema,
   syncWeeklyClaimsQuerySchema,
   weeklyClaimIdParamsSchema,
   updateWeeklyClaimQuerySchema,
+  updateWeeklyClaimBodySchema,
 } from '../validation';
 
 const weeklyClaimRoutes = express.Router();
@@ -288,7 +289,11 @@ weeklyClaimRoutes.post(
  */
 weeklyClaimRoutes.put(
   '/:id',
-  validateParamsAndQuery(weeklyClaimIdParamsSchema, updateWeeklyClaimQuerySchema),
+  validate({
+    params: weeklyClaimIdParamsSchema,
+    query: updateWeeklyClaimQuerySchema,
+    body: updateWeeklyClaimBodySchema,
+  }),
   updateWeeklyClaims
 );
 

--- a/backend/src/routes/weeklyClaimRoute.ts
+++ b/backend/src/routes/weeklyClaimRoute.ts
@@ -254,7 +254,46 @@ weeklyClaimRoutes.post(
  *           properties:
  *             signature:
  *               type: string
- *               description: The EIP-712 signature (required for sign and enable actions)
+ *               description: The EIP-712 signature. Required for `action=sign` and `action=enable`.
+ *             signedAgainstContractAddress:
+ *               type: string
+ *               description: |
+ *                 EIP-712 verifyingContract the signature was bound to. Required for
+ *                 `action=sign`. The backend validates this matches the team's current
+ *                 CashRemunerationEIP712 (scoped to the current Officer) and persists it
+ *                 on the row so post-redeploy stale-detection works without a sweep.
+ *             chainId:
+ *               type: integer
+ *               description: Chain ID the signature was produced on. Required for `action=sign`.
+ *             typedDataMessage:
+ *               type: object
+ *               description: |
+ *                 The EIP-712 WageClaim message envelope as signed. Required for
+ *                 `action=sign`. The backend rebuilds the typed data from this envelope
+ *                 plus `signedAgainstContractAddress`/`chainId` and runs
+ *                 `recoverTypedDataAddress` to confirm the signer is the caller.
+ *               required: [employeeAddress, minutesWorked, date, wages]
+ *               properties:
+ *                 employeeAddress:
+ *                   type: string
+ *                 minutesWorked:
+ *                   type: integer
+ *                   minimum: 0
+ *                   maximum: 65535
+ *                 date:
+ *                   type: string
+ *                   description: Stringified unsigned integer (Unix seconds — JSON can't carry bigint).
+ *                 wages:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     required: [hourlyRate, tokenAddress]
+ *                     properties:
+ *                       hourlyRate:
+ *                         type: string
+ *                         description: Stringified unsigned integer (wei).
+ *                       tokenAddress:
+ *                         type: string
  *   responses:
  *     200:
  *       description: Weekly claim updated successfully

--- a/backend/src/utils/__tests__/cashRemunerationUtil.test.ts
+++ b/backend/src/utils/__tests__/cashRemunerationUtil.test.ts
@@ -48,10 +48,14 @@ describe('cashRemunerationUtil', () => {
       const result = await getCashRemunerationOwner(teamId);
 
       expect(result).toBe(ownerAddress);
+      // Scoped to the current Officer (linked-list head) — required after
+      // an Officer redeploy leaves multiple TeamContract rows of this type
+      // for the team. See cashRemunerationUtil.ts.
       expect(prisma.teamContract.findFirst).toHaveBeenCalledWith({
         where: {
           teamId,
           type: 'CashRemunerationEIP712',
+          officer: { nextOfficer: { is: null } },
         },
       });
       expect(publicClient.readContract).toHaveBeenCalledWith({

--- a/backend/src/utils/cashRemunerationUtil.ts
+++ b/backend/src/utils/cashRemunerationUtil.ts
@@ -4,19 +4,33 @@ import CASH_REMUNERATION_ABI from '../artifacts/cash_remuneration_eip712_abi.jso
 import { prisma } from '.';
 
 /**
+ * Resolve the team's *current* CashRemunerationEIP712 contract — the one
+ * governed by the current Officer (linked-list head: TeamOfficer with no
+ * successor). After an Officer redeploy, multiple `TeamContract` rows of
+ * type `CashRemunerationEIP712` exist for the team; an unscoped `findFirst`
+ * is non-deterministic and may return an archived contract. Scoping to the
+ * current Officer is the deterministic source of truth.
+ *
+ * Returns null if the team has no current Officer or the current Officer
+ * has no CashRemunerationEIP712 contract registered.
+ */
+export const getCurrentCashRemunerationContract = (teamId: number) =>
+  prisma.teamContract.findFirst({
+    where: {
+      teamId,
+      type: 'CashRemunerationEIP712',
+      officer: { nextOfficer: { is: null } },
+    },
+  });
+
+/**
  * Get the owner address of the Cash Remuneration contract for a specific team
  * @param teamId The team ID
  * @returns The owner address of the Cash Remuneration contract or null if not found
  */
 export const getCashRemunerationOwner = async (teamId: number): Promise<Address | null> => {
   try {
-    // Find the Cash Remuneration contract for the team
-    const contract = await prisma.teamContract.findFirst({
-      where: {
-        teamId: teamId,
-        type: 'CashRemunerationEIP712',
-      },
-    });
+    const contract = await getCurrentCashRemunerationContract(teamId);
 
     if (!contract || !isAddress(contract.address)) {
       return null;

--- a/backend/src/validation/schemas/weeklyClaim.ts
+++ b/backend/src/validation/schemas/weeklyClaim.ts
@@ -1,6 +1,27 @@
 import { z } from 'zod';
 import { addressSchema, teamIdSchema, positiveIntegerSchema } from './common';
 
+// EIP-712 WageClaim message envelope as signed by the approver. The backend
+// rebuilds the typed data with this envelope (plus the verifying contract /
+// chainId in the body) and runs `recoverTypedDataAddress` to confirm the
+// signature actually came from the caller. Rates and token addresses are not
+// re-derived server-side — the on-chain contract is the canonical authority
+// at withdraw time, so the backend's job here is just to authenticate the
+// signature and record the contract it was bound to (issue #1825).
+const wageClaimMessageSchema = z.object({
+  employeeAddress: addressSchema,
+  minutesWorked: z.number().int().min(0).max(65535),
+  date: z.string().regex(/^\d+$/, 'date must be a stringified unsigned integer'),
+  wages: z
+    .array(
+      z.object({
+        hourlyRate: z.string().regex(/^\d+$/, 'hourlyRate must be a stringified unsigned integer'),
+        tokenAddress: addressSchema,
+      })
+    )
+    .min(1),
+});
+
 /**
  * Weekly claim-related validation schemas
  */
@@ -36,6 +57,15 @@ export const updateWeeklyClaimQuerySchema = z.object({
 });
 
 // Update weekly claim request body
+//
+// signedAgainstContractAddress + typedDataMessage + chainId are required only
+// for `action=sign` so the backend can authenticate the EIP-712 signature.
+// They're optional at the schema level because the same body shape is reused
+// for withdraw / disable / enable, where they don't apply. The sign branch in
+// the controller enforces presence at request time and surfaces 400 errors.
 export const updateWeeklyClaimBodySchema = z.object({
   signature: z.string().optional(),
+  signedAgainstContractAddress: addressSchema.optional(),
+  typedDataMessage: wageClaimMessageSchema.optional(),
+  chainId: z.number().int().positive().optional(),
 });


### PR DESCRIPTION
# Description

## Initial Issue Description

Fixes #1825

Release v0.10.0 (PR #1816) ships a breaking EIP-712 typehash change on `CashRemunerationEIP712` (`WageClaim.hoursWorked` → `WageClaim.minutesWorked`) and the contract is being redeployed. Between the dev-side rollout and the per-team redeploy step, the new app runs against teams still on the old contract, and existing `signed` claims carry signatures bound to the old typehash + old contract address. We need to ride out that window without data loss and without freezing the whole product.

## PR Summary

- **Schema (`backend/prisma/schema.prisma` + new migration).** `TeamOfficer.version` tags an Officer generation; pre-existing rows backfilled to `'legacy'`. `WeeklyClaim.signedAgainstContractAddress` records the verifying contract a signature was bound to, so stale rows are derivable without a transactional sweep at redeploy time.
- **Backend.** `createOfficer` now stamps `version: 'v0.10'` on insert (the upsert-update path is a no-op so legacy rows stay legacy until a fresh Officer is deployed). Team responses derive `isMigrated = currentOfficer.version === 'v0.10'`. The sign endpoint now requires `signedAgainstContractAddress`, the typed-data envelope, and `chainId`; it rejects when the declared verifying contract isn't the team's current `CashRemunerationEIP712` and runs `recoverTypedDataAddress` to confirm the signature actually came from the caller. The verifying contract is persisted on the row.
- **Frontend.** While `!isMigrated` a `UAlert` banner explains the state and `Sign`/`Submit` are disabled (`Withdraw` stays enabled — the old contract is still live on-chain). After the team redeploys, `signed` rows whose stored verifying contract no longer matches the team's current `CashRemunerationEIP712` render a "Needs re-signing" badge, and the action dropdown swaps `Withdraw` → `Re-sign` so the approver re-binds against the new contract. `CRSigne.vue` sends `signedAgainstContractAddress`, `chainId`, and the typed-data envelope on sign.

## Notes for the reviewer

- **The four commits map to the four layers.** Schema → Officer/Team payload → sign-endpoint validation → frontend UX. Reviewing in that order keeps each diff self-contained.
- **Trust model on the sign endpoint.** The frontend sends the typed-data envelope it signed; the backend rebuilds the EIP-712 domain from `signedAgainstContractAddress` + `chainId` and runs recovery. This is sufficient because the on-chain contract independently re-derives the canonical message at withdraw time. Server-side message reconstruction (so the backend wouldn't trust any field of the message) is plausible as a follow-up, but porting the rate/overtime split + the per-chain token resolution is well outside the scope of this PR.
- **No data migration on `WeeklyClaim`.** Existing `signed` rows have `signedAgainstContractAddress = NULL`. The frontend treats null as "not stale" — those rows continue to behave exactly as today. The first time a row is signed after this lands, it picks up the column.
- **Out of scope (per the issue).** Dual-typehash signing, best-effort `minutesWorked → hoursWorked` conversion for old contracts, the admin dashboard listing non-migrated teams, and an in-app notification system. Tracked separately in the issue body.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] The commit messages follow the conventional-commits + gitmoji guideline
- [x] Tests for the changes have been added (`backend/`: 557 unit tests pass, +9 new for sign validation / version stamping / `isMigrated` derivation; `app/`: 1512 unit tests pass, +8 new for sign payload, migration banner, freeze, stale badge, Re-sign swap)
- [x] Code-quality gate passed in every touched subproject (`lint`, `format-check`, `type-check`, `test:unit`)
- [ ] Docs have been added / updated — not applicable