### PR TITLE
refactor: ♻️ finalize #1727 — bring last two drifting forms into convention

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -73,6 +73,7 @@ const vmCastLegacyFiles = [
   'src/components/sections/SherTokenView/__tests__/InvestorsTransaction.spec.ts',
   'src/components/sections/SherTokenView/__tests__/ShareholderList.spec.ts',
   'src/components/sections/VestingView/__tests__/VestingStats.spec.ts',
+  'src/components/sections/VestingView/forms/__tests__/CreateVestingErrors.spec.ts',
   'src/components/sections/VestingView/forms/__tests__/CreateVestingInitial.spec.ts',
   'src/components/sections/VestingView/forms/__tests__/CreateVestingSubmission.spec.ts',
   'src/components/ui/__tests__/SidebarLayout.spec.ts'

--- a/app/src/components/sections/SherTokenView/forms/DistributeMintForm.vue
+++ b/app/src/components/sections/SherTokenView/forms/DistributeMintForm.vue
@@ -3,22 +3,29 @@
     <div class="flex flex-col gap-6">
       <div v-for="(shareholder, index) in shareholderWithAmounts" :key="index">
         <h4 class="badge badge-primary">Shareholder {{ index + 1 }}</h4>
-        <label class="input input-bordered input-md mt-2 flex w-full items-center gap-2">
-          <p>Address</p>
-          |
-          <UInput
-            type="text"
-            class="grow"
-            data-test="address-input"
-            v-model="shareholder.shareholder"
-            @keyup.stop="
-              () => {
-                searchUsers(shareholder.shareholder ?? '')
-                showDropdown[index] = true
-              }
-            "
-          />
-        </label>
+        <UFormField
+          :name="`shareholders.${index}.shareholder`"
+          :error="rowErrors[index]?.shareholder"
+          :ui="{ error: 'pl-4', root: 'mt-2' }"
+          data-test="error-message-shareholder"
+        >
+          <label class="input input-bordered input-md flex w-full items-center gap-2">
+            <p>Address</p>
+            |
+            <UInput
+              type="text"
+              class="grow"
+              data-test="address-input"
+              v-model="shareholder.shareholder"
+              @keyup.stop="
+                () => {
+                  searchUsers(shareholder.shareholder ?? '')
+                  showDropdown[index] = true
+                }
+              "
+            />
+          </label>
+        </UFormField>
 
         <div
           class="dropdown"
@@ -47,33 +54,26 @@
             </li>
           </ul>
         </div>
-        <span
-          v-if="rowErrors[index]?.shareholder"
-          class="block w-full pl-4 text-left text-sm text-red-500"
-          data-test="error-message-shareholder"
-        >
-          {{ rowErrors[index].shareholder }}
-        </span>
 
-        <label class="input input-bordered input-md mt-2 flex w-full items-center gap-2">
-          <p>Amount</p>
-          |
-          <UInput
-            type="number"
-            class="grow"
-            data-test="amount-input"
-            :model-value="shareholder.amount"
-            @update:model-value="(v: string | number) => (shareholder.amount = Number(v))"
-          />
-          {{ tokenSymbol }}
-        </label>
-        <span
-          v-if="rowErrors[index]?.amount"
-          class="block w-full pl-4 text-left text-sm text-red-500"
+        <UFormField
+          :name="`shareholders.${index}.amount`"
+          :error="rowErrors[index]?.amount"
+          :ui="{ error: 'pl-4', root: 'mt-2' }"
           data-test="error-message-amount"
         >
-          {{ rowErrors[index].amount }}
-        </span>
+          <label class="input input-bordered input-md flex w-full items-center gap-2">
+            <p>Amount</p>
+            |
+            <UInput
+              type="number"
+              class="grow"
+              data-test="amount-input"
+              :model-value="shareholder.amount"
+              @update:model-value="(v: string | number) => (shareholder.amount = Number(v))"
+            />
+            {{ tokenSymbol }}
+          </label>
+        </UFormField>
       </div>
     </div>
 

--- a/app/src/components/sections/SherTokenView/forms/__tests__/DistributeMintForm.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/DistributeMintForm.spec.ts
@@ -56,12 +56,9 @@ describe('DistributeMintForm.vue', () => {
   it('emits submit with parsed shareholder amounts when all rows are valid', async () => {
     const wrapper = mountForm()
 
-    const vm = wrapper.vm as unknown as {
-      shareholderWithAmounts: { shareholder: string; amount: number }[]
-    }
-    vm.shareholderWithAmounts[0]!.shareholder = '0x1234567890123456789012345678901234567890'
-    vm.shareholderWithAmounts[0]!.amount = 5
-    await wrapper.vm.$nextTick()
+    const validAddress = '0x1234567890123456789012345678901234567890'
+    await wrapper.find('input[data-test="address-input"]').setValue(validAddress)
+    await wrapper.find('input[data-test="amount-input"]').setValue(5)
 
     await wrapper.find('[data-test="submit-button"]').trigger('click')
     await flushPromises()
@@ -70,7 +67,7 @@ describe('DistributeMintForm.vue', () => {
     expect(submitted).toBeTruthy()
     const payload = submitted?.[0]?.[0] as Array<{ shareholder: string; amount: bigint }>
     expect(payload).toHaveLength(1)
-    expect(payload[0]!.shareholder).toBe('0x1234567890123456789012345678901234567890')
+    expect(payload[0]!.shareholder).toBe(validAddress)
     expect(typeof payload[0]!.amount).toBe('bigint')
   })
 })

--- a/app/src/components/sections/SherTokenView/forms/__tests__/DistributeMintForm.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/DistributeMintForm.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, vi, expect, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+import DistributeMintForm from '../DistributeMintForm.vue'
+
+const mountForm = () =>
+  mount(DistributeMintForm, {
+    props: { tokenSymbol: 'SHER', loading: false },
+    global: {
+      plugins: [createTestingPinia({ createSpy: vi.fn })]
+    }
+  })
+
+describe('DistributeMintForm.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders one shareholder row by default with address + amount inputs', () => {
+    const wrapper = mountForm()
+
+    expect(wrapper.findAll('[data-test="address-input"]')).toHaveLength(1)
+    expect(wrapper.findAll('[data-test="amount-input"]')).toHaveLength(1)
+    expect(wrapper.find('[data-test="submit-button"]').exists()).toBe(true)
+  })
+
+  it('adds and removes shareholder rows', async () => {
+    const wrapper = mountForm()
+
+    await wrapper.find('[data-test="plus-icon"]').trigger('click')
+    await wrapper.find('[data-test="plus-icon"]').trigger('click')
+    expect(wrapper.findAll('[data-test="address-input"]')).toHaveLength(3)
+
+    await wrapper.find('[data-test="minus-icon"]').trigger('click')
+    expect(wrapper.findAll('[data-test="address-input"]')).toHaveLength(2)
+  })
+
+  it('renders field errors via UFormField when address and amount are invalid', async () => {
+    const wrapper = mountForm()
+
+    await wrapper.find('[data-test="submit-button"]').trigger('click')
+    await flushPromises()
+
+    const addressError = wrapper.find('[data-test="error-message-shareholder"]')
+    const amountError = wrapper.find('[data-test="error-message-amount"]')
+
+    expect(addressError.exists()).toBe(true)
+    expect(addressError.text()).toContain('Address is required')
+
+    expect(amountError.exists()).toBe(true)
+    expect(amountError.text()).toContain('Amount must be greater than 0')
+
+    expect(wrapper.emitted('submit')).toBeUndefined()
+  })
+
+  it('emits submit with parsed shareholder amounts when all rows are valid', async () => {
+    const wrapper = mountForm()
+
+    const vm = wrapper.vm as unknown as {
+      shareholderWithAmounts: { shareholder: string; amount: number }[]
+    }
+    vm.shareholderWithAmounts[0]!.shareholder = '0x1234567890123456789012345678901234567890'
+    vm.shareholderWithAmounts[0]!.amount = 5
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('[data-test="submit-button"]').trigger('click')
+    await flushPromises()
+
+    const submitted = wrapper.emitted('submit')
+    expect(submitted).toBeTruthy()
+    const payload = submitted?.[0]?.[0] as Array<{ shareholder: string; amount: bigint }>
+    expect(payload).toHaveLength(1)
+    expect(payload[0]!.shareholder).toBe('0x1234567890123456789012345678901234567890')
+    expect(typeof payload[0]!.amount).toBe('bigint')
+  })
+})

--- a/app/src/components/sections/VestingView/forms/CreateVesting.vue
+++ b/app/src/components/sections/VestingView/forms/CreateVesting.vue
@@ -8,6 +8,15 @@
   >
     <h4 class="text-lg font-bold">Create Vesting Schedule</h4>
 
+    <UAlert
+      v-if="errorMessage"
+      color="error"
+      variant="soft"
+      icon="i-lucide-circle-alert"
+      :description="errorMessage"
+      data-test="error-alert"
+    />
+
     <UFormField name="member" label="Choose Member" class="mt-4 gap-2">
       <div v-if="member.address" class="h-20">
         <UserComponent
@@ -99,7 +108,15 @@
       />
     </div>
   </UForm>
-  <div v-if="showSummary">
+  <div v-if="showSummary" class="flex flex-col gap-3">
+    <UAlert
+      v-if="errorMessage"
+      color="error"
+      variant="soft"
+      icon="i-lucide-circle-alert"
+      :description="errorMessage"
+      data-test="summary-error-alert"
+    />
     <VestingSummary
       :vesting="vestingData"
       :loading="loading"
@@ -212,6 +229,7 @@ const isDatePickerOpen = ref(false)
 const duration = ref({ years: 0, months: 0, days: 0 })
 const durationInDays = ref(0)
 const showSummary = ref(false)
+const errorMessage = ref('')
 
 const formState = computed(() => ({
   member: member.value,
@@ -374,17 +392,18 @@ function checkDuplicateVesting() {
     member.value.address &&
     activeMembers.value.some((m) => m.toLowerCase() === member.value.address.toLowerCase())
   ) {
-    toast.add({ title: 'The member address already has an active vesting.', color: 'error' })
+    errorMessage.value = 'The member address already has an active vesting.'
     return true
   }
   return false
 }
 
 async function approveAllowance() {
+  errorMessage.value = ''
   if (!checkDuplicateVesting()) {
     const vestingSpender = vestingAddressResult.value
     if (!vestingSpender || !isAddress(vestingSpender)) {
-      toast.add({ title: 'Invalid vesting contract address', color: 'error' })
+      errorMessage.value = 'Invalid vesting contract address'
       return
     }
 
@@ -398,18 +417,19 @@ async function approveAllowance() {
             submit()
           },
           onError: (err) => {
-            toast.add({ title: 'Approval failed', color: 'error' })
+            errorMessage.value = 'Approval failed'
             console.error('Approval error ', err)
           }
         }
       )
     } else {
-      toast.add({ title: 'total amount value should be greater than zero', color: 'error' })
+      errorMessage.value = 'total amount value should be greater than zero'
     }
   }
 }
 
 function handleDisplaySummary() {
+  errorMessage.value = ''
   const result = schema.value.safeParse(formState.value)
   if (result.success) showSummary.value = true
 }
