### PR TITLE
refactor: ♻️ deduplicate useUserDataStore mock in store.setup.ts

### DIFF
--- a/app/src/components/ui/__tests__/SidebarLayout.spec.ts
+++ b/app/src/components/ui/__tests__/SidebarLayout.spec.ts
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { nextTick } from 'vue'
 import SidebarLayout from '@/components/ui/SidebarLayout.vue'
+import { useUserDataStore } from '@/stores/user'
 
 describe('SidebarLayout.vue', () => {
   let router: ReturnType<typeof createRouter>
@@ -155,5 +156,48 @@ describe('SidebarLayout.vue', () => {
     await nextTick()
 
     expect((wrapper.vm as { open: boolean }).open).toBe(true)
+  })
+
+  it('falls back to default avatar and name when user store is empty', async () => {
+    vi.mocked(useUserDataStore).mockReturnValueOnce({
+      address: '0xUSER',
+      name: '',
+      imageUrl: '',
+      isAuth: false
+    } as never)
+
+    await router.push('/teams/1')
+    await router.isReady()
+
+    const wrapper = mount(SidebarLayout, {
+      global: {
+        stubs: {
+          UDashboardSidebar: {
+            template: `
+              <div>
+                <slot name="header" :collapsed="false" />
+                <slot name="default" :collapsed="false" />
+                <slot name="footer" :collapsed="false" />
+              </div>
+            `,
+            props: ['collapsible', 'resizable', 'class', 'ui']
+          },
+          UNavigationMenu: true,
+          UModal: {
+            template: `<div><slot /></div>`,
+            props: ['open', 'title', 'description'],
+            emits: ['update:open']
+          },
+          EditUserForm: true
+        },
+        plugins: [router]
+      }
+    })
+
+    const avatarImg = wrapper.find('img[alt="User Avatar"]')
+    expect(avatarImg.attributes('src')).toContain('img.daisyui.com')
+
+    const userName = wrapper.find('[data-test="user-name"]')
+    expect(userName.text()).toBe('User')
   })
 })

--- a/app/src/stores/__tests__/currencyStore.spec.ts
+++ b/app/src/stores/__tests__/currencyStore.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
+
+// Unmock the store file so we can test the real implementation
+vi.unmock('@/stores/currencyStore')
+
 import { useCurrencyStore } from '../currencyStore'
 import { nextTick, ref } from 'vue'
 import { useQueryFn } from '@/tests/mocks'

