### PR TITLE
test: ✅ add unit tests for teamStore (Pinia)

### DIFF
--- a/app/src/stores/__tests__/teamStore.spec.ts
+++ b/app/src/stores/__tests__/teamStore.spec.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick, ref, toValue } from 'vue'
+
+// store.setup.ts replaces useTeamStore with a fixture mock — undo it so we test
+// the real Pinia store. The global @/queries/team.queries mock is kept because
+// teamStore calls useGetTeamQuery internally and we override it per test.
+vi.unmock('@/stores/teamStore')
+
+import { useTeamStore } from '@/stores/teamStore'
+import { useGetTeamQuery } from '@/queries/team.queries'
+import { mockTeamData } from '@/tests/mocks/query.mock'
+import { log } from '@/utils/generalUtil'
+
+type QueryReturn = ReturnType<typeof useGetTeamQuery>
+
+const buildQueryReturn = (overrides: Partial<Record<string, unknown>> = {}): QueryReturn =>
+  ({
+    data: ref(mockTeamData),
+    error: ref(null),
+    isLoading: ref(false),
+    isPending: ref(false),
+    isSuccess: ref(true),
+    isFetched: ref(true),
+    refetch: vi.fn(),
+    ...overrides
+  }) as unknown as QueryReturn
+
+describe('Team Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.mocked(useGetTeamQuery).mockReturnValue(buildQueryReturn())
+  })
+
+  describe('initial state', () => {
+    it('starts with a null currentTeamId', () => {
+      const store = useTeamStore()
+      expect(store.currentTeamId).toBeNull()
+    })
+
+    it('passes the currentTeamId ref through to useGetTeamQuery', () => {
+      useTeamStore()
+      const calls = vi.mocked(useGetTeamQuery).mock.calls
+      const params = calls[calls.length - 1]?.[0]
+      expect(params).toBeDefined()
+      expect(toValue(params!.pathParams.teamId)).toBeNull()
+    })
+  })
+
+  describe('getters', () => {
+    // Pinia setup stores wrap returned objects with reactive(), which auto-unwraps
+    // nested refs — so consumers read currentTeamMeta.data, not .data.value.
+    it('exposes currentTeamMeta from the underlying query', () => {
+      const store = useTeamStore()
+      expect(store.currentTeamMeta.data).toEqual(mockTeamData)
+    })
+
+    it('exposes currentTeam as a deprecated alias for currentTeamMeta.data', () => {
+      const store = useTeamStore()
+      expect(store.currentTeam).toEqual(mockTeamData)
+    })
+  })
+
+  describe('setCurrentTeamId', () => {
+    it('updates currentTeamId', async () => {
+      const store = useTeamStore()
+      await store.setCurrentTeamId('42')
+      expect(store.currentTeamId).toBe('42')
+    })
+
+    it('flows the new id through to the query params ref', async () => {
+      const store = useTeamStore()
+      const calls = vi.mocked(useGetTeamQuery).mock.calls
+      const params = calls[calls.length - 1]![0]
+      await store.setCurrentTeamId('xyz')
+      expect(toValue(params.pathParams.teamId)).toBe('xyz')
+    })
+
+    it('is a no-op when the id is unchanged', async () => {
+      const store = useTeamStore()
+      await store.setCurrentTeamId('42')
+      const calls = vi.mocked(useGetTeamQuery).mock.calls
+      const params = calls[calls.length - 1]![0]
+      const teamIdRef = params.pathParams.teamId as { value: string | null }
+      const valueRef = teamIdRef.value
+      await store.setCurrentTeamId('42')
+      expect(teamIdRef.value).toBe(valueRef)
+      expect(store.currentTeamId).toBe('42')
+    })
+  })
+
+  describe('getContractAddressByType', () => {
+    it('returns the address of a matching contract', () => {
+      const store = useTeamStore()
+      expect(store.getContractAddressByType('InvestorV1')).toBe(
+        '0x1111111111111111111111111111111111111111'
+      )
+    })
+
+    it('returns undefined when no contract of the requested type exists', () => {
+      const store = useTeamStore()
+      expect(store.getContractAddressByType('Bank')).toBeUndefined()
+    })
+
+    it('returns undefined when team data has not loaded yet', () => {
+      vi.mocked(useGetTeamQuery).mockReturnValueOnce(
+        buildQueryReturn({ data: ref(undefined), isSuccess: ref(false), isFetched: ref(false) })
+      )
+      const store = useTeamStore()
+      expect(store.getContractAddressByType('InvestorV1')).toBeUndefined()
+    })
+  })
+
+  describe('error reactivity', () => {
+    // useToast is auto-imported via the @nuxt/ui/vite unplugin, which rewrites
+    // `useToast()` to a deep import from the runtime composables path — so the
+    // global vi.mock('@nuxt/ui') in store.setup.ts does not actually intercept
+    // it. We assert the watch fires via log.error instead, which matches the
+    // pattern used elsewhere in the suite (e.g. AddMemberForm.spec).
+    it('logs an error and triggers the toast when the team query errors', async () => {
+      const logErrorSpy = vi.spyOn(log, 'error').mockImplementation(() => undefined)
+      const errorRef = ref<Error | null>(null)
+      vi.mocked(useGetTeamQuery).mockReturnValueOnce(
+        buildQueryReturn({
+          data: ref(undefined),
+          error: errorRef,
+          isSuccess: ref(false),
+          isFetched: ref(false)
+        })
+      )
+      useTeamStore()
+      const boom = new Error('Network down')
+      errorRef.value = boom
+      await nextTick()
+      expect(logErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to load'), boom)
+    })
+
+    it('does not log when the team query succeeds', async () => {
+      const logErrorSpy = vi.spyOn(log, 'error').mockImplementation(() => undefined)
+      useTeamStore()
+      await nextTick()
+      expect(logErrorSpy).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
# Description

## Initial Issue Description

Fixes #1841 (sub-task of umbrella refactor #1837).

`teamStore` is central to the app and was previously only mocked — never tested. Only `user` and `currencyStore` had real Pinia specs.

## PR Summary

Adds `app/src/stores/__tests__/teamStore.spec.ts` covering the real Pinia store via `createPinia()` (per the parent issue's direction — no `createTestingPinia`). 12 tests across:

- **Initial state** — `currentTeamId` defaults to `null`; the ref is forwarded to `useGetTeamQuery` as `pathParams.teamId`.
- **Getters** — `currentTeamMeta` exposes the underlying query result; `currentTeam` works as the deprecated alias.
- **`setCurrentTeamId`** — updates the id, flows new values through to the query params ref, and is a no-op when the id is unchanged.
- **`getContractAddressByType`** — returns the matching contract address, `undefined` for unknown types, and `undefined` before the team has loaded.
- **Error reactivity** — the watcher logs and triggers the toast pathway when the underlying query errors, and stays silent on success.

The error tests assert via `log.error` rather than `mockToast.add` because `useToast` is auto-imported through the `@nuxt/ui/vite` unplugin from a deep runtime path — so the global `vi.mock('@nuxt/ui')` in `store.setup.ts` does not actually intercept it. The `log.error` pattern matches what the rest of the suite uses (e.g. `AddMemberForm.spec`). This is documented inline.

### Coverage

`teamStore.ts`: **100 % statements / 100 % functions / 100 % lines** (acceptance was ≥ 80 % lines). Only one branch is uncovered — the falsy re-entry of the error watcher's guard.

```
File          | % Stmts | % Branch | % Funcs | % Lines
teamStore.ts  |     100 |       75 |     100 |     100
```

## Type of change

- [x] New test coverage (no production code changes)

- **PR fulfills these requirements**
  - [x] The commit message follows our guidelines
  - [x] Tests for the changes have been added
  - [ ] Docs have been added / updated — n/a