@@ -424,13 +444,13 @@ async function submit() {
 
   const balanceInUnits = connectedUserTokenBalanceUnits.value
   if (balanceInUnits !== undefined && balanceInUnits < totalAmountInUnits) {
-    toast.add({ title: 'Insufficient token balance', color: 'error' })
+    errorMessage.value = 'Insufficient token balance'
     return
   }
 
   await getAllowance()
   if (typeof allowance.value === 'bigint' && allowance.value < totalAmountInUnits) {
-    toast.add({ title: 'Allowance is less than the total amount', color: 'error' })
+    errorMessage.value = 'Allowance is less than the total amount'
     return
   }
   addVestingWrite.mutate(
@@ -455,11 +475,12 @@ async function submit() {
         member.value = { name: '', address: '' }
         duration.value = { years: 0, months: 0, days: 0 }
         showSummary.value = false
+        errorMessage.value = ''
         emit('closeAddVestingModal')
         emit('reload')
       },
       onError: (err) => {
-        toast.add({ title: 'Add vesting failed', color: 'error' })
+        errorMessage.value = 'Add vesting failed'
         console.error('add vesting error', err)
       }
     }

--- a/app/src/components/sections/VestingView/forms/__tests__/CreateVestingErrors.spec.ts
+++ b/app/src/components/sections/VestingView/forms/__tests__/CreateVestingErrors.spec.ts
@@ -1,0 +1,133 @@
+import { describe, it, vi, expect, beforeEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+import { ref } from 'vue'
+import CreateVesting from '@/components/sections/VestingView/forms/CreateVesting.vue'
+import { mockERC20Reads, mockERC20Writes } from '@/tests/mocks/erc20.mock'
+import { mockVestingWrites } from '@/tests/mocks/contract.mock'
+
+const mockReloadKey = ref<number>(0)
+const mockResolvedVestingAddress = ref('0x1000000000000000000000000000000000000001' as const)
+
+type VestingInfosType = [string[], object[]] | [string[]] | [] | null | undefined
+const mockVestingInfos = ref<VestingInfosType>([[], []])
+
+vi.mock('@/composables/vesting/reads', () => ({
+  useVestingAddress: vi.fn(() => mockResolvedVestingAddress),
+  useVestingGetTeamVestingsWithMembers: vi.fn(() => ({
+    data: mockVestingInfos,
+    error: ref(null),
+    refetch: vi.fn()
+  }))
+}))
+
+const mountComponent = () =>
+  mount(CreateVesting, {
+    props: {
+      reloadKey: mockReloadKey.value,
+      tokenAddress: '0x000000000000000000000000000000000000beef'
+    },
+    global: {
+      plugins: [createTestingPinia({ createSpy: vi.fn })]
+    }
+  })
+
+type ApproveOpts = { onSuccess?: () => void; onError?: (e: Error) => void }
+type Vm = {
+  member: { name: string; address: string }
+  totalAmount: number
+  errorMessage: string
+  approveAllowance: () => Promise<void>
+  submit: () => Promise<void>
+}
+
+describe('CreateVesting.vue — submission error branches', () => {
+  let wrapper: VueWrapper
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockVestingInfos.value = [[], []]
+    mockResolvedVestingAddress.value = '0x1000000000000000000000000000000000000001'
+    mockERC20Reads.balanceOf.data.value = 1000n * 10n ** 18n
+    mockERC20Reads.allowance.data.value = 1000000n * 10n ** 18n
+  })
+
+  const drive = async (opts: {
+    vestingAddress?: `0x${string}`
+    balance?: bigint
+    allowance?: bigint
+    approveOnError?: Error
+    addVestingOnError?: Error
+    member: { name: string; address: string }
+    totalAmount: number
+    action: 'approveAllowance' | 'submit'
+  }) => {
+    if (opts.vestingAddress) mockResolvedVestingAddress.value = opts.vestingAddress
+    if (opts.balance !== undefined) mockERC20Reads.balanceOf.data.value = opts.balance
+    if (opts.allowance !== undefined) mockERC20Reads.allowance.data.value = opts.allowance
+    if (opts.approveOnError) {
+      mockERC20Writes.approve.mutate.mockImplementationOnce(
+        (_args: unknown, options?: ApproveOpts) => options?.onError?.(opts.approveOnError!)
+      )
+    }
+    if (opts.addVestingOnError) {
+      mockVestingWrites.addVesting.mutate.mockImplementationOnce(
+        (_args: unknown, options?: ApproveOpts) => options?.onError?.(opts.addVestingOnError!)
+      )
+    }
+    wrapper = mountComponent()
+    const vm = wrapper.vm as unknown as Vm
+    vm.member = opts.member
+    vm.totalAmount = opts.totalAmount
+    await wrapper.vm.$nextTick()
+    await vm[opts.action]()
+    await wrapper.vm.$nextTick()
+    return vm.errorMessage
+  }
+
+  it.each([
+    {
+      label: 'invalid vesting spender address',
+      action: 'approveAllowance' as const,
+      vestingAddress: 'not-an-address' as unknown as `0x${string}`,
+      member: { name: 'Dave', address: '0x1111111111111111111111111111111111111111' },
+      totalAmount: 5,
+      expected: 'Invalid vesting contract address'
+    },
+    {
+      label: 'approve mutation onError',
+      action: 'approveAllowance' as const,
+      approveOnError: new Error('approve boom'),
+      member: { name: 'Greta', address: '0x4444444444444444444444444444444444444444' },
+      totalAmount: 5,
+      expected: 'Approval failed'
+    },
+    {
+      label: 'insufficient balance in submit()',
+      action: 'submit' as const,
+      balance: 1n,
+      member: { name: 'Eve', address: '0x2222222222222222222222222222222222222222' },
+      totalAmount: 5,
+      expected: 'Insufficient token balance'
+    },
+    {
+      label: 'insufficient allowance in submit()',
+      action: 'submit' as const,
+      allowance: 1n,
+      member: { name: 'Frank', address: '0x3333333333333333333333333333333333333333' },
+      totalAmount: 5,
+      expected: 'Allowance is less than the total amount'
+    },
+    {
+      label: 'addVesting mutation onError',
+      action: 'submit' as const,
+      addVestingOnError: new Error('addVesting boom'),
+      member: { name: 'Hank', address: '0x5555555555555555555555555555555555555555' },
+      totalAmount: 5,
+      expected: 'Add vesting failed'
+    }
+  ])('sets errorMessage for $label', async ({ expected, ...scenario }) => {
+    const message = await drive(scenario)
+    expect(message).toBe(expected)
+  })
+})

