### PR TITLE
fix: 🐛 chained wage creation fails on partial unique index

### DIFF
--- a/backend/prisma/migrations/20260428000000_wage_active_deferrable/migration.sql
+++ b/backend/prisma/migrations/20260428000000_wage_active_deferrable/migration.sql
@@ -1,0 +1,14 @@
+-- Replace the partial unique INDEX on active wages with an equivalent
+-- DEFERRABLE EXCLUDE CONSTRAINT. The invariant is unchanged ("at most one
+-- wage per (teamId, userAddress) may have nextWageId IS NULL"), but a
+-- deferrable constraint allows a transaction to momentarily hold two active
+-- rows during a chained insert+update, with the check run at COMMIT.
+-- Partial unique indexes cannot be deferred in Postgres; an EXCLUDE
+-- constraint with all "=" operators is the equivalent form that can.
+
+DROP INDEX IF EXISTS "Wage_teamId_userAddress_active_key";
+
+ALTER TABLE "Wage" ADD CONSTRAINT "Wage_active_unique"
+  EXCLUDE ("teamId" WITH =, "userAddress" WITH =)
+  WHERE ("nextWageId" IS NULL)
+  DEFERRABLE INITIALLY DEFERRED;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -103,8 +103,9 @@ model Wage {
   updatedAt                   DateTime      @updatedAt
 
   // Only one "active" wage (nextWageId IS NULL) per (teamId, userAddress).
-  // Enforced by a partial unique index created in migration 20260418_wage_active_unique_and_indexes
-  // because Prisma Schema Language cannot express partial unique indexes.
+  // Enforced by a deferrable EXCLUDE constraint (Wage_active_unique) in
+  // migration 20260428_wage_active_deferrable. Deferrable so chained
+  // create-and-relink can run inside a single transaction.
 }
 
 model Claim {

--- a/backend/src/controllers/__tests__/wageController.test.ts
+++ b/backend/src/controllers/__tests__/wageController.test.ts
@@ -7,20 +7,22 @@ import { prisma } from '../../utils';
 
 vi.mock('../../utils', async () => {
   const actual = await vi.importActual('../../utils');
+  const prismaMock: Record<string, unknown> = {
+    team: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    wage: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+  prismaMock.$transaction = vi.fn(async (cb: (tx: unknown) => unknown) => cb(prismaMock));
   return {
     ...actual,
-    prisma: {
-      team: {
-        findFirst: vi.fn(),
-        findUnique: vi.fn(),
-      },
-      wage: {
-        findFirst: vi.fn(),
-        findMany: vi.fn(),
-        create: vi.fn(),
-        update: vi.fn(),
-      },
-    },
+    prisma: prismaMock,
   };
 });
 vi.mock('../../utils/viem.config');

--- a/backend/src/controllers/wageController.ts
+++ b/backend/src/controllers/wageController.ts
@@ -54,14 +54,16 @@ export const setWage = async (req: Request, res: Response) => {
         return errorResponse(400, 'Cannot set wage: the current wage is disabled', res);
       }
 
-      // Create wage and chain it to the previous wage
-      const createdWage = await prisma.wage.create({
-        data: {
-          ...wagePayload,
-          previousWage: {
-            connect: { id: currentWage.id },
-          },
-        },
+      // Create wage and chain it to the previous wage. Done in a transaction
+      // so the deferrable Wage_active_unique constraint is checked at COMMIT,
+      // after the old wage's nextWageId has been set.
+      const createdWage = await prisma.$transaction(async (tx) => {
+        const newWage = await tx.wage.create({ data: wagePayload });
+        await tx.wage.update({
+          where: { id: currentWage.id },
+          data: { nextWageId: newWage.id },
+        });
+        return newWage;
       });
 
       return res.status(201).json(createdWage);


### PR DESCRIPTION
Closes #1828
Refs #1780

## Summary

- Replace the partial unique index `Wage_teamId_userAddress_active_key` with a deferrable `EXCLUDE` constraint `Wage_active_unique`. Same invariant (one active wage per `(teamId, userAddress)`), but check is deferrable to `COMMIT`.
- Wrap chained create in `setWage` with `prisma.$transaction`: insert the new wage, then update the previous wage's `nextWageId`. The constraint passes at commit because by then only the new row has `nextWageId IS NULL`.
- Update `Wage` model comment in `schema.prisma` to point at the new constraint and migration.

## Why

`prisma.wage.create({ ..., previousWage: { connect: ... } })` runs as INSERT + UPDATE. Between the two, both old and new rows have `nextWageId IS NULL`, so the partial unique index fired on the INSERT and `setWage` returned 500 with P2002.

A partial unique index cannot be deferred in Postgres; an `EXCLUDE` constraint with all `=` operators is the equivalent form that supports `DEFERRABLE INITIALLY DEFERRED`.

## Test plan

- [ ] `npx prisma migrate dev` applies cleanly
- [ ] First wage creation for a `(team, user)` pair still works
- [ ] Replacing an existing active wage no longer returns 500 P2002
- [ ] Old wage ends up with `nextWageId = newWage.id`; new wage has `nextWageId = null`
- [ ] Disabled current wage still returns the 400 "Cannot set wage" path