### PR TITLE
refactor: ♻️ remove direct @wagmi/core write calls from feature code

### DIFF
--- a/app/src/components/sections/AdministrationView/CurrentBoDElectionSection.vue
+++ b/app/src/components/sections/AdministrationView/CurrentBoDElectionSection.vue
@@ -72,15 +72,13 @@ import { computed, ref, watch } from 'vue'
 import CreateElectionForm from './forms/CreateElectionForm.vue'
 import { ELECTIONS_ABI } from '@/artifacts/abi/elections'
 import { useTeamStore } from '@/stores'
-import { simulateContract, writeContract, waitForTransactionReceipt } from '@wagmi/core'
 import type { OldProposal } from '@/types'
 import { log, parseError } from '@/utils'
-import { config } from '@/wagmi.config'
 import ElectionStatus from '@/components/sections/AdministrationView/ElectionStatus.vue'
 import ElectionStats from '@/components/sections/AdministrationView/ElectionStats.vue'
 import ElectionActions from './ElectionActions.vue'
 import CurrentBoDElection404 from './CurrentBoDElection404.vue'
-import { useBoDElections } from '@/composables/elections'
+import { useBoDElections, useElectionsCreateElection } from '@/composables/elections'
 import { useCreateElectionNotificationsMutation } from '@/queries/action.queries'
 
 const props = defineProps<{ electionId: bigint; isDetails?: boolean }>()
@@ -94,16 +92,17 @@ const showCreateElectionModal = ref({
   mount: false,
   show: false
 })
-const isLoadingCreateElection = ref(false)
 const createElectionError = ref('')
 
 const { mutateAsync: addElectionNotifications, error: electionNotificationError } =
   useCreateElectionNotificationsMutation()
 