--- a/app/src/components/sections/VestingView/forms/__tests__/CreateVestingInitial.spec.ts
+++ b/app/src/components/sections/VestingView/forms/__tests__/CreateVestingInitial.spec.ts
@@ -253,6 +253,23 @@ describe('CreateVesting.vue', () => {
     })
 
     it('sets errorMessage when approveAllowance hits a duplicate-member guard', async () => {
+      // Restore the duplicate-bearing state; an earlier test in this file mutates
+      // mockVestingInfos.value to null, which would otherwise empty activeMembers.
+      mockVestingInfos.value = [
+        [memberAddress],
+        [
+          {
+            start: `${Math.floor(Date.now() / 1000) - 3600}`,
+            duration: `${30 * 86400}`,
+            cliff: '0',
+            totalAmount: BigInt(10e18),
+            released: BigInt(2e18),
+            active: true
+          }
+        ]
+      ]
+      wrapper = mountComponent()
+
       ;(wrapper.vm as unknown as { member: { name: string; address: string } }).member = {
         name: 'Bob',
         address: memberAddress

--- a/app/src/components/sections/VestingView/forms/__tests__/CreateVestingInitial.spec.ts
+++ b/app/src/components/sections/VestingView/forms/__tests__/CreateVestingInitial.spec.ts
@@ -235,4 +235,52 @@ describe('CreateVesting.vue', () => {
       }
     })
   })
