### PR TITLE
refactor: ♻️ derive Safe address from URL param instead of team store

### DIFF
--- a/app/src/views/team/[id]/Accounts/SafeView.vue
+++ b/app/src/views/team/[id]/Accounts/SafeView.vue
@@ -40,12 +40,9 @@ import GenericTokenHoldingsSection from '@/components/GenericTokenHoldingsSectio
 import SafeTransactions from '@/components/sections/SafeView/SafeTransactions.vue'
 import SafeIncomingTransactions from '@/components/sections/SafeView/SafeIncomingTransactions.vue'
 import SafeDeploymentCard from '@/components/sections/SafeView/SafeDeploymentCard.vue'
-import { useTeamStore } from '@/stores'
-
-import { type Address } from 'viem'
+import { type Address, isAddress } from 'viem'
 
 const route = useRoute()
-const teamStore = useTeamStore()
 
 const isLoadingSafe = ref(false)
 
@@ -54,8 +51,10 @@ const teamId = computed(() => {
   return id ? parseInt(id, 10) : null
 })
 
-// Computed property to get Safe address once per render cycle
-const safeAddress = computed(() => teamStore.getContractAddressByType('Safe') as Address)
+const safeAddress = computed(() => {
+  const address = route.params.address as string | undefined
+  return address && isAddress(address) ? (address as Address) : undefined
+})
 
 /**
  * Handle successful Safe deployment


### PR DESCRIPTION
## Summary

- Read `safeAddress` from `route.params.address` (validated via viem `isAddress`) in `SafeView.vue`.
- Drop the `useTeamStore` import — the route is the canonical source.

## Why

The route `/teams/:id/accounts/safe-account/:address` already carries the Safe address. Reading it from the store on top of that introduced a second source of truth that could drift from the URL the user actually opened.

Closes #1875

## Test plan

- [x] `npm run lint`
- [x] `npm run format-check`
- [x] `npm run type-check`
- [x] `npm run test:unit -- --run` (1665 passed)
- [ ] Manual: open a Safe via its URL and confirm the view loads with that exact address.
- [ ] Manual: open the route without `:address` (or with an invalid one) and confirm the deployment card / loading state shows.