+const { mutateAsync: writeCreateElection, isPending: isLoadingCreateElection } =
+  useElectionsCreateElection()
+
 const createElection = async (electionData: OldProposal) => {
   try {
     createElectionError.value = ''
-    isLoadingCreateElection.value = true
     if (!electionsAddress.value) {
       createElectionError.value = 'Elections contract address not found'
       return
@@ -124,25 +123,9 @@ const createElection = async (electionData: OldProposal) => {
       electionData.winnerCount,
       electionData.candidates?.map((c) => c.candidateAddress) || [],
       teamStore.currentTeam?.members.map((m) => m.address) || []
-    ]
+    ] as readonly unknown[]
 
-    await simulateContract(config, {
-      address: electionsAddress.value,
-      abi: ELECTIONS_ABI,
-      functionName: 'createElection',
-      args
-    })
-
-    const hash = await writeContract(config, {
-      address: electionsAddress.value,
-      abi: ELECTIONS_ABI,
-      functionName: 'createElection',
-      args
-    })
-
-    await waitForTransactionReceipt(config, {
-      hash
-    })
+    await writeCreateElection({ args })
 
     await addElectionNotifications({ pathParams: { teamId: teamStore.currentTeamId! } })
     toast.add({ title: 'Election created successfully!', color: 'success' })
@@ -151,8 +134,6 @@ const createElection = async (electionData: OldProposal) => {
   } catch (error) {
     createElectionError.value = parseError(error, ELECTIONS_ABI)
     log.error('creatingElection error:', error)
-  } finally {
-    isLoadingCreateElection.value = false
   }
 }
 

--- a/app/src/components/sections/AdministrationView/__tests__/CurrentBoDElectionSection.spec.ts
+++ b/app/src/components/sections/AdministrationView/__tests__/CurrentBoDElectionSection.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import ElectionComponent from '@/components/sections/AdministrationView/CurrentBoDElectionSection.vue'
-import { mockElectionsReads, mockWagmiCore } from '@/tests/mocks'
+import { mockElectionsReads, mockElectionsWrites } from '@/tests/mocks'
 
 describe('ElectionComponent', () => {
   let wrapper: ReturnType<typeof mount> | undefined
@@ -62,9 +62,7 @@ describe('ElectionComponent', () => {
     }
 
     beforeEach(() => {
-      mockWagmiCore.simulateContract.mockResolvedValue({})
-      mockWagmiCore.writeContract.mockResolvedValue('0xTXNHASH')
-      mockWagmiCore.waitForTransactionReceipt.mockResolvedValue({})
+      mockElectionsWrites.createElection.mutateAsync.mockResolvedValue({})
     })
 
     it('handles past start date by adjusting to future', async () => {
@@ -83,7 +81,9 @@ describe('ElectionComponent', () => {
 
       await vm.createElection(mockPastElectionData)
 
-      const args = mockWagmiCore.simulateContract.mock.calls[0]![1].args as unknown[]
+      const [{ args }] = mockElectionsWrites.createElection.mutateAsync.mock.calls[0]! as [
+        { args: readonly unknown[] }
+      ]
       const startTime = Number(args[2])
       const endTime = Number(args[3])
 

--- a/app/src/composables/elections/writes.ts
+++ b/app/src/composables/elections/writes.ts
@@ -1,7 +1,3 @@
-// UNUSED — all Elections write composables currently have no consumers
-// outside their own spec + mock setup. Kept for reference; re-enable when
-// wiring up an Elections write flow.
-/*
 import { computed } from 'vue'
 import { ELECTIONS_ABI } from '@/artifacts/abi/elections'
 import { useContractWritesV3 } from '@/composables/contracts/useContractWritesV3'
@@ -21,13 +17,3 @@ function useElectionsContractWrite(functionName: ElectionsFunctionName) {
 export function useElectionsCreateElection() {
   return useElectionsContractWrite('createElection')
 }
-
-export function useElectionsCastVote() {
-  return useElectionsContractWrite('castVote')
-}
-
-export function useElectionsPublishResults() {
-  return useElectionsContractWrite('publishResults')
-}
-*/
-export {}

--- a/app/src/composables/investor/__tests__/useShareholderMigration.spec.ts
+++ b/app/src/composables/investor/__tests__/useShareholderMigration.spec.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { readContract, writeContract, waitForTransactionReceipt } from '@wagmi/core'
+import { readContract } from '@wagmi/core'
 import {
   migrateShareholders,
   useMigrateShareholders,
   InconsistentSupplyError
 } from '../useShareholderMigration'
+import { executeContractWrite } from '@/composables/contracts/useContractWritesV3'
 import {
   useMutationFn,
   smartUseMutation,
@@ -12,6 +13,16 @@ import {
   mockInvalidateQueries
 } from '@/tests/mocks/composables.mock'
 import type { Address } from 'viem'
+
+// Stub out the V3 executor — we're testing the migration helper, not its
+// simulate/write/wait plumbing.
+vi.mock('@/composables/contracts/useContractWritesV3', async (importOriginal) => {
+  const actual = (await importOriginal()) as object
+  return {
+    ...actual,
+    executeContractWrite: vi.fn()
+  }
+})
 
 const PREV_OFFICER = '0x1111111111111111111111111111111111111111' as Address
 const OLD_INVESTOR = '0x2222222222222222222222222222222222222222' as Address
@@ -54,8 +65,11 @@ describe('migrateShareholders (pure)', () => {
 
   it('mints on the new InvestorV1 when supply is 0', async () => {
     stubReads({ shareholders, newSupply: 0n })
-    vi.mocked(writeContract).mockResolvedValue(TX_HASH)
-    vi.mocked(waitForTransactionReceipt).mockResolvedValue({ status: 'success' } as never)
+    vi.mocked(executeContractWrite).mockResolvedValue({
+      hash: TX_HASH,
+      receipt: { status: 'success' } as never,
+      simulation: {} as never
+    })
 
     const res = await migrateShareholders({
       previousOfficerAddress: PREV_OFFICER,
@@ -63,8 +77,7 @@ describe('migrateShareholders (pure)', () => {
     })
 
     expect(res).toEqual({ kind: 'done', migratedCount: 2, shareholders })
-    expect(writeContract).toHaveBeenCalledWith(
-      expect.anything(),
+    expect(executeContractWrite).toHaveBeenCalledWith(
       expect.objectContaining({
         address: NEW_INVESTOR,
         functionName: 'distributeMint',
@@ -76,7 +89,6 @@ describe('migrateShareholders (pure)', () => {
         ]
       })
     )
-    expect(waitForTransactionReceipt).toHaveBeenCalledWith(expect.anything(), { hash: TX_HASH })
   })
 
   it('returns noop-empty when the previous InvestorV1 has no shareholders', async () => {
@@ -88,7 +100,7 @@ describe('migrateShareholders (pure)', () => {
     })
 
     expect(res).toEqual({ kind: 'noop-empty' })
-    expect(writeContract).not.toHaveBeenCalled()
+    expect(executeContractWrite).not.toHaveBeenCalled()
   })
 
   it('returns noop-already-migrated when supply matches sum', async () => {
@@ -100,7 +112,7 @@ describe('migrateShareholders (pure)', () => {
     })
 
     expect(res).toEqual({ kind: 'noop-already-migrated', matchedCount: 2 })
-    expect(writeContract).not.toHaveBeenCalled()
+    expect(executeContractWrite).not.toHaveBeenCalled()
   })
 
   it('throws InconsistentSupplyError when supply is non-zero and differs', async () => {
@@ -112,7 +124,7 @@ describe('migrateShareholders (pure)', () => {
         newInvestorAddress: NEW_INVESTOR
       })
     ).rejects.toBeInstanceOf(InconsistentSupplyError)
-    expect(writeContract).not.toHaveBeenCalled()
+    expect(executeContractWrite).not.toHaveBeenCalled()
   })
 
   it('exposes newSupply and expectedSupply on the error', async () => {
@@ -158,8 +170,11 @@ describe('useMigrateShareholders (TanStack wrapper)', () => {
 
   it('resolves with done result when supply is 0', async () => {
     stubReads({ shareholders, newSupply: 0n })
-    vi.mocked(writeContract).mockResolvedValue(TX_HASH)
-    vi.mocked(waitForTransactionReceipt).mockResolvedValue({ status: 'success' } as never)
+    vi.mocked(executeContractWrite).mockResolvedValue({
+      hash: TX_HASH,
+      receipt: { status: 'success' } as never,
+      simulation: {} as never
+    })
 
     const m = useMigrateShareholders()
     const res = await m.mutateAsync({

--- a/app/src/composables/investor/useShareholderMigration.ts
+++ b/app/src/composables/investor/useShareholderMigration.ts
@@ -1,9 +1,10 @@
 import { useMutation } from '@tanstack/vue-query'
-import { readContract, writeContract, waitForTransactionReceipt } from '@wagmi/core'
+import { readContract } from '@wagmi/core'
 import type { Address } from 'viem'
 import { config } from '@/wagmi.config'
 import { INVESTOR_ABI } from '@/artifacts/abi/investors'
 import { OFFICER_ABI } from '@/artifacts/abi/officer'
+import { executeContractWrite } from '@/composables/contracts/useContractWritesV3'
 
 export interface Shareholder {
   shareholder: Address
@@ -89,13 +90,12 @@ export async function migrateShareholders(
     throw new InconsistentSupplyError(newSupply, expected)
   }
 
-  const hash = await writeContract(config, {
+  await executeContractWrite({
     address: args.newInvestorAddress,
     abi: INVESTOR_ABI,
     functionName: 'distributeMint',
     args: [shareholders.map((s) => ({ shareholder: s.shareholder, amount: s.amount }))]
   })
-  await waitForTransactionReceipt(config, { hash })
 
   return { kind: 'done', migratedCount: shareholders.length, shareholders }
 }

--- a/app/src/tests/setup/elections.setup.ts
+++ b/app/src/tests/setup/elections.setup.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest'
 import { computed } from 'vue'
 import type { Address } from 'viem'
-import { mockElectionsReads } from '../mocks/contract.mock'
+import { mockElectionsReads, mockElectionsWrites } from '../mocks/contract.mock'
 
 const MOCK_ELECTIONS_ADDRESS = '0x1234567890123456789012345678901234567890' as Address
 
@@ -19,5 +19,6 @@ vi.mock('@/composables/elections/reads', () => ({
   useElectionsHasVoted: vi.fn(() => mockElectionsReads.hasVoted)
 }))
 
-// All Elections write composables are unused; see src/composables/elections/writes.ts.
-// vi.mock('@/composables/elections/writes', () => ({}))
+vi.mock('@/composables/elections/writes', () => ({
+  useElectionsCreateElection: vi.fn(() => mockElectionsWrites.createElection)
+}))


### PR DESCRIPTION
Closes #1859.

Replaces direct `writeContract` / `waitForTransactionReceipt` / `simulateContract` (write-path) calls in feature code with `useContractWritesV3`-based helpers so the simulate → write → wait pipeline (and revert-cause decoding) goes through the shared path.

## Files migrated

- `app/src/composables/investor/useShareholderMigration.ts` — now calls `executeContractWrite` (the framework-agnostic standalone entry point) instead of `writeContract` + `waitForTransactionReceipt`.
- `app/src/components/sections/AdministrationView/CurrentBoDElectionSection.vue` — now consumes the new `useElectionsCreateElection` composable; the inline simulate/write/wait block is gone.
- `app/src/composables/elections/writes.ts` — `useElectionsCreateElection` re-enabled (was kept commented out as “unused”; the migration above is its first consumer).

`AddCampaignService.ts` was listed in the issue but is already removed (see PR #1910).

## Acceptance

- ✅ `grep -rE \"from '@wagmi/core'\" app/src` shows no `writeContract` / `waitForTransactionReceipt` imports in the migrated files (read-path `readContract` remains, which is explicitly out of scope).
- ✅ Specs covering each migrated path pass:
  - `useShareholderMigration.spec.ts` updated to mock `executeContractWrite` (10/10 pass).
  - `CurrentBoDElectionSection.spec.ts` updated to assert against `mockElectionsWrites.createElection.mutateAsync` (2/2 pass).
- ✅ Full unit suite passes: 197 files / 1659 tests.
- ✅ `npm run type-check` clean.

## Test plan

- [x] `npm run test:unit` — all 1659 tests pass
- [x] `npm run type-check` — clean
- [x] `npx prettier --check` on touched files — clean