### PR TITLE
refactor: ♻️ migrate safeDepositRouter writes to useContractWritesV3

### DIFF
--- a/app/src/components/forms/SafeDepositRouterForm.vue
+++ b/app/src/components/forms/SafeDepositRouterForm.vue
@@ -88,6 +88,8 @@ import {
 } from '@/composables/safeDepositRouter/reads'
 import { useDeposit } from '@/composables/safeDepositRouter/writes'
 import { useInvestorSymbol } from '@/composables/investor/reads'
+import { useTeamStore } from '@/stores/teamStore'
+import { useQueryClient } from '@tanstack/vue-query'
 
 const emits = defineEmits<{
   closeModal: []
@@ -118,6 +120,8 @@ const submitError = ref<string | null>(null)
 
 const currencyStore = useCurrencyStore()
 const userDataStore = useUserDataStore()
+const teamStore = useTeamStore()
+const queryClient = useQueryClient()
 const toast = useToast()
 
 const safeDepositRouterAddress = useSafeDepositRouterAddress()
@@ -247,14 +251,12 @@ const isLoading = computed(
     isBalanceLoading.value ||
     isTokenSymbolLoading.value ||
     approveWrite.isPending.value ||
-    depositWrite.writeResult.isPending.value
+    depositWrite.isPending.value
 )
 
 const errorMessage = computed(() => {
   if (submitError.value) return submitError.value
-  const err = (approveWrite.error.value ||
-    depositWrite.writeResult.error.value ||
-    depositWrite.receiptResult.error.value) as Error | null
+  const err = (approveWrite.error.value || depositWrite.error.value) as Error | null
   return err ? parseError(err) || err.message || 'Transaction failed' : null
 })
 
@@ -295,7 +297,7 @@ watch(
 )
 
 watch(
-  () => depositWrite.writeResult.error.value,
+  () => depositWrite.error.value,
   (error) => {
     if (error) {
       console.error('Error depositing tokens:', error)
@@ -314,9 +316,24 @@ watch(
 )
 
 watch(
-  () => depositWrite.receiptResult.isSuccess.value,
-  (success) => {
+  () => depositWrite.isSuccess.value,
+  async (success) => {
     if (!success) return
+    // V3 invalidates reads on the SafeDepositRouter automatically; the deposit
+    // also mints SHER, so we additionally flush InvestorV1 reads (balances,
+    // total supply) which the V2 wrapper used to handle in invalidateQueries.
+    const investorAddress = teamStore.getContractAddressByType('InvestorV1')
+    if (investorAddress) {
+      const lower = investorAddress.toLowerCase()
+      await queryClient.invalidateQueries({
+        predicate: (query) => {
+          const key = query.queryKey
+          if (!Array.isArray(key) || key[0] !== 'readContract') return false
+          const params = key[1] as { address?: string } | undefined
+          return typeof params?.address === 'string' && params.address.toLowerCase() === lower
+        }
+      })
+    }
     toast.add({
       title: `Successfully deposited ${amount.value} ${selectedToken.value?.token.symbol} and minted ${sherAmount.value} ${tokenSymbol.value || 'SHER'} tokens`,
       color: 'success'
@@ -346,7 +363,7 @@ function handleCancel() {
 
 async function performDeposit() {
   await depositWrite
-    .executeWrite(selectedTokenAddress.value, bigIntAmount.value)
+    .mutateAsync({ args: [selectedTokenAddress.value, bigIntAmount.value] })
     .catch((error) => console.error('Deposit execution error:', error))
 }
 

--- a/app/src/components/forms/SafeDepositRouterForm.vue
+++ b/app/src/components/forms/SafeDepositRouterForm.vue
@@ -320,20 +320,10 @@ watch(
   async (success) => {
     if (!success) return
     // V3 invalidates reads on the SafeDepositRouter automatically; the deposit
-    // also mints SHER, so we additionally flush InvestorV1 reads (balances,
-    // total supply) which the V2 wrapper used to handle in invalidateQueries.
-    const investorAddress = teamStore.getContractAddressByType('InvestorV1')
-    if (investorAddress) {
-      const lower = investorAddress.toLowerCase()
-      await queryClient.invalidateQueries({
-        predicate: (query) => {
-          const key = query.queryKey
-          if (!Array.isArray(key) || key[0] !== 'readContract') return false
-          const params = key[1] as { address?: string } | undefined
-          return typeof params?.address === 'string' && params.address.toLowerCase() === lower
-        }
-      })
-    }
+    // also mints SHER, so flush InvestorV1 reads (balances, total supply) too.
+    await queryClient.invalidateQueries({
+      queryKey: ['readContract', { address: teamStore.getContractAddressByType('InvestorV1') }]
+    })
     toast.add({
       title: `Successfully deposited ${amount.value} ${selectedToken.value?.token.symbol} and minted ${sherAmount.value} ${tokenSymbol.value || 'SHER'} tokens`,
       color: 'success'

--- a/app/src/components/forms/SafeDepositRouterForm.vue
+++ b/app/src/components/forms/SafeDepositRouterForm.vue
@@ -88,8 +88,6 @@ import {
 } from '@/composables/safeDepositRouter/reads'
 import { useDeposit } from '@/composables/safeDepositRouter/writes'
 import { useInvestorSymbol } from '@/composables/investor/reads'
-import { useTeamStore } from '@/stores/teamStore'
-import { useQueryClient } from '@tanstack/vue-query'
 
 const emits = defineEmits<{
   closeModal: []
@@ -103,7 +101,7 @@ const tokenAmountModel = computed({
   set: (value: { amount: string; tokenId: TokenId | string }) => {
     amount.value = value.amount ?? ''
     selectedTokenId.value = (value.tokenId as TokenId) ?? 'usdc'
-    submitError.value = null
+    guardError.value = null
   }
 })
 const stepperItems = [
@@ -113,15 +111,12 @@ const stepperItems = [
 ]
 
 const currentStep = ref(0)
-const submitting = ref(false)
 const isAmountValid = ref(false)
 const isUpdatingFromSher = ref(false)
-const submitError = ref<string | null>(null)
+const guardError = ref<string | null>(null)
 
 const currencyStore = useCurrencyStore()
 const userDataStore = useUserDataStore()
-const teamStore = useTeamStore()
-const queryClient = useQueryClient()
 const toast = useToast()
 
 const safeDepositRouterAddress = useSafeDepositRouterAddress()
@@ -222,7 +217,7 @@ const handleSherAmountChange = (value: string) => {
 
 watch(amount, (newAmount) => {
   currentStep.value = 0
-  submitError.value = null
+  guardError.value = null
   if (isUpdatingFromSher.value) {
     isUpdatingFromSher.value = false
     return
@@ -243,19 +238,24 @@ const { data: allowance } = useErc20Allowance(
 // ERC20 Approve composable
 const approveWrite = useERC20Approve(selectedTokenAddress)
 
-// Deposit composable
+// Deposit composable — handles cross-contract invalidation (router + InvestorV1)
+// internally on success. See useDeposit in safeDepositRouter/writes.ts.
 const depositWrite = useDeposit()
 
+// Submitting state derives from the underlying mutations: no manual flag to
+// keep in sync, no resets to forget on every error path.
+const submitting = computed(() => approveWrite.isPending.value || depositWrite.isPending.value)
+
 const isLoading = computed(
-  () =>
-    isBalanceLoading.value ||
-    isTokenSymbolLoading.value ||
-    approveWrite.isPending.value ||
-    depositWrite.isPending.value
+  () => isBalanceLoading.value || isTokenSymbolLoading.value || submitting.value
 )
 
+// Errors from the mutations stay reactive on `approveWrite.error.value` /
+// `depositWrite.error.value` and surface inline via UAlert. Toasts and modal
+// close are handled by per-call onSuccess/onError callbacks so the side
+// effects sit next to the action that triggered them.
 const errorMessage = computed(() => {
-  if (submitError.value) return submitError.value
+  if (guardError.value) return guardError.value
   const err = (approveWrite.error.value || depositWrite.error.value) as Error | null
   return err ? parseError(err) || err.message || 'Transaction failed' : null
 })
@@ -267,81 +267,26 @@ watch(multiplierError, (error) => {
   }
 })
 
-watch(
-  () => approveWrite.error.value,
-  (error) => {
-    if (error) {
-      console.error('Error approving tokens:', error)
-      const errorMessage = parseError(error)
+const isUserRejection = (err: unknown) => {
+  const msg = parseError(err as Error)
+  return msg.includes('User rejected') || msg.includes('User denied')
+}
 
-      if (errorMessage.includes('User rejected') || errorMessage.includes('User denied')) {
-        toast.add({ title: 'Transaction cancelled by user', color: 'error' })
-      } else {
-        toast.add({ title: 'Failed to approve tokens', color: 'error' })
-      }
-
-      submitting.value = false
-      currentStep.value = 0
-    }
-  }
-)
-
-watch(
-  () => approveWrite.isSuccess.value,
-  (success) => {
-    if (!success) return
-    toast.add({ title: 'Token approval successful', color: 'success' })
-    currentStep.value = 2
-    performDeposit()
-  }
-)
-
-watch(
-  () => depositWrite.error.value,
-  (error) => {
-    if (error) {
-      console.error('Error depositing tokens:', error)
-      const errorMessage = parseError(error)
-
-      if (errorMessage.includes('User rejected') || errorMessage.includes('User denied')) {
-        toast.add({ title: 'Transaction cancelled by user', color: 'error' })
-      } else {
-        toast.add({ title: 'Failed to deposit', color: 'error' })
-      }
-
-      submitting.value = false
-      currentStep.value = 0
-    }
-  }
-)
-
-watch(
-  () => depositWrite.isSuccess.value,
-  async (success) => {
-    if (!success) return
-    // V3 invalidates reads on the SafeDepositRouter automatically; the deposit
-    // also mints SHER, so flush InvestorV1 reads (balances, total supply) too.
-    await queryClient.invalidateQueries({
-      queryKey: ['readContract', { address: teamStore.getContractAddressByType('InvestorV1') }]
-    })
-    toast.add({
-      title: `Successfully deposited ${amount.value} ${selectedToken.value?.token.symbol} and minted ${sherAmount.value} ${tokenSymbol.value || 'SHER'} tokens`,
-      color: 'success'
-    })
-    reset()
-    emits('closeModal')
-  }
-)
+const toastFailure = (err: unknown, fallback: string) => {
+  toast.add({
+    title: isUserRejection(err) ? 'Transaction cancelled by user' : fallback,
+    color: 'error'
+  })
+}
 
 function reset() {
   amount.value = ''
   sherAmount.value = '0'
   selectedTokenId.value = 'usdc'
   currentStep.value = 0
-  submitting.value = false
   isAmountValid.value = false
   isUpdatingFromSher.value = false
-  submitError.value = null
+  guardError.value = null
 }
 
 defineExpose({ reset })
@@ -351,14 +296,8 @@ function handleCancel() {
   emits('closeModal')
 }
 
-async function performDeposit() {
-  await depositWrite
-    .mutateAsync({ args: [selectedTokenAddress.value, bigIntAmount.value] })
-    .catch((error) => console.error('Deposit execution error:', error))
-}
-
 const failGuard = (msg: string) => {
-  submitError.value = msg
+  guardError.value = msg
   toast.add({ title: msg, color: 'error' })
 }
 
@@ -368,18 +307,50 @@ const submitForm = async () => {
   if (!selectedToken.value) return failGuard('No token selected')
   if (!multiplier.value) return failGuard('Unable to calculate SHER compensation')
 
-  submitError.value = null
-  submitting.value = true
+  guardError.value = null
   const currentAllowance = (allowance.value as bigint | undefined) ?? 0n
-  if (currentAllowance < bigIntAmount.value) {
-    currentStep.value = 1
 
-    approveWrite.mutate({
-      args: [safeDepositRouterAddress.value, bigIntAmount.value]
-    })
-  } else {
+  // Sequential: approve (if needed) → deposit. mutateAsync throws on failure;
+  // we handle the toast in onError per-call and stop the chain via try/catch
+  // at the top of the flow. UAlert keeps showing the reactive error.
+  try {
+    if (currentAllowance < bigIntAmount.value) {
+      currentStep.value = 1
+      await approveWrite.mutateAsync(
+        { args: [safeDepositRouterAddress.value, bigIntAmount.value] },
+        {
+          onSuccess: () => toast.add({ title: 'Token approval successful', color: 'success' }),
+          onError: (err) => {
+            console.error('Error approving tokens:', err)
+            toastFailure(err, 'Failed to approve tokens')
+            currentStep.value = 0
+          }
+        }
+      )
+    }
+
     currentStep.value = 2
-    await performDeposit()
+    await depositWrite.mutateAsync(
+      { args: [selectedTokenAddress.value, bigIntAmount.value] },
+      {
+        onSuccess: () => {
+          toast.add({
+            title: `Successfully deposited ${amount.value} ${selectedToken.value?.token.symbol} and minted ${sherAmount.value} ${tokenSymbol.value || 'SHER'} tokens`,
+            color: 'success'
+          })
+          reset()
+          emits('closeModal')
+        },
+        onError: (err) => {
+          console.error('Error depositing tokens:', err)
+          toastFailure(err, 'Failed to deposit')
+          currentStep.value = 0
+        }
+      }
+    )
+  } catch {
+    // Per-call onError already surfaced the toast and reset the step. The
+    // error stays reactive on the mutation for UAlert. Nothing to do here.
   }
 }
 </script>

--- a/app/src/components/forms/__tests__/SafeDepositRouterForm.spec.ts
+++ b/app/src/components/forms/__tests__/SafeDepositRouterForm.spec.ts
@@ -210,9 +210,7 @@ describe('SafeDepositRouterForm.vue', () => {
     await setTokenAmount(wrapper, 'invalid', 'usdc', true)
     expect(vm.bigIntAmount).toBe(0n)
 
-    mockSafeDepositRouterWrites.deposit.mutateAsync.mockRejectedValueOnce(
-      new Error('deposit boom')
-    )
+    mockSafeDepositRouterWrites.deposit.mutateAsync.mockRejectedValueOnce(new Error('deposit boom'))
     await vm.performDeposit()
 
     mockERC20Writes.approve.mutate.mockRejectedValueOnce(new Error('approve boom'))

--- a/app/src/components/forms/__tests__/SafeDepositRouterForm.spec.ts
+++ b/app/src/components/forms/__tests__/SafeDepositRouterForm.spec.ts
@@ -131,7 +131,7 @@ describe('SafeDepositRouterForm.vue', () => {
     vm.submitting = true
     vm.currentStep = 2
     mockParseError.mockReturnValueOnce('Deposit failed')
-    mockSafeDepositRouterWrites.deposit.writeResult.error.value = new Error('deposit failed')
+    mockSafeDepositRouterWrites.deposit.error.value = new Error('deposit failed')
     await wrapper.vm.$nextTick()
     expect(vm.submitting).toBe(false)
   })
@@ -142,13 +142,13 @@ describe('SafeDepositRouterForm.vue', () => {
 
     await setTokenAmount(wrapper, '1', 'usdc', true)
     vm.handleSherAmountChange('5')
-    mockSafeDepositRouterWrites.deposit.executeWrite.mockResolvedValue(undefined)
+    mockSafeDepositRouterWrites.deposit.mutateAsync.mockResolvedValue(undefined)
 
     mockERC20Writes.approve.isSuccess.value = true
     await flushPromises()
-    expect(mockSafeDepositRouterWrites.deposit.executeWrite).toHaveBeenCalled()
+    expect(mockSafeDepositRouterWrites.deposit.mutateAsync).toHaveBeenCalled()
 
-    mockSafeDepositRouterWrites.deposit.receiptResult.isSuccess.value = true
+    mockSafeDepositRouterWrites.deposit.isSuccess.value = true
     await flushPromises()
 
     expect(vm.amount).toBe('')
@@ -171,12 +171,12 @@ describe('SafeDepositRouterForm.vue', () => {
     mockSafeDepositRouterAddress.value = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
     vm.selectedTokenId = 'missing-token'
     await vm.submitForm()
-    expect(mockSafeDepositRouterWrites.deposit.executeWrite).not.toHaveBeenCalled()
+    expect(mockSafeDepositRouterWrites.deposit.mutateAsync).not.toHaveBeenCalled()
 
     vm.selectedTokenId = 'usdc'
     mockSafeDepositRouterReads.multiplier.data.value = undefined as never
     await vm.submitForm()
-    expect(mockSafeDepositRouterWrites.deposit.executeWrite).not.toHaveBeenCalled()
+    expect(mockSafeDepositRouterWrites.deposit.mutateAsync).not.toHaveBeenCalled()
   })
 
   it('runs approval when allowance is too low and deposits directly otherwise', async () => {
@@ -193,14 +193,13 @@ describe('SafeDepositRouterForm.vue', () => {
     expect(vm.currentStep).toBe(1)
 
     mockERC20Reads.allowance.data.value = 1000000n
-    mockSafeDepositRouterWrites.deposit.executeWrite.mockResolvedValue(undefined)
+    mockSafeDepositRouterWrites.deposit.mutateAsync.mockResolvedValue(undefined)
     await vm.submitForm()
     await flushPromises()
 
-    expect(mockSafeDepositRouterWrites.deposit.executeWrite).toHaveBeenCalledWith(
-      '0xA3492D046095AFFE351cFac15de9b86425E235dB',
-      1000000n
-    )
+    expect(mockSafeDepositRouterWrites.deposit.mutateAsync).toHaveBeenCalledWith({
+      args: ['0xA3492D046095AFFE351cFac15de9b86425E235dB', 1000000n]
+    })
     expect(vm.currentStep).toBe(2)
   })
 
@@ -211,7 +210,7 @@ describe('SafeDepositRouterForm.vue', () => {
     await setTokenAmount(wrapper, 'invalid', 'usdc', true)
     expect(vm.bigIntAmount).toBe(0n)
 
-    mockSafeDepositRouterWrites.deposit.executeWrite.mockRejectedValueOnce(
+    mockSafeDepositRouterWrites.deposit.mutateAsync.mockRejectedValueOnce(
       new Error('deposit boom')
     )
     await vm.performDeposit()
@@ -222,6 +221,6 @@ describe('SafeDepositRouterForm.vue', () => {
     await vm.submitForm()
     await flushPromises()
 
-    expect(mockSafeDepositRouterWrites.deposit.executeWrite).toHaveBeenCalledTimes(1)
+    expect(mockSafeDepositRouterWrites.deposit.mutateAsync).toHaveBeenCalledTimes(1)
   })
 })

--- a/app/src/components/forms/__tests__/SafeDepositRouterForm.spec.ts
+++ b/app/src/components/forms/__tests__/SafeDepositRouterForm.spec.ts
@@ -16,6 +16,11 @@ import {
   resetSafeDepositRouterMocks
 } from '@/tests/mocks'
 
+type MutateOptions = {
+  onSuccess?: (...args: unknown[]) => void | Promise<void>
+  onError?: (err: unknown) => void | Promise<void>
+}
+
 type SafeDepositRouterVm = {
   amount: string
   sherAmount: string
@@ -23,10 +28,8 @@ type SafeDepositRouterVm = {
   isAmountValid: boolean
   isUpdatingFromSher: boolean
   currentStep: number
-  submitting: boolean
   bigIntAmount: bigint
   handleSherAmountChange: (value: string) => void
-  performDeposit: () => Promise<void>
   submitForm: () => Promise<void>
   handleCancel: () => void
   reset: () => void
@@ -53,6 +56,22 @@ const setTokenAmount = async (
   await tokenAmount.vm.$emit('validation', isValid)
   await wrapper.vm.$nextTick()
 }
+
+/**
+ * Helpers that fire the per-call onSuccess / onError that `submitForm` passes
+ * to mutateAsync. Mirrors the V3 + TanStack callback contract.
+ */
+const resolveOnSuccess = (mutateAsync: ReturnType<typeof vi.fn>) =>
+  mutateAsync.mockImplementationOnce(async (_vars: unknown, opts?: MutateOptions) => {
+    await opts?.onSuccess?.()
+    return undefined
+  })
+
+const rejectOnError = (mutateAsync: ReturnType<typeof vi.fn>, err: Error) =>
+  mutateAsync.mockImplementationOnce(async (_vars: unknown, opts?: MutateOptions) => {
+    await opts?.onError?.(err)
+    throw err
+  })
 
 describe('SafeDepositRouterForm.vue', () => {
   beforeEach(() => {
@@ -114,45 +133,84 @@ describe('SafeDepositRouterForm.vue', () => {
     expect(wrapper.emitted('closeModal')).toBeTruthy()
   })
 
-  it('reacts to multiplier and transaction errors with the right toast messages', async () => {
+  it('toasts on multiplier read failure', async () => {
     const wrapper = createWrapper()
-    const vm = getVm(wrapper)
-
     mockSafeDepositRouterReads.multiplier.error.value = new Error('Multiplier failed')
     await wrapper.vm.$nextTick()
-
-    vm.submitting = true
-    vm.currentStep = 1
-    mockParseError.mockReturnValueOnce('User rejected request')
-    mockERC20Writes.approve.error.value = new Error('approve rejected')
-    await wrapper.vm.$nextTick()
-    expect(vm.currentStep).toBe(0)
-
-    vm.submitting = true
-    vm.currentStep = 2
-    mockParseError.mockReturnValueOnce('Deposit failed')
-    mockSafeDepositRouterWrites.deposit.error.value = new Error('deposit failed')
-    await wrapper.vm.$nextTick()
-    expect(vm.submitting).toBe(false)
+    // The watcher logs the error and shows a toast — covered by mockToast in
+    // the shared composables setup; we're asserting the watcher path runs
+    // without throwing.
+    expect(wrapper.exists()).toBe(true)
   })
 
-  it('deposits after approval success and closes after deposit receipt success', async () => {
+  it('approve onError resets the step and surfaces a user-rejection toast', async () => {
     const wrapper = createWrapper()
     const vm = getVm(wrapper)
 
     await setTokenAmount(wrapper, '1', 'usdc', true)
-    vm.handleSherAmountChange('5')
-    mockSafeDepositRouterWrites.deposit.mutateAsync.mockResolvedValue(undefined)
+    mockParseError.mockReturnValue('User rejected request')
+    rejectOnError(mockERC20Writes.approve.mutateAsync, new Error('approve rejected'))
 
-    mockERC20Writes.approve.isSuccess.value = true
-    await flushPromises()
-    expect(mockSafeDepositRouterWrites.deposit.mutateAsync).toHaveBeenCalled()
-
-    mockSafeDepositRouterWrites.deposit.isSuccess.value = true
+    await vm.submitForm()
     await flushPromises()
 
+    expect(vm.currentStep).toBe(0)
+    expect(mockSafeDepositRouterWrites.deposit.mutateAsync).not.toHaveBeenCalled()
+  })
+
+  it('deposit onError resets the step', async () => {
+    const wrapper = createWrapper()
+    const vm = getVm(wrapper)
+
+    await setTokenAmount(wrapper, '1', 'usdc', true)
+    mockERC20Reads.allowance.data.value = 1000000n // skip approval
+    mockParseError.mockReturnValue('Deposit failed')
+    rejectOnError(mockSafeDepositRouterWrites.deposit.mutateAsync, new Error('deposit failed'))
+
+    await vm.submitForm()
+    await flushPromises()
+
+    expect(vm.currentStep).toBe(0)
+  })
+
+  it('runs approval then deposit sequentially and closes on success', async () => {
+    const wrapper = createWrapper()
+    const vm = getVm(wrapper)
+
+    await setTokenAmount(wrapper, '1', 'usdc', true)
+
+    resolveOnSuccess(mockERC20Writes.approve.mutateAsync)
+    resolveOnSuccess(mockSafeDepositRouterWrites.deposit.mutateAsync)
+
+    await vm.submitForm()
+    await flushPromises()
+
+    expect(mockERC20Writes.approve.mutateAsync).toHaveBeenCalledWith(
+      { args: ['0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB', 1000000n] },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+    )
+    expect(mockSafeDepositRouterWrites.deposit.mutateAsync).toHaveBeenCalledWith(
+      { args: ['0xA3492D046095AFFE351cFac15de9b86425E235dB', 1000000n] },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+    )
     expect(vm.amount).toBe('')
     expect(vm.sherAmount).toBe('0')
+    expect(wrapper.emitted('closeModal')).toBeTruthy()
+  })
+
+  it('skips approval when allowance is sufficient', async () => {
+    const wrapper = createWrapper()
+    const vm = getVm(wrapper)
+
+    await setTokenAmount(wrapper, '1', 'usdc', true)
+    mockERC20Reads.allowance.data.value = 1000000n
+    resolveOnSuccess(mockSafeDepositRouterWrites.deposit.mutateAsync)
+
+    await vm.submitForm()
+    await flushPromises()
+
+    expect(mockERC20Writes.approve.mutateAsync).not.toHaveBeenCalled()
+    expect(mockSafeDepositRouterWrites.deposit.mutateAsync).toHaveBeenCalled()
     expect(wrapper.emitted('closeModal')).toBeTruthy()
   })
 
@@ -161,12 +219,12 @@ describe('SafeDepositRouterForm.vue', () => {
     const vm = getVm(wrapper)
 
     await vm.submitForm()
-    expect(mockERC20Writes.approve.mutate).not.toHaveBeenCalled()
+    expect(mockERC20Writes.approve.mutateAsync).not.toHaveBeenCalled()
 
     vm.isAmountValid = true
     mockSafeDepositRouterAddress.value = ''
     await vm.submitForm()
-    expect(mockERC20Writes.approve.mutate).not.toHaveBeenCalled()
+    expect(mockERC20Writes.approve.mutateAsync).not.toHaveBeenCalled()
 
     mockSafeDepositRouterAddress.value = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
     vm.selectedTokenId = 'missing-token'
@@ -179,46 +237,11 @@ describe('SafeDepositRouterForm.vue', () => {
     expect(mockSafeDepositRouterWrites.deposit.mutateAsync).not.toHaveBeenCalled()
   })
 
-  it('runs approval when allowance is too low and deposits directly otherwise', async () => {
-    const wrapper = createWrapper()
-    const vm = getVm(wrapper)
-
-    await setTokenAmount(wrapper, '1', 'usdc', true)
-    await vm.submitForm()
-    await flushPromises()
-
-    expect(mockERC20Writes.approve.mutate).toHaveBeenCalledWith({
-      args: ['0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB', 1000000n]
-    })
-    expect(vm.currentStep).toBe(1)
-
-    mockERC20Reads.allowance.data.value = 1000000n
-    mockSafeDepositRouterWrites.deposit.mutateAsync.mockResolvedValue(undefined)
-    await vm.submitForm()
-    await flushPromises()
-
-    expect(mockSafeDepositRouterWrites.deposit.mutateAsync).toHaveBeenCalledWith({
-      args: ['0xA3492D046095AFFE351cFac15de9b86425E235dB', 1000000n]
-    })
-    expect(vm.currentStep).toBe(2)
-  })
-
-  it('handles execution exceptions and bigint parsing fallback', async () => {
+  it('returns 0n on invalid bigint input', async () => {
     const wrapper = createWrapper()
     const vm = getVm(wrapper)
 
     await setTokenAmount(wrapper, 'invalid', 'usdc', true)
     expect(vm.bigIntAmount).toBe(0n)
-
-    mockSafeDepositRouterWrites.deposit.mutateAsync.mockRejectedValueOnce(new Error('deposit boom'))
-    await vm.performDeposit()
-
-    mockERC20Writes.approve.mutate.mockRejectedValueOnce(new Error('approve boom'))
-    await setTokenAmount(wrapper, '1', 'usdc', true)
-    mockERC20Reads.allowance.data.value = 0n
-    await vm.submitForm()
-    await flushPromises()
-
-    expect(mockSafeDepositRouterWrites.deposit.mutateAsync).toHaveBeenCalledTimes(1)
   })
 })

--- a/app/src/components/sections/SherTokenView/InvestorActions/SetCompensationMultiplierAction.vue
+++ b/app/src/components/sections/SherTokenView/InvestorActions/SetCompensationMultiplierAction.vue
@@ -146,7 +146,7 @@ const displayMultiplierExample = computed(() => {
 })
 
 const isReadLoading = computed(() => isMultiplierLoading.value || isOwnerLoading.value)
-const isWriteLoading = computed(() => setMultiplierWrite.writeResult.isPending.value)
+const isWriteLoading = computed(() => setMultiplierWrite.isPending.value)
 const isLoading = computed(() => isReadLoading.value || isWriteLoading.value)
 
 const canManageMultiplier = computed(() => {
@@ -183,7 +183,7 @@ const isMultiplierValid = computed(() => {
 })
 
 watch(
-  () => setMultiplierWrite.writeResult.error.value,
+  () => setMultiplierWrite.error.value,
   (error) => {
     if (error) {
       console.error('Error setting multiplier:', error)
@@ -201,7 +201,7 @@ watch(
 )
 
 watch(
-  () => setMultiplierWrite.receiptResult.isSuccess.value,
+  () => setMultiplierWrite.isSuccess.value,
   (success) => {
     if (success) {
       toast.add({
@@ -271,7 +271,7 @@ async function handleSetMultiplier(event?: FormSubmitEvent<MultiplierFormSchema>
     return
   }
 
-  await setMultiplierWrite.executeWrite(multiplierInWei)
+  await setMultiplierWrite.mutateAsync({ args: [multiplierInWei] })
 }
 
 defineExpose({ handleSetMultiplier })

--- a/app/src/components/sections/SherTokenView/InvestorActions/ToggleSherCompensationAction.vue
+++ b/app/src/components/sections/SherTokenView/InvestorActions/ToggleSherCompensationAction.vue
@@ -72,9 +72,9 @@ const isReadLoading = computed(
 
 const isWriteLoading = computed(() => {
   return (
-    enableDepositsWrite.writeResult.isPending.value ||
-    disableDepositsWrite.writeResult.isPending.value ||
-    setSafeAddressWrite.writeResult.isPending.value
+    enableDepositsWrite.isPending.value ||
+    disableDepositsWrite.isPending.value ||
+    setSafeAddressWrite.isPending.value
   )
 })
 
@@ -101,7 +101,7 @@ const isSafeAddressCorrect = computed(() => {
 
 // Watch for enable deposits errors
 watch(
-  () => enableDepositsWrite.writeResult.error.value,
+  () => enableDepositsWrite.error.value,
   (error) => {
     if (error) {
       console.error('Error enabling deposits:', error)
@@ -119,7 +119,7 @@ watch(
 
 // Watch for enable deposits success
 watch(
-  () => enableDepositsWrite.receiptResult.isSuccess.value,
+  () => enableDepositsWrite.isSuccess.value,
   (success) => {
     if (success) {
       toast.add({ title: 'SHER compensation enabled successfully', color: 'success' })
@@ -130,7 +130,7 @@ watch(
 
 // Watch for disable deposits errors
 watch(
-  () => disableDepositsWrite.writeResult.error.value,
+  () => disableDepositsWrite.error.value,
   (error) => {
     if (error) {
       console.error('Error disabling deposits:', error)
@@ -147,7 +147,7 @@ watch(
 
 // Watch for disable deposits success
 watch(
-  () => disableDepositsWrite.receiptResult.isSuccess.value,
+  () => disableDepositsWrite.isSuccess.value,
   (success) => {
     if (success) {
       toast.add({ title: 'SHER compensation disabled successfully', color: 'success' })
@@ -157,7 +157,7 @@ watch(
 
 // Watch for set safe address errors
 watch(
-  () => setSafeAddressWrite.writeResult.error.value,
+  () => setSafeAddressWrite.error.value,
   (error) => {
     if (error) {
       console.error('Error setting safe address:', error)
@@ -175,7 +175,7 @@ watch(
 
 // Watch for set safe address success - automatically enable deposits after
 watch(
-  () => setSafeAddressWrite.receiptResult.isSuccess.value,
+  () => setSafeAddressWrite.isSuccess.value,
   (success) => {
     if (success && isSettingSafeAddress.value) {
       toast.add({ title: 'Safe address updated successfully', color: 'success' })
@@ -205,21 +205,21 @@ async function updateSafeAddress() {
 
   safeAddressErrorShown.value = false
   toast.add({ title: 'Updating Safe address...', color: 'info' })
-  await setSafeAddressWrite.executeWrite(safeAddress)
+  await setSafeAddressWrite.mutateAsync({ args: [safeAddress] })
 }
 
 /**
  * Enable deposits
  */
 async function handleEnableDeposits() {
-  await enableDepositsWrite.executeWrite()
+  await enableDepositsWrite.mutateAsync({})
 }
 
 /**
  * Disable deposits
  */
 async function handleDisableDeposits() {
-  await disableDepositsWrite.executeWrite()
+  await disableDepositsWrite.mutateAsync({})
 }
 
 /**

--- a/app/src/components/sections/SherTokenView/InvestorActions/__tests__/SetCompensationMultiplierAction.spec.ts
+++ b/app/src/components/sections/SherTokenView/InvestorActions/__tests__/SetCompensationMultiplierAction.spec.ts
@@ -34,7 +34,7 @@ describe('SetCompensationMultiplierAction.vue', () => {
     mockUseConnection.isConnected.value = true
     mockUseConnection.address.value = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa'
 
-    mockSafeDepositRouterWrites.setMultiplier.executeWrite.mockResolvedValue(undefined)
+    mockSafeDepositRouterWrites.setMultiplier.mutateAsync.mockResolvedValue(undefined)
   })
 
   it('does not render when safe deposit router address is missing', () => {
@@ -99,7 +99,7 @@ describe('SetCompensationMultiplierAction.vue', () => {
     await wrapper.find('[data-test="multiplier-input"]').setValue('abc')
     await vm.handleSetMultiplier()
 
-    expect(mockSafeDepositRouterWrites.setMultiplier.executeWrite).not.toHaveBeenCalled()
+    expect(mockSafeDepositRouterWrites.setMultiplier.mutateAsync).not.toHaveBeenCalled()
   })
 
   describe('schema validation', () => {
@@ -111,7 +111,7 @@ describe('SetCompensationMultiplierAction.vue', () => {
       await wrapper.find('form').trigger('submit')
       await flushPromises()
 
-      expect(mockSafeDepositRouterWrites.setMultiplier.executeWrite).not.toHaveBeenCalled()
+      expect(mockSafeDepositRouterWrites.setMultiplier.mutateAsync).not.toHaveBeenCalled()
       expect(wrapper.text()).toContain('Multiplier is required')
     })
 
@@ -123,7 +123,7 @@ describe('SetCompensationMultiplierAction.vue', () => {
       await wrapper.find('form').trigger('submit')
       await flushPromises()
 
-      expect(mockSafeDepositRouterWrites.setMultiplier.executeWrite).not.toHaveBeenCalled()
+      expect(mockSafeDepositRouterWrites.setMultiplier.mutateAsync).not.toHaveBeenCalled()
       expect(wrapper.text()).toContain('Must be a valid number')
     })
 
@@ -135,7 +135,7 @@ describe('SetCompensationMultiplierAction.vue', () => {
       await wrapper.find('form').trigger('submit')
       await flushPromises()
 
-      expect(mockSafeDepositRouterWrites.setMultiplier.executeWrite).not.toHaveBeenCalled()
+      expect(mockSafeDepositRouterWrites.setMultiplier.mutateAsync).not.toHaveBeenCalled()
       expect(wrapper.text()).toContain('Multiplier must be at least 1')
     })
 
@@ -147,7 +147,7 @@ describe('SetCompensationMultiplierAction.vue', () => {
       await wrapper.find('form').trigger('submit')
       await flushPromises()
 
-      expect(mockSafeDepositRouterWrites.setMultiplier.executeWrite).not.toHaveBeenCalled()
+      expect(mockSafeDepositRouterWrites.setMultiplier.mutateAsync).not.toHaveBeenCalled()
       expect(wrapper.text()).toContain('Multiplier is too large')
     })
   })
@@ -160,7 +160,7 @@ describe('SetCompensationMultiplierAction.vue', () => {
     await wrapper.find('[data-test="multiplier-input"]').setValue('3')
     await vm.handleSetMultiplier()
 
-    expect(mockSafeDepositRouterWrites.setMultiplier.executeWrite).toHaveBeenCalledTimes(1)
+    expect(mockSafeDepositRouterWrites.setMultiplier.mutateAsync).toHaveBeenCalledTimes(1)
   })
 
   it('handleSetMultiplier blocks submission when parse returns 0n', async () => {
@@ -172,13 +172,13 @@ describe('SetCompensationMultiplierAction.vue', () => {
     await wrapper.find('[data-test="multiplier-input"]').setValue('+3')
     await vm.handleSetMultiplier()
 
-    expect(mockSafeDepositRouterWrites.setMultiplier.executeWrite).not.toHaveBeenCalled()
+    expect(mockSafeDepositRouterWrites.setMultiplier.mutateAsync).not.toHaveBeenCalled()
   })
 
   it('watcher handles write error with generic message', async () => {
     const wrapper = createWrapper()
 
-    mockSafeDepositRouterWrites.setMultiplier.writeResult.error.value = new Error('boom')
+    mockSafeDepositRouterWrites.setMultiplier.error.value = new Error('boom')
     await nextTick()
 
     expect(wrapper.exists()).toBe(true)
@@ -189,7 +189,7 @@ describe('SetCompensationMultiplierAction.vue', () => {
     mockParseError.mockReturnValue('User rejected transaction')
     const wrapper = createWrapper()
 
-    mockSafeDepositRouterWrites.setMultiplier.writeResult.error.value = new Error('boom')
+    mockSafeDepositRouterWrites.setMultiplier.error.value = new Error('boom')
     await nextTick()
 
     expect(wrapper.exists()).toBe(true)
@@ -202,7 +202,7 @@ describe('SetCompensationMultiplierAction.vue', () => {
     await wrapper.find('[data-test="set-compensation-multiplier-button"]').trigger('click')
     expect(wrapper.find('[data-test="multiplier-input"]').exists()).toBe(true)
 
-    mockSafeDepositRouterWrites.setMultiplier.receiptResult.isSuccess.value = true
+    mockSafeDepositRouterWrites.setMultiplier.isSuccess.value = true
     await nextTick()
 
     expect(wrapper.find('[data-test="multiplier-input"]').exists()).toBe(false)

--- a/app/src/components/sections/SherTokenView/InvestorActions/__tests__/ToggleSherCompensationAction.spec.ts
+++ b/app/src/components/sections/SherTokenView/InvestorActions/__tests__/ToggleSherCompensationAction.spec.ts
@@ -34,9 +34,9 @@ describe('ToggleSherCompensationAction.vue', () => {
     mockUseConnection.isConnected.value = true
     mockUseConnection.address.value = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa'
 
-    mockSafeDepositRouterWrites.enableDeposits.executeWrite.mockResolvedValue(undefined)
-    mockSafeDepositRouterWrites.disableDeposits.executeWrite.mockResolvedValue(undefined)
-    mockSafeDepositRouterWrites.setSafeAddress.executeWrite.mockResolvedValue(undefined)
+    mockSafeDepositRouterWrites.enableDeposits.mutateAsync.mockResolvedValue(undefined)
+    mockSafeDepositRouterWrites.disableDeposits.mutateAsync.mockResolvedValue(undefined)
+    mockSafeDepositRouterWrites.setSafeAddress.mutateAsync.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -91,8 +91,8 @@ describe('ToggleSherCompensationAction.vue', () => {
 
     await vm.handleToggleCompensation()
 
-    expect(mockSafeDepositRouterWrites.enableDeposits.executeWrite).not.toHaveBeenCalled()
-    expect(mockSafeDepositRouterWrites.disableDeposits.executeWrite).not.toHaveBeenCalled()
+    expect(mockSafeDepositRouterWrites.enableDeposits.mutateAsync).not.toHaveBeenCalled()
+    expect(mockSafeDepositRouterWrites.disableDeposits.mutateAsync).not.toHaveBeenCalled()
   })
 
   it('disables deposits when currently enabled', async () => {
@@ -102,7 +102,7 @@ describe('ToggleSherCompensationAction.vue', () => {
 
     await vm.handleToggleCompensation()
 
-    expect(mockSafeDepositRouterWrites.disableDeposits.executeWrite).toHaveBeenCalledTimes(1)
+    expect(mockSafeDepositRouterWrites.disableDeposits.mutateAsync).toHaveBeenCalledTimes(1)
   })
 
   it('enables deposits directly when safe address is correct', async () => {
@@ -113,7 +113,7 @@ describe('ToggleSherCompensationAction.vue', () => {
 
     await vm.handleToggleCompensation()
 
-    expect(mockSafeDepositRouterWrites.enableDeposits.executeWrite).toHaveBeenCalledTimes(1)
+    expect(mockSafeDepositRouterWrites.enableDeposits.mutateAsync).toHaveBeenCalledTimes(1)
   })
 
   it('updates safe address before enabling when safe address mismatches', async () => {
@@ -124,8 +124,8 @@ describe('ToggleSherCompensationAction.vue', () => {
 
     await vm.handleToggleCompensation()
 
-    expect(mockSafeDepositRouterWrites.setSafeAddress.executeWrite).toHaveBeenCalledTimes(1)
-    expect(mockSafeDepositRouterWrites.enableDeposits.executeWrite).not.toHaveBeenCalled()
+    expect(mockSafeDepositRouterWrites.setSafeAddress.mutateAsync).toHaveBeenCalledTimes(1)
+    expect(mockSafeDepositRouterWrites.enableDeposits.mutateAsync).not.toHaveBeenCalled()
   })
 
   it('updateSafeAddress returns early when safe address is missing', async () => {
@@ -140,7 +140,7 @@ describe('ToggleSherCompensationAction.vue', () => {
     await vm.handleToggleCompensation()
     await vm.handleToggleCompensation()
 
-    expect(mockSafeDepositRouterWrites.setSafeAddress.executeWrite).not.toHaveBeenCalled()
+    expect(mockSafeDepositRouterWrites.setSafeAddress.mutateAsync).not.toHaveBeenCalled()
     expect(wrapper.exists()).toBe(true)
   })
 
@@ -153,19 +153,19 @@ describe('ToggleSherCompensationAction.vue', () => {
     const vm = wrapper.vm as unknown as { handleToggleCompensation: () => Promise<void> }
 
     await vm.handleToggleCompensation()
-    mockSafeDepositRouterWrites.setSafeAddress.receiptResult.isSuccess.value = true
+    mockSafeDepositRouterWrites.setSafeAddress.isSuccess.value = true
     await nextTick()
 
     vi.runAllTimers()
     await nextTick()
 
-    expect(mockSafeDepositRouterWrites.enableDeposits.executeWrite).toHaveBeenCalled()
+    expect(mockSafeDepositRouterWrites.enableDeposits.mutateAsync).toHaveBeenCalled()
     wrapper.unmount()
   })
 
   it('watch enable error path executes', async () => {
     const wrapper = createWrapper()
-    mockSafeDepositRouterWrites.enableDeposits.writeResult.error.value = new Error('boom')
+    mockSafeDepositRouterWrites.enableDeposits.error.value = new Error('boom')
     await nextTick()
     expect(wrapper.exists()).toBe(true)
     wrapper.unmount()
@@ -174,7 +174,7 @@ describe('ToggleSherCompensationAction.vue', () => {
   it('watch enable error handles user rejected message', async () => {
     mockParseError.mockReturnValue('User denied signature')
     const wrapper = createWrapper()
-    mockSafeDepositRouterWrites.enableDeposits.writeResult.error.value = new Error('boom')
+    mockSafeDepositRouterWrites.enableDeposits.error.value = new Error('boom')
     await nextTick()
     expect(wrapper.exists()).toBe(true)
     wrapper.unmount()
@@ -182,7 +182,7 @@ describe('ToggleSherCompensationAction.vue', () => {
 
   it('watch disable error path executes', async () => {
     const wrapper = createWrapper()
-    mockSafeDepositRouterWrites.disableDeposits.writeResult.error.value = new Error('boom')
+    mockSafeDepositRouterWrites.disableDeposits.error.value = new Error('boom')
     await nextTick()
     expect(wrapper.exists()).toBe(true)
     wrapper.unmount()
@@ -190,7 +190,7 @@ describe('ToggleSherCompensationAction.vue', () => {
 
   it('watch setSafeAddress error path executes', async () => {
     const wrapper = createWrapper()
-    mockSafeDepositRouterWrites.setSafeAddress.writeResult.error.value = new Error('boom')
+    mockSafeDepositRouterWrites.setSafeAddress.error.value = new Error('boom')
     await nextTick()
     expect(wrapper.exists()).toBe(true)
     wrapper.unmount()
@@ -198,8 +198,8 @@ describe('ToggleSherCompensationAction.vue', () => {
 
   it('watch success paths execute for enable and disable', async () => {
     const wrapper = createWrapper()
-    mockSafeDepositRouterWrites.enableDeposits.receiptResult.isSuccess.value = true
-    mockSafeDepositRouterWrites.disableDeposits.receiptResult.isSuccess.value = true
+    mockSafeDepositRouterWrites.enableDeposits.isSuccess.value = true
+    mockSafeDepositRouterWrites.disableDeposits.isSuccess.value = true
     await nextTick()
     expect(wrapper.exists()).toBe(true)
     wrapper.unmount()

--- a/app/src/composables/contracts/__tests__/useContractWritesV3.spec.ts
+++ b/app/src/composables/contracts/__tests__/useContractWritesV3.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
-import { BaseError, type Abi } from 'viem'
+import { BaseError, type Abi, type Address } from 'viem'
 import { simulateContract, writeContract, waitForTransactionReceipt } from '@wagmi/core'
 import {
   mockInvalidateQueries,
@@ -240,5 +240,66 @@ describe('useContractWritesV3 — input validation & logging', () => {
     await expect(m.mutateAsync({})).rejects.toBeInstanceOf(ContractWriteRevertedError)
 
     expect(mockLog.error).not.toHaveBeenCalled()
+  })
+})
+
+describe('useContractWritesV3 — caller callbacks', () => {
+  const baseConfig = (overrides: Partial<ContractWriteV3Config> = {}): ContractWriteV3Config => ({
+    contractAddress: ADDRESS,
+    abi: ABI as unknown as Abi,
+    functionName: 'foo',
+    ...overrides
+  })
+
+  it('awaits the caller onSuccess after invalidating the built-in reads', async () => {
+    vi.mocked(simulateContract).mockResolvedValueOnce(okSimulation)
+    vi.mocked(writeContract).mockResolvedValueOnce(HASH)
+    vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(successReceipt())
+
+    const order: string[] = []
+    mockInvalidateQueries.mockImplementationOnce(async () => {
+      order.push('builtin-invalidate')
+    })
+    const onSuccess = vi.fn(async () => {
+      order.push('caller-onSuccess-start')
+      await Promise.resolve()
+      order.push('caller-onSuccess-end')
+    })
+
+    const m = useContractWritesV3(baseConfig({ onSuccess }))
+    await m.mutateAsync({ args: [1n] })
+
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(onSuccess.mock.calls[0]![1]).toEqual({ args: [1n] })
+    expect(order).toEqual(['builtin-invalidate', 'caller-onSuccess-start', 'caller-onSuccess-end'])
+  })
+
+  it('still fires onSuccess when the address went undefined and built-in invalidation was skipped', async () => {
+    const address = ref<Address | undefined>(ADDRESS)
+    vi.mocked(simulateContract).mockResolvedValueOnce(okSimulation)
+    vi.mocked(writeContract).mockImplementationOnce(async () => {
+      address.value = undefined
+      return HASH
+    })
+    vi.mocked(waitForTransactionReceipt).mockResolvedValueOnce(successReceipt())
+
+    const onSuccess = vi.fn()
+    const m = useContractWritesV3(baseConfig({ contractAddress: address, onSuccess }))
+    await m.mutateAsync({})
+
+    expect(mockInvalidateQueries).not.toHaveBeenCalled()
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes the caller onError after the built-in failure log', async () => {
+    const err = new BaseError('boom')
+    vi.mocked(simulateContract).mockRejectedValueOnce(err)
+
+    const onError = vi.fn<NonNullable<ContractWriteV3Config['onError']>>()
+    const m = useContractWritesV3(baseConfig({ onError }))
+    await expect(m.mutateAsync({ args: [7n] })).rejects.toBe(err)
+
+    expect(mockLog.error).toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledWith(err, { args: [7n] })
   })
 })

--- a/app/src/composables/contracts/useContractWritesV3.ts
+++ b/app/src/composables/contracts/useContractWritesV3.ts
@@ -27,6 +27,19 @@ export interface ContractWriteV3Config {
   config?: {
     log?: boolean
   }
+  /**
+   * Runs after the built-in read-invalidation. Awaited, so `mutateAsync`
+   * resolves only once any cross-contract invalidation the caller queues here
+   * has settled.
+   */
+  onSuccess?: (
+    result: ExecuteContractWriteResult,
+    variables: ExecuteWriteVariables
+  ) => void | Promise<void>
+  /**
+   * Runs after the built-in error log. Must not throw.
+   */
+  onError?: (error: Error, variables: ExecuteWriteVariables) => void
 }
 
 export interface ExecuteWriteVariables {
@@ -208,14 +221,18 @@ export function useContractWritesV3(cfg: ContractWriteV3Config) {
           : undefined
       })
     },
-    onError: (error) => {
+    onError: (error, variables) => {
       if (shouldLog) {
         log.error(`useContractWritesV3(${unref(cfg.functionName)}) failed:\n`, parseErrorV2(error))
       }
+      cfg.onError?.(error, variables)
     },
-    onSuccess: async () => {
+    onSuccess: async (data, variables) => {
       const address = unref(cfg.contractAddress)
-      if (!address) return
+      if (!address) {
+        await cfg.onSuccess?.(data, variables)
+        return
+      }
       const chainId = unref(cfg.chainId)
       const addressLower = address.toLowerCase()
 
@@ -245,6 +262,7 @@ export function useContractWritesV3(cfg: ContractWriteV3Config) {
           return true
         }
       })
+      await cfg.onSuccess?.(data, variables)
     }
   })
 }

--- a/app/src/composables/safeDepositRouter/writes.ts
+++ b/app/src/composables/safeDepositRouter/writes.ts
@@ -1,239 +1,53 @@
-import { computed, type MaybeRef } from 'vue'
-import type { Address } from 'viem'
-import { useQueryClient } from '@tanstack/vue-query'
+import { computed } from 'vue'
 import { SAFE_DEPOSIT_ROUTER_ABI } from '@/artifacts/abi/safe-deposit-router'
-import { useContractWrites } from '@/composables/contracts/useContractWritesV2'
+import { useContractWritesV3 } from '@/composables/contracts/useContractWritesV3'
 import { useTeamStore } from '@/stores/teamStore'
 import type { ExtractAbiFunctionNames } from 'abitype'
 
 type SafeDepositRouterFunctionNames = ExtractAbiFunctionNames<typeof SAFE_DEPOSIT_ROUTER_ABI>
 
-// ============================================================================
-// Base Write Helper
-// ============================================================================
-function useSafeDepositRouterContractWrite(options: {
-  functionName: SafeDepositRouterFunctionNames
-  args?: MaybeRef<readonly unknown[]>
-  value?: MaybeRef<bigint>
-}) {
+function useSafeDepositRouterContractWrite(functionName: SafeDepositRouterFunctionNames) {
   const teamStore = useTeamStore()
-  const safeDepositRouterAddress = computed(() =>
-    teamStore.getContractAddressByType('SafeDepositRouter')
-  )
-
-  return useContractWrites({
-    contractAddress: safeDepositRouterAddress,
+  const contractAddress = computed(() => teamStore.getContractAddressByType('SafeDepositRouter'))
+  return useContractWritesV3({
+    contractAddress,
     abi: SAFE_DEPOSIT_ROUTER_ABI,
-    functionName: options.functionName,
-    args: options.args ?? [],
-    ...(options.value !== undefined ? { value: options.value } : {})
+    functionName
   })
 }
 
-// ============================================================================
-// Admin Functions - Simple Pattern (No Args)
-// ============================================================================
-
 export function useEnableDeposits() {
-  const write = useSafeDepositRouterContractWrite({
-    functionName: 'enableDeposits'
-  })
-
-  return {
-    ...write,
-    executeWrite: () => write.executeWrite([])
-  }
+  return useSafeDepositRouterContractWrite('enableDeposits')
 }
 
 export function useDisableDeposits() {
-  const write = useSafeDepositRouterContractWrite({
-    functionName: 'disableDeposits'
-  })
-
-  return {
-    ...write,
-    executeWrite: () => write.executeWrite([])
-  }
+  return useSafeDepositRouterContractWrite('disableDeposits')
 }
-
-// UNUSED — no consumers outside safeDepositRouter.setup.ts.
-/*
-export function usePauseContract() {
-  const write = useSafeDepositRouterContractWrite({
-    functionName: 'pause'
-  })
-
-  return {
-    ...write,
-    executeWrite: () => write.executeWrite([])
-  }
-}
-
-export function useUnpauseContract() {
-  const write = useSafeDepositRouterContractWrite({
-    functionName: 'unpause'
-  })
-
-  return {
-    ...write,
-    executeWrite: () => write.executeWrite([])
-  }
-}
-*/
 
 export function useRenounceOwnership() {
-  const write = useSafeDepositRouterContractWrite({
-    functionName: 'renounceOwnership'
-  })
-
-  return {
-    ...write,
-    executeWrite: () => write.executeWrite([])
-  }
+  return useSafeDepositRouterContractWrite('renounceOwnership')
 }
 
-// ============================================================================
-// Configuration Functions - Dynamic Args Pattern
-// ============================================================================
-
 export function useTransferOwnership() {
-  const write = useSafeDepositRouterContractWrite({
-    functionName: 'transferOwnership'
-  })
-
-  return {
-    ...write,
-    executeWrite: (newOwner: Address) => write.executeWrite([newOwner])
-  }
+  return useSafeDepositRouterContractWrite('transferOwnership')
 }
 
 export function useSetSafeAddress() {
-  const write = useSafeDepositRouterContractWrite({
-    functionName: 'setSafeAddress'
-  })
-
-  return {
-    ...write,
-    executeWrite: (newSafeAddress: Address) =>
-      write.executeWrite([newSafeAddress], undefined, { skipGasEstimation: true })
-  }
+  return useSafeDepositRouterContractWrite('setSafeAddress')
 }
 
 export function useSetMultiplier() {
-  const write = useSafeDepositRouterContractWrite({
-    functionName: 'setMultiplier'
-  })
-
-  return {
-    ...write,
-    executeWrite: (newMultiplier: bigint) =>
-      write.executeWrite([newMultiplier], undefined, { skipGasEstimation: true })
-  }
+  return useSafeDepositRouterContractWrite('setMultiplier')
 }
 
 export function useAddTokenSupport() {
-  const write = useSafeDepositRouterContractWrite({
-    functionName: 'addTokenSupport'
-  })
-
-  return {
-    ...write,
-    executeWrite: (tokenAddress: Address) => write.executeWrite([tokenAddress])
-  }
+  return useSafeDepositRouterContractWrite('addTokenSupport')
 }
 
 export function useRemoveTokenSupport() {
-  const write = useSafeDepositRouterContractWrite({
-    functionName: 'removeTokenSupport'
-  })
-
-  return {
-    ...write,
-    executeWrite: (tokenAddress: Address) => write.executeWrite([tokenAddress])
-  }
+  return useSafeDepositRouterContractWrite('removeTokenSupport')
 }
-
-// ============================================================================
-// Deposit Functions - With Custom Query Invalidation
-// ============================================================================
 
 export function useDeposit() {
-  const queryClient = useQueryClient()
-  const teamStore = useTeamStore()
-  const safeDepositRouterAddress = computed(() =>
-    teamStore.getContractAddressByType('SafeDepositRouter')
-  )
-
-  const write = useSafeDepositRouterContractWrite({
-    functionName: 'deposit'
-  })
-
-  // Override invalidateQueries for deposit-specific cache updates
-  const originalInvalidateQueries = write.invalidateQueries
-  write.invalidateQueries = async () => {
-    await originalInvalidateQueries()
-
-    // Invalidate SafeDepositRouter queries
-    await queryClient.invalidateQueries({
-      queryKey: ['readContract', { address: safeDepositRouterAddress.value }]
-    })
-
-    // Invalidate InvestorV1 queries (balance changes)
-    await queryClient.invalidateQueries({
-      queryKey: ['readContract', { address: teamStore.getContractAddressByType('InvestorV1') }]
-    })
-  }
-
-  return {
-    ...write,
-    // Always skip gas estimation for deposit (multi-step operation with approval dependency)
-    executeWrite: (tokenAddress: Address, amount: bigint) =>
-      write.executeWrite([tokenAddress, amount], undefined, { skipGasEstimation: true })
-  }
+  return useSafeDepositRouterContractWrite('deposit')
 }
-
-// UNUSED — no consumers outside safeDepositRouter.setup.ts.
-/*
-export function useDepositWithSlippage() {
-  const queryClient = useQueryClient()
-  const teamStore = useTeamStore()
-  const safeDepositRouterAddress = computed(() =>
-    teamStore.getContractAddressByType('SafeDepositRouter')
-  )
-
-  const write = useSafeDepositRouterContractWrite({
-    functionName: 'depositWithSlippage'
-  })
-
-  const originalInvalidateQueries = write.invalidateQueries
-  write.invalidateQueries = async () => {
-    await originalInvalidateQueries()
-
-    await queryClient.invalidateQueries({
-      queryKey: ['readContract', { address: safeDepositRouterAddress.value }]
-    })
-
-    await queryClient.invalidateQueries({
-      queryKey: ['readContract', { address: teamStore.getContractAddressByType('InvestorV1') }]
-    })
-  }
-
-  return {
-    ...write,
-    executeWrite: (tokenAddress: Address, amount: bigint, minSherOut: bigint) =>
-      write.executeWrite([tokenAddress, amount, minSherOut], undefined, { skipGasEstimation: true })
-  }
-}
-
-export function useRecoverERC20() {
-  const write = useSafeDepositRouterContractWrite({
-    functionName: 'recoverERC20'
-  })
-
-  return {
-    ...write,
-    executeWrite: (tokenAddress: Address, amount: bigint) =>
-      write.executeWrite([tokenAddress, amount])
-  }
-}
-*/

--- a/app/src/composables/safeDepositRouter/writes.ts
+++ b/app/src/composables/safeDepositRouter/writes.ts
@@ -1,7 +1,12 @@
 import { computed } from 'vue'
+import { useMutation, useQueryClient } from '@tanstack/vue-query'
 import { SAFE_DEPOSIT_ROUTER_ABI } from '@/artifacts/abi/safe-deposit-router'
-import { useContractWritesV3 } from '@/composables/contracts/useContractWritesV3'
+import {
+  useContractWritesV3,
+  executeContractWrite
+} from '@/composables/contracts/useContractWritesV3'
 import { useTeamStore } from '@/stores/teamStore'
+import { log, parseErrorV2 } from '@/utils'
 import type { ExtractAbiFunctionNames } from 'abitype'
 
 type SafeDepositRouterFunctionNames = ExtractAbiFunctionNames<typeof SAFE_DEPOSIT_ROUTER_ABI>
@@ -48,6 +53,53 @@ export function useRemoveTokenSupport() {
   return useSafeDepositRouterContractWrite('removeTokenSupport')
 }
 
+/**
+ * Deposit on SafeDepositRouter.
+ *
+ * Goes through `useMutation + executeContractWrite` (rather than the thin
+ * `useContractWritesV3` wrapper) so the success path can flush both the router
+ * reads *and* the InvestorV1 reads — depositing mints SHER, so balances /
+ * total supply on InvestorV1 also need to refetch. Cross-contract invalidation
+ * lives in the composable, not in every consumer.
+ */
 export function useDeposit() {
-  return useSafeDepositRouterContractWrite('deposit')
+  const queryClient = useQueryClient()
+  const teamStore = useTeamStore()
+
+  return useMutation({
+    mutationFn: async (variables: { args?: readonly unknown[]; value?: bigint } = {}) => {
+      const address = teamStore.getContractAddressByType('SafeDepositRouter')
+      if (!address) throw new Error('SafeDepositRouter address is undefined')
+      return executeContractWrite({
+        address,
+        abi: SAFE_DEPOSIT_ROUTER_ABI,
+        functionName: 'deposit',
+        args: variables.args,
+        value: variables.value
+      })
+    },
+    onSuccess: async () => {
+      const routerAddress = teamStore.getContractAddressByType('SafeDepositRouter')
+      const investorAddress = teamStore.getContractAddressByType('InvestorV1')
+      const invalidations: Promise<unknown>[] = []
+      if (routerAddress) {
+        invalidations.push(
+          queryClient.invalidateQueries({
+            queryKey: ['readContract', { address: routerAddress }]
+          })
+        )
+      }
+      if (investorAddress) {
+        invalidations.push(
+          queryClient.invalidateQueries({
+            queryKey: ['readContract', { address: investorAddress }]
+          })
+        )
+      }
+      await Promise.all(invalidations)
+    },
+    onError: (error) => {
+      log.error('useDeposit failed:\n', parseErrorV2(error))
+    }
+  })
 }

--- a/app/src/composables/safeDepositRouter/writes.ts
+++ b/app/src/composables/safeDepositRouter/writes.ts
@@ -1,12 +1,8 @@
 import { computed } from 'vue'
-import { useMutation, useQueryClient } from '@tanstack/vue-query'
+import { useQueryClient } from '@tanstack/vue-query'
 import { SAFE_DEPOSIT_ROUTER_ABI } from '@/artifacts/abi/safe-deposit-router'
-import {
-  useContractWritesV3,
-  executeContractWrite
-} from '@/composables/contracts/useContractWritesV3'
+import { useContractWritesV3 } from '@/composables/contracts/useContractWritesV3'
 import { useTeamStore } from '@/stores/teamStore'
-import { log, parseErrorV2 } from '@/utils'
 import type { ExtractAbiFunctionNames } from 'abitype'
 
 type SafeDepositRouterFunctionNames = ExtractAbiFunctionNames<typeof SAFE_DEPOSIT_ROUTER_ABI>
@@ -54,52 +50,32 @@ export function useRemoveTokenSupport() {
 }
 
 /**
- * Deposit on SafeDepositRouter.
- *
- * Goes through `useMutation + executeContractWrite` (rather than the thin
- * `useContractWritesV3` wrapper) so the success path can flush both the router
- * reads *and* the InvestorV1 reads — depositing mints SHER, so balances /
- * total supply on InvestorV1 also need to refetch. Cross-contract invalidation
- * lives in the composable, not in every consumer.
+ * `deposit` mints SHER, so reads on InvestorV1 must also be invalidated.
+ * The router's own reads are flushed by `useContractWritesV3`.
  */
 export function useDeposit() {
   const queryClient = useQueryClient()
   const teamStore = useTeamStore()
+  const contractAddress = computed(() => teamStore.getContractAddressByType('SafeDepositRouter'))
 
-  return useMutation({
-    mutationFn: async (variables: { args?: readonly unknown[]; value?: bigint } = {}) => {
-      const address = teamStore.getContractAddressByType('SafeDepositRouter')
-      if (!address) throw new Error('SafeDepositRouter address is undefined')
-      return executeContractWrite({
-        address,
-        abi: SAFE_DEPOSIT_ROUTER_ABI,
-        functionName: 'deposit',
-        args: variables.args,
-        value: variables.value
-      })
-    },
+  return useContractWritesV3({
+    contractAddress,
+    abi: SAFE_DEPOSIT_ROUTER_ABI,
+    functionName: 'deposit',
     onSuccess: async () => {
-      const routerAddress = teamStore.getContractAddressByType('SafeDepositRouter')
-      const investorAddress = teamStore.getContractAddressByType('InvestorV1')
-      const invalidations: Promise<unknown>[] = []
-      if (routerAddress) {
-        invalidations.push(
-          queryClient.invalidateQueries({
-            queryKey: ['readContract', { address: routerAddress }]
-          })
-        )
-      }
-      if (investorAddress) {
-        invalidations.push(
-          queryClient.invalidateQueries({
-            queryKey: ['readContract', { address: investorAddress }]
-          })
-        )
-      }
-      await Promise.all(invalidations)
-    },
-    onError: (error) => {
-      log.error('useDeposit failed:\n', parseErrorV2(error))
+      const investor = teamStore.getContractAddressByType('InvestorV1')
+      if (!investor) return
+      const investorLower = investor.toLowerCase()
+      await queryClient.invalidateQueries({
+        predicate: (query) => {
+          const key = query.queryKey
+          if (!Array.isArray(key) || key[0] !== 'readContract') return false
+          const params = key[1] as { address?: string } | undefined
+          return (
+            typeof params?.address === 'string' && params.address.toLowerCase() === investorLower
+          )
+        }
+      })
     }
   })
 }

--- a/app/src/tests/mocks/safeDepositRouter.mock.ts
+++ b/app/src/tests/mocks/safeDepositRouter.mock.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest'
 import { ref } from 'vue'
-import { createContractReadMock, createContractWriteMock } from './erc20.mock'
+import { createContractReadMock, createContractWriteV3Mock } from './erc20.mock'
 
 export const mockSafeDepositRouterAddress = ref('0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB')
 
@@ -18,19 +18,19 @@ export const mockSafeDepositRouterReads = {
 }
 
 export const mockSafeDepositRouterWrites = {
-  enableDeposits: createContractWriteMock(),
-  disableDeposits: createContractWriteMock(),
-  pause: createContractWriteMock(),
-  unpause: createContractWriteMock(),
-  renounceOwnership: createContractWriteMock(),
-  transferOwnership: createContractWriteMock(),
-  setSafeAddress: createContractWriteMock(),
-  setMultiplier: createContractWriteMock(),
-  addTokenSupport: createContractWriteMock(),
-  removeTokenSupport: createContractWriteMock(),
-  deposit: createContractWriteMock(),
-  depositWithSlippage: createContractWriteMock(),
-  recoverERC20: createContractWriteMock()
+  enableDeposits: createContractWriteV3Mock(),
+  disableDeposits: createContractWriteV3Mock(),
+  pause: createContractWriteV3Mock(),
+  unpause: createContractWriteV3Mock(),
+  renounceOwnership: createContractWriteV3Mock(),
+  transferOwnership: createContractWriteV3Mock(),
+  setSafeAddress: createContractWriteV3Mock(),
+  setMultiplier: createContractWriteV3Mock(),
+  addTokenSupport: createContractWriteV3Mock(),
+  removeTokenSupport: createContractWriteV3Mock(),
+  deposit: createContractWriteV3Mock(),
+  depositWithSlippage: createContractWriteV3Mock(),
+  recoverERC20: createContractWriteV3Mock()
 }
 
 export const resetSafeDepositRouterMocks = () => {
@@ -49,26 +49,19 @@ export const resetSafeDepositRouterMocks = () => {
   })
 
   Object.values(mockSafeDepositRouterWrites).forEach((mock) => {
-    mock.writeResult.data.value = null
-    mock.writeResult.error.value = null
-    mock.writeResult.isLoading.value = false
-    mock.writeResult.isSuccess.value = false
-    mock.writeResult.isError.value = false
-    mock.writeResult.isPending.value = false
-    mock.writeResult.status.value = 'idle'
+    mock.data.value = null
+    mock.error.value = null
+    mock.isPending.value = false
+    mock.isSuccess.value = false
+    mock.isError.value = false
+    mock.status.value = 'idle'
 
-    mock.receiptResult.data.value = null
-    mock.receiptResult.error.value = null
-    mock.receiptResult.isLoading.value = false
-    mock.receiptResult.isSuccess.value = false
-    mock.receiptResult.isError.value = false
-    mock.receiptResult.isPending.value = false
-    mock.receiptResult.status.value = 'idle'
-
-    if (vi.isMockFunction(mock.executeWrite)) {
-      mock.executeWrite.mockClear()
-      mock.executeWrite.mockResolvedValue(undefined)
+    if (vi.isMockFunction(mock.mutate)) mock.mutate.mockClear()
+    if (vi.isMockFunction(mock.mutateAsync)) {
+      mock.mutateAsync.mockClear()
+      mock.mutateAsync.mockResolvedValue(undefined)
     }
+    if (vi.isMockFunction(mock.reset)) mock.reset.mockClear()
   })
 
   mockSafeDepositRouterAddress.value = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'


### PR DESCRIPTION
Closes #1907 (sub-issue of #1857, parent #1798).

## Summary

- `safeDepositRouter/writes.ts` — replaced with thin V3 wrappers that return the TanStack mutation directly. Each `useXxx()` is now a single-line `useContractWritesV3({ contractAddress, abi, functionName })` call, mirroring the `bank/writes.ts` pattern.
- Three consumers updated to the V3 mutation API (`mutateAsync({ args })`, flat `isPending`/`isSuccess`/`error`):
  - `forms/SafeDepositRouterForm.vue`
  - `SherTokenView/InvestorActions/SetCompensationMultiplierAction.vue`
  - `SherTokenView/InvestorActions/ToggleSherCompensationAction.vue`
- Mocks switch from `createContractWriteMock` → `createContractWriteV3Mock` and the resetter is updated.
- `useContractWritesV3` gains optional `onSuccess` / `onError` callbacks (awaited after the built-in invalidation/log). `useDeposit` uses them to fan out invalidation to InvestorV1 reads, instead of bypassing V3 with a hand-rolled `useMutation`. This pattern also unblocks the `bod/` migration's post-write side effects.
- Specs updated — 191 tests pass.

## Why

V2's `useContractWrites` wraps `@wagmi/vue`'s `useWriteContract`/`useWaitForTransactionReceipt`. V3 (`useContractWritesV3`) is a TanStack mutation built on `@wagmi/core`'s standalone primitives — it throws on revert (so success branches see only confirmed writes), is framework-agnostic, and has cleaner cross-chain invalidation semantics. Consolidating on V3 unblocks deleting the V2 composable once the remaining `bod/` and `vesting/` writers also migrate.

## Notes for reviewer

- V2's `useDeposit` had an `invalidateQueries` override that flushed both SafeDepositRouter and InvestorV1 reads. The new V3 `onSuccess` hook restores that cross-contract behaviour from inside the composable itself — consumers no longer need to know about InvestorV1.
- No behaviour change for end users — same toasts, same modal flow, same step transitions.

## Out of scope

- `bod/writes.ts` and `vesting/writes.ts` migrations (still on V2) — tracked separately under #1857.
- Deleting `useContractWritesV2.ts` itself — blocked on the two remaining callers above.

## Test plan

- [x] `npm run test:unit -- --run src/composables/contracts safeDepositRouter` — 191/191 pass.
- [x] `npm run type-check` + `npm run lint` clean.
- [ ] Manual smoke: deposit USDC into SafeDepositRouter, toggle SHER compensation, set multiplier — all happy paths.