--- a/app/src/tests/mocks/store.mock.ts
+++ b/app/src/tests/mocks/store.mock.ts
@@ -43,22 +43,10 @@ export const mockToast = {
 export const mockUserStore = {
   address: '0x0000000000000000000000000000000000000001',
   name: 'Test User',
+  nonce: '',
   imageUrl: 'https://example.com/avatar.jpg',
   isAuth: true,
   setUserData: vi.fn(),
-  clearUserData: vi.fn(),
-  setAuthStatus: vi.fn()
-}
-
-/**
- * Mock useUserDataStore - for tracking current user address
- */
-export const mockUserDataStore = {
-  address: '0xUSER1',
-  name: 'Test User',
-  setAddress: vi.fn(),
-  setUserData: vi.fn(),
-  clear: vi.fn(),
   clearUserData: vi.fn(),
   setAuthStatus: vi.fn()
 }

--- a/app/src/tests/setup/store.setup.ts
+++ b/app/src/tests/setup/store.setup.ts
@@ -1,25 +1,40 @@
 import { vi } from 'vitest'
 import * as mocks from '@/tests/mocks/store.mock'
 
-// Mock each Pinia store submodule individually rather than the `@/stores`
-// barrel. `@/stores/index.ts` re-exports each submodule via `export *`, so a
-// submodule mock propagates to consumers that import from either path while
-// avoiding duplicate `vi.mock` declarations with non-deterministic resolution
-// order.
+// Convention: mock individual store submodules, not the `@/stores` barrel.
+// `@/stores/index.ts` re-exports each submodule via `export *`, so a mock on
+// `@/stores/<name>` propagates to consumers that import from either path.
+// Mocking the barrel as well risks duplicate `vi.mock` declarations whose
+// resolution order is non-deterministic.
 
-const withActual = async <T extends object>(
-  importOriginal: () => Promise<unknown>,
-  overrides: T
-) => ({ ...((await importOriginal()) as object), ...overrides })
+vi.mock('@/stores/user', async (importOriginal) => {
+  const actual: object = await importOriginal()
+  return {
+    ...actual,
+    useUserDataStore: vi.fn(() => ({ ...mocks.mockUserStore }))
+  }
+})
 
-vi.mock('@/stores/user', (orig) =>
-  withActual(orig, { useUserDataStore: vi.fn(() => ({ ...mocks.mockUserStore })) })
-)
-vi.mock('@/stores/teamStore', (orig) =>
-  withActual(orig, { useTeamStore: vi.fn(() => ({ ...mocks.mockTeamStore })) })
-)
-vi.mock('@/stores/currencyStore', (orig) =>
-  withActual(orig, { useCurrencyStore: vi.fn(() => mocks.mockUseCurrencyStore()) })
-)
+vi.mock('@/stores/teamStore', async (importOriginal) => {
+  const actual: object = await importOriginal()
+  return {
+    ...actual,
+    useTeamStore: vi.fn(() => ({ ...mocks.mockTeamStore }))
+  }
+})
 
-vi.mock('@nuxt/ui', (orig) => withActual(orig, { useToast: vi.fn(() => mocks.mockToast) }))
+vi.mock('@/stores/currencyStore', async (importOriginal) => {
+  const actual: object = await importOriginal()
+  return {
+    ...actual,
+    useCurrencyStore: vi.fn(() => mocks.mockUseCurrencyStore())
+  }
+})
+
+vi.mock('@nuxt/ui', async (importOriginal) => {
+  const actual: object = await importOriginal()
+  return {
+    ...actual,
+    useToast: vi.fn(() => mocks.mockToast)
+  }
+})

--- a/app/src/tests/setup/store.setup.ts
+++ b/app/src/tests/setup/store.setup.ts
@@ -1,40 +1,25 @@
 import { vi } from 'vitest'
 import * as mocks from '@/tests/mocks/store.mock'
 
-// Convention: mock individual store submodules, not the `@/stores` barrel.
-// `@/stores/index.ts` re-exports each submodule via `export *`, so a mock on
-// `@/stores/<name>` propagates to consumers that import from either path.
-// Mocking the barrel as well risks duplicate `vi.mock` declarations whose
-// resolution order is non-deterministic.
+// Mock each Pinia store submodule individually rather than the `@/stores`
+// barrel. `@/stores/index.ts` re-exports each submodule via `export *`, so a
+// submodule mock propagates to consumers that import from either path while
+// avoiding duplicate `vi.mock` declarations with non-deterministic resolution
+// order.
 
-vi.mock('@/stores/user', async (importOriginal) => {
-  const actual: object = await importOriginal()
-  return {
-    ...actual,
-    useUserDataStore: vi.fn(() => ({ ...mocks.mockUserStore }))
-  }
-})
+const withActual = async <T extends object>(
+  importOriginal: () => Promise<unknown>,
+  overrides: T
+) => ({ ...((await importOriginal()) as object), ...overrides })
 
-vi.mock('@/stores/teamStore', async (importOriginal) => {
-  const actual: object = await importOriginal()
-  return {
-    ...actual,
-    useTeamStore: vi.fn(() => ({ ...mocks.mockTeamStore }))
-  }
-})
+vi.mock('@/stores/user', (orig) =>
+  withActual(orig, { useUserDataStore: vi.fn(() => ({ ...mocks.mockUserStore })) })
+)
+vi.mock('@/stores/teamStore', (orig) =>
+  withActual(orig, { useTeamStore: vi.fn(() => ({ ...mocks.mockTeamStore })) })
+)
+vi.mock('@/stores/currencyStore', (orig) =>
+  withActual(orig, { useCurrencyStore: vi.fn(() => mocks.mockUseCurrencyStore()) })
+)
 
-vi.mock('@/stores/currencyStore', async (importOriginal) => {
-  const actual: object = await importOriginal()
-  return {
-    ...actual,
-    useCurrencyStore: vi.fn(() => mocks.mockUseCurrencyStore())
-  }
-})
-
-vi.mock('@nuxt/ui', async (importOriginal) => {
-  const actual: object = await importOriginal()
-  return {
-    ...actual,
-    useToast: vi.fn(() => mocks.mockToast)
-  }
-})
+vi.mock('@nuxt/ui', (orig) => withActual(orig, { useToast: vi.fn(() => mocks.mockToast) }))

--- a/app/src/tests/setup/store.setup.ts
+++ b/app/src/tests/setup/store.setup.ts
@@ -1,30 +1,17 @@
 import { vi } from 'vitest'
 import * as mocks from '@/tests/mocks/store.mock'
 
-// Mock the barrel export for components/composables that use @/stores
-vi.mock('@/stores', async (importOriginal) => {
-  const actual: object = await importOriginal()
-  return {
-    ...actual,
-    useTeamStore: vi.fn(() => ({ ...mocks.mockTeamStore })),
-    useCurrencyStore: vi.fn(() => mocks.mockUseCurrencyStore()),
-    useUserDataStore: vi.fn(() => ({ ...mocks.mockUserStore }))
-  }
-})
-
-vi.mock('@nuxt/ui', async (importOriginal) => {
-  const actual: object = await importOriginal()
-  return {
-    ...actual,
-    useToast: vi.fn(() => mocks.mockToast)
-  }
-})
+// Convention: mock individual store submodules, not the `@/stores` barrel.
+// `@/stores/index.ts` re-exports each submodule via `export *`, so a mock on
+// `@/stores/<name>` propagates to consumers that import from either path.
+// Mocking the barrel as well risks duplicate `vi.mock` declarations whose
+// resolution order is non-deterministic.
 
 vi.mock('@/stores/user', async (importOriginal) => {
   const actual: object = await importOriginal()
   return {
     ...actual,
-    useUserDataStore: vi.fn(() => ({ ...mocks.mockUserDataStore }))
+    useUserDataStore: vi.fn(() => ({ ...mocks.mockUserStore }))
   }
 })
 
@@ -33,5 +20,21 @@ vi.mock('@/stores/teamStore', async (importOriginal) => {
   return {
     ...actual,
     useTeamStore: vi.fn(() => ({ ...mocks.mockTeamStore }))
+  }
+})
+
+vi.mock('@/stores/currencyStore', async (importOriginal) => {
+  const actual: object = await importOriginal()
+  return {
+    ...actual,
+    useCurrencyStore: vi.fn(() => mocks.mockUseCurrencyStore())
+  }
+})
+
+vi.mock('@nuxt/ui', async (importOriginal) => {
+  const actual: object = await importOriginal()
+  return {
+    ...actual,
+    useToast: vi.fn(() => mocks.mockToast)
   }
 })


### PR DESCRIPTION
# Description

## Initial Issue Description

Fixes #1838 (sub-task of #1837)

`app/src/tests/setup/store.setup.ts` declared `vi.mock('@/stores/user', …)` twice with two different fixtures (`mockUserStore` via the `@/stores` barrel mock vs `mockUserDataStore` via the submodule mock). Resolution order was non-deterministic, making spec failures non-reproducible.

## PR Summary Or Solution description

**Convention adopted:** mock each store submodule individually, never the `@/stores` barrel. `stores/index.ts` re-exports each submodule with `export *`, so a submodule mock propagates to consumers regardless of whether they import from `@/stores` or `@/stores/<name>`. This is now documented in a comment at the top of `store.setup.ts`.

**Changes:**
- Drop the `@/stores` barrel mock from `store.setup.ts`.
- Move the `useCurrencyStore` mock into a new `@/stores/currencyStore` submodule mock. `currencyStore.spec.ts` now `vi.unmock`s itself, mirroring the pattern already used in `user.spec.ts`.
- Collapse `mockUserDataStore` into `mockUserStore` (the canonical fixture, used in ~45 specs). The `setAddress` / `clear` methods that only existed on `mockUserDataStore` are not used in production code, so they are dropped. Added the missing `nonce` field to `mockUserStore` so it matches the real store shape.

## Acceptance (from #1838)

- ✅ No duplicate `vi.mock` for the same module in any setup file.
- ✅ Tests still green — full suite: 1527 passed / 136 skipped (no spec was relying on the second mock; only `currencyStore.spec.ts` needed an `unmock` because the submodule is now globally mocked).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Contribution checklist

- [x] `npm run lint` passes
- [x] `npm run format-check` passes
- [x] `npm run type-check` passes
- [x] `npm run test:unit -- --run` passes