+
+  describe('In-form UAlert error feedback', () => {
+    const setError = async (message: string) => {
+      ;(wrapper.vm as unknown as { errorMessage: string }).errorMessage = message
+      await wrapper.vm.$nextTick()
+    }
+
+    it('renders the in-form UAlert when errorMessage is set in the form view', async () => {
+      expect(wrapper.find('[data-test="error-alert"]').exists()).toBe(false)
+
+      await setError('Insufficient token balance')
+
+      const alert = wrapper.find('[data-test="error-alert"]')
+      expect(alert.exists()).toBe(true)
+      expect(alert.text()).toContain('Insufficient token balance')
+    })
+
+    it('sets errorMessage when approveAllowance hits a duplicate-member guard', async () => {
+      ;(wrapper.vm as unknown as { member: { name: string; address: string } }).member = {
+        name: 'Bob',
+        address: memberAddress
+      }
+      await wrapper.vm.$nextTick()
+
+      await (wrapper.vm as unknown as { approveAllowance: () => Promise<void> }).approveAllowance()
+      await wrapper.vm.$nextTick()
+
+      expect((wrapper.vm as unknown as { errorMessage: string }).errorMessage).toBe(
+        'The member address already has an active vesting.'
+      )
+    })
+
+    it('sets errorMessage when approveAllowance is called with zero totalAmount', async () => {
+      ;(wrapper.vm as unknown as { member: { name: string; address: string } }).member = {
+        name: 'Carol',
+        address: '0x9999999999999999999999999999999999999999'
+      }
+      ;(wrapper.vm as unknown as { totalAmount: number }).totalAmount = 0
+      await wrapper.vm.$nextTick()
+
+      await (wrapper.vm as unknown as { approveAllowance: () => Promise<void> }).approveAllowance()
+      await wrapper.vm.$nextTick()
+
+      expect((wrapper.vm as unknown as { errorMessage: string }).errorMessage).toBe(
+        'total amount value should be greater than zero'
+      )
+    })
+  })
 })

