### PR TITLE
refactor: ♻️ complete UAlert/useToast coverage in remaining forms

### DIFF
--- a/app/src/components/sections/AdministrationView/CurrentBoDElectionSection.vue
+++ b/app/src/components/sections/AdministrationView/CurrentBoDElectionSection.vue
@@ -29,15 +29,9 @@
             description="Create a new Board of Directors election to manage your team's leadership."
           >
             <template #body>
-              <UAlert
-                v-if="createElectionError"
-                color="error"
-                variant="soft"
-                :description="createElectionError"
-                class="mb-4"
-              />
               <CreateElectionForm
                 :is-loading="isLoadingCreateElection /*|| isConfirmingCreateElection*/"
+                :error-message="createElectionError"
                 @create-proposal="createElection"
                 @close-modal="() => (showCreateElectionModal = { mount: false, show: false })"
               />

--- a/app/src/components/sections/AdministrationView/forms/CreateElectionForm.vue
+++ b/app/src/components/sections/AdministrationView/forms/CreateElectionForm.vue
@@ -82,6 +82,16 @@
         </UFormField>
       </div>
 
+      <UAlert
+        v-if="errorMessage"
+        color="error"
+        variant="soft"
+        :description="errorMessage"
+        icon="i-lucide-circle-alert"
+        class="mt-2"
+        data-test="error-alert"
+      />
+
       <div class="flex justify-center">
         <UButton
           type="submit"
@@ -114,7 +124,9 @@ const startDateOpen = ref(false)
 const endDateOpen = ref(false)
 
 const emits = defineEmits(['createProposal'])
-defineProps<{ isLoading: boolean }>()
+withDefaults(defineProps<{ isLoading: boolean; errorMessage?: string }>(), {
+  errorMessage: ''
+})
 
 const formData = ref<Array<Pick<User, 'address' | 'name'>>>([])
 const errors = reactive({ startDate: '', endDate: '', candidates: '' })

--- a/app/src/components/sections/AdministrationView/forms/__tests__/CreateElectionForm.spec.ts
+++ b/app/src/components/sections/AdministrationView/forms/__tests__/CreateElectionForm.spec.ts
@@ -50,6 +50,19 @@ describe('CreateElectionForm.vue', () => {
     )
   })
 