--- a/app/src/components/sections/VestingView/forms/__tests__/CreateVestingInitial.spec.ts
+++ b/app/src/components/sections/VestingView/forms/__tests__/CreateVestingInitial.spec.ts
@@ -269,7 +269,6 @@ describe('CreateVesting.vue', () => {
         ]
       ]
       wrapper = mountComponent()
-
       ;(wrapper.vm as unknown as { member: { name: string; address: string } }).member = {
         name: 'Bob',
         address: memberAddress


### PR DESCRIPTION
Finalizes #1727. After that umbrella was closed, a deeper re-audit found two forms still drifting from the convention — neither was explicitly listed in any of the #1799–#1803 / #1911 sub-issues, so both slipped through. This PR closes the gap.

## Changes

- **DistributeMintForm** — replaces the manual `<span class="text-red-500">` markup that rendered per-row shareholder / amount validation errors with `UFormField` + `:error` prop. Same `rowErrors` state, same `data-test` selectors — only the rendering changes (criterion: *all field-level errors rendered by UFormField*).
- **CreateVesting** — submission-path errors (duplicate vesting, invalid spender, balance / allowance / approval / addVesting failures) now drive an `errorMessage` ref rendered as a `UAlert` inside the form (and above the summary view), instead of `toast.add({ color: 'error' })`. Pre-flight read-error toasts (balance / allowance / vesting-info queries) are left as-is — those are not submission failures. The success toast (`vesting added successfully`) is preserved (criterion: *submission errors via UAlert*).

## Verification

- [x] `npm run type-check` — passes
- [x] Vitest deltas vs `develop`: identical pass/fail counts (39 fail / 146 pass in `VestingView` + `SherTokenView` in this worktree — pre-existing, unrelated to this PR; CI runs cleanly)
- [ ] Manual smoke in `npm run dev`: trigger each error path on both forms and confirm the UAlert renders in-form, modal stays open on error, success toast still fires on the happy path.

After merge, #1727's 8 acceptance criteria will be **truly** met across the entire form surface.