+  it('renders error alert when errorMessage prop is set', async () => {
+    const wrapper = mount(CreateElectionForm, {
+      props: { isLoading: false, errorMessage: 'Contract reverted' }
+    })
+
+    const alert = wrapper.find('[data-test="error-alert"]')
+    expect(alert.exists()).toBe(true)
+    expect(alert.text()).toContain('Contract reverted')
+
+    await wrapper.setProps({ errorMessage: '' })
+    expect(wrapper.find('[data-test="error-alert"]').exists()).toBe(false)
+  })
+
   it('syncs input and popover v-model bindings with component state', async () => {
     const wrapper = mountComponent()
     const vm = getVm(wrapper)

--- a/app/src/components/sections/CashRemunerationView/EditClaims.vue
+++ b/app/src/components/sections/CashRemunerationView/EditClaims.vue
@@ -7,20 +7,11 @@
       :is-loading="isUpdating"
       :restrict-submit="isRestricted"
       :existing-files="existingFiles"
+      :error-message="updateClaimError?.message ?? ''"
+      error-title="Failed to update claim"
       @submit="updateClaim"
       @cancel="$emit('close')"
       @delete-file="deleteFile"
-    />
-
-    <UAlert
-      v-if="updateClaimError"
-      color="error"
-      variant="soft"
-      icon="i-heroicons-x-circle"
-      title="Failed to update claim"
-      :description="updateClaimError.message"
-      class="mt-4"
-      data-test="edit-claim-error"
     />
   </div>
 </template>

--- a/app/src/components/sections/CashRemunerationView/Form/ClaimForm.vue
+++ b/app/src/components/sections/CashRemunerationView/Form/ClaimForm.vue
@@ -102,6 +102,16 @@
       />
     </div>
 
+    <UAlert
+      v-if="errorMessage"
+      color="error"
+      variant="soft"
+      icon="i-heroicons-x-circle"
+      :title="errorTitle"
+      :description="errorMessage"
+      data-test="claim-error-alert"
+    />
+
     <div class="flex justify-center gap-4">
       <UButton
         v-if="isEdit"
@@ -143,6 +153,8 @@ interface Props {
   restrictSubmit?: boolean
   existingFiles?: Partial<ClaimFormFileData>[]
   deletingFileIndex?: number | null
+  errorMessage?: string
+  errorTitle?: string
 }
 
 const toast = useToast()
@@ -153,7 +165,9 @@ const props = withDefaults(defineProps<Props>(), {
   disabledWeekStarts: () => [],
   restrictSubmit: true,
   existingFiles: () => [],
-  deletingFileIndex: null
+  deletingFileIndex: null,
+  errorMessage: '',
+  errorTitle: 'Failed to submit claim'
 })
 
 const emit = defineEmits<{

--- a/app/src/components/sections/CashRemunerationView/Form/__tests__/ClaimForm.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/Form/__tests__/ClaimForm.spec.ts
@@ -60,6 +60,21 @@ describe('ClaimForm.vue', () => {
     resetUploadMock.mockClear()
   })
 
+  it('renders error alert when errorMessage prop is set', async () => {
+    const wrapper = createWrapper({
+      errorMessage: 'Server unavailable',
+      errorTitle: 'Failed to submit claim'
+    })
+
+    const alert = wrapper.find('[data-test="claim-error-alert"]')
+    expect(alert.exists()).toBe(true)
+    expect(alert.text()).toContain('Server unavailable')
+    expect(alert.text()).toContain('Failed to submit claim')
+
+    await wrapper.setProps({ errorMessage: '' })
+    expect(wrapper.find('[data-test="claim-error-alert"]').exists()).toBe(false)
+  })
+
   it('handles edit actions and prop updates', async () => {
     const wrapper = createWrapper({
       isEdit: true,

--- a/app/src/components/sections/CashRemunerationView/SubmitClaims.vue
+++ b/app/src/components/sections/CashRemunerationView/SubmitClaims.vue
@@ -24,17 +24,9 @@
           :is-loading="isWageClaimAdding"
           :disabled-week-starts="props.signedWeekStarts"
           :restrict-submit="isRestricted"
+          :error-message="addWageClaimError && errorMessage ? errorMessage.message : ''"
+          error-title="Failed to submit claim"
           @submit="handleSubmit"
-        />
-        <UAlert
-          v-if="addWageClaimError && errorMessage"
-          color="error"
-          variant="soft"
-          icon="i-heroicons-x-circle"
-          title="Failed to submit claim"
-          :description="errorMessage.message"
-          class="mt-4"
-          data-test="submit-claim-error"
         />
       </div>
     </template>

--- a/app/src/components/sections/CashRemunerationView/__tests__/EditClaims.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/__tests__/EditClaims.spec.ts
@@ -50,7 +50,9 @@ const ClaimFormStub = defineComponent({
     isEdit: { type: Boolean, required: false },
     isLoading: { type: Boolean, required: false },
     restrictSubmit: { type: Boolean, required: false },
-    existingFiles: { type: Array, required: false }
+    existingFiles: { type: Array, required: false },
+    errorMessage: { type: String, required: false, default: '' },
+    errorTitle: { type: String, required: false, default: '' }
   },
   emits: ['submit', 'cancel', 'delete-file'],
   setup(_, { expose }) {
@@ -114,7 +116,7 @@ describe('EditClaims', () => {
     expect(wrapper.emitted('close')).toBeUndefined()
   })
 
-  it('renders backend error message when mutation returns an error', async () => {
+  it('passes backend error message to ClaimForm when mutation returns an error', async () => {
     vi.mocked(useEditClaimWithFilesMutation).mockReturnValueOnce(
       createMockMutationResponse(null, false, new Error('Server unavailable')) as ReturnType<
         typeof useEditClaimWithFilesMutation
@@ -124,8 +126,9 @@ describe('EditClaims', () => {
     const wrapper = createWrapper()
     await flushPromises()
 
-    expect(wrapper.find('[data-test="edit-claim-error"]').exists()).toBe(true)
-    expect(wrapper.find('[data-test="edit-claim-error"]').text()).toContain('Server unavailable')
+    const form = wrapper.findComponent({ name: 'ClaimForm' })
+    expect(form.props('errorMessage')).toBe('Server unavailable')
+    expect(form.props('errorTitle')).toBe('Failed to update claim')
   })
 
   it('emits close when cancel is triggered', async () => {

--- a/app/src/components/sections/CashRemunerationView/__tests__/SubmitClaims.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/__tests__/SubmitClaims.spec.ts
@@ -16,7 +16,9 @@ const ClaimFormStub = defineComponent({
     initialData: { type: Object, required: false },
     isLoading: { type: Boolean, required: false },
     disabledWeekStarts: { type: Array, required: false },
-    restrictSubmit: { type: Boolean, required: false }
+    restrictSubmit: { type: Boolean, required: false },
+    errorMessage: { type: String, required: false, default: '' },
+    errorTitle: { type: String, required: false, default: '' }
   },
   emits: ['submit'],
   setup(_, { expose }) {

--- a/app/src/components/sections/ExpenseAccountView/ApprovedExpensesSection.vue
+++ b/app/src/components/sections/ExpenseAccountView/ApprovedExpensesSection.vue
@@ -197,6 +197,7 @@ const approveUser = async (data: BudgetLimit) => {
   approveUsersModal.value = { mount: false, show: false }
   approveErrorMessage.value = ''
   confirmationModal.value = false
+  toast.add({ title: 'User approved successfully', color: 'success' })
 }
 
 const errorMessage = (error: {}, message: string) =>

--- a/app/src/components/sections/ProposalsView/forms/CreateProposalForm.vue
+++ b/app/src/components/sections/ProposalsView/forms/CreateProposalForm.vue
@@ -77,6 +77,16 @@
       </UFormField>
     </div>
 
+    <UAlert
+      v-if="errorMessage"
+      color="error"
+      variant="soft"
+      icon="i-lucide-circle-alert"
+      :description="errorMessage"
+      class="mt-2"
+      data-test="error-alert"
+    />
+
     <div class="modal-action">
       <UButton color="error" variant="outline" @click="emit('closeModal')" label="Cancel" />
       <UButton
@@ -111,6 +121,7 @@ const toast = useToast()
 
 const startDateOpen = ref(false)
 const endDateOpen = ref(false)
+const errorMessage = ref('')
 
 const state = reactive({
   title: '',
@@ -170,23 +181,19 @@ const {
 const dateToTimestamp = (date: Date): number => Math.floor(date.getTime() / 1000)
 
 const handleSubmit = async () => {
-  try {
-    createProposal({
-      address: proposalsAddress.value,
-      abi: PROPOSALS_ABI,
-      functionName: 'createProposal',
-      args: [
-        state.title,
-        state.description,
-        state.type,
-        BigInt(dateToTimestamp(state.startDate!)),
-        BigInt(dateToTimestamp(state.endDate!))
-      ]
-    })
-  } catch (error) {
-    console.error('Error creating proposal:', error)
-    toast.add({ title: 'Failed to create proposal', color: 'error' })
-  }
+  errorMessage.value = ''
+  createProposal({
+    address: proposalsAddress.value,
+    abi: PROPOSALS_ABI,
+    functionName: 'createProposal',
+    args: [
+      state.title,
+      state.description,
+      state.type,
+      BigInt(dateToTimestamp(state.startDate!)),
+      BigInt(dateToTimestamp(state.endDate!))
+    ]
+  })
 }
 
 watch(isProposalCreated, (success) => {
@@ -199,10 +206,11 @@ watch(isProposalCreated, (success) => {
 watch(createError, (error) => {
   if (!error) return
   console.error(error)
+  errorMessage.value = error.message || 'Failed to create proposal'
 })
 
 watch(errorConfirmingProposal, (error) => {
   if (!error) return
-  toast.add({ title: 'Failed to confirm proposal creation', color: 'error' })
+  errorMessage.value = error.message || 'Failed to confirm proposal creation'
 })
 </script>


### PR DESCRIPTION
Closes #1911. Part of #1727.

## Summary

Verification of #1727 on 2026-05-11 found 5 forms not fully aligned with the convention (UAlert inside the form for errors, useToast for success). This PR brings them in line.

## Changes

- **CreateElectionForm + CurrentBoDElectionSection** — moved the contract-error UAlert from the modal body into the form via an `errorMessage` prop.
- **ClaimForm + SubmitClaims + EditClaims** — added `errorMessage` / `errorTitle` props to ClaimForm and render UAlert inside. The two parents now forward mutation errors through the prop instead of rendering a sibling UAlert.
- **CreateProposalForm** — replaced the error toast pattern with an in-form UAlert driven by `createError` / `errorConfirmingProposal`. Drops a dead try/catch around a synchronous `mutate()` call. Previously contract write errors were silent (only logged).
- **ApprovedExpensesSection** — added the missing success toast for the approve-user flow. The form delegates to this parent for the API call, so the toast belongs here.

`TransferForm` and `ApproveUsersEIP712Form` were also flagged in the audit but turned out to be false positives — both are pure delegating forms whose parent already toasts on success (TransferModal, ApprovedExpensesSection after this PR).

## Test plan

- [x] `npm run type-check` — no new errors vs `develop` (pre-existing `useToast` auto-import warnings unchanged)
- [x] `npx vitest run src/components/sections/{CashRemunerationView,AdministrationView,ProposalsView,ExpenseAccountView} src/components/forms` — 233 tests passing
- [ ] Manual smoke in `npm run dev`: trigger validation error / API error / success for each of the 5 forms; confirm UAlert renders inside the form on error, success toast fires, modal stays open on error and closes on success.