### PR TITLE
perf: ⚡️ replace @vuepic/vue-datepicker with custom UPopover month picker

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -26,7 +26,6 @@
         "@types/pdfmake": "^0.2.11",
         "@types/xlsx": "^0.0.35",
         "@vue/apollo-composable": "^4.2.1",
-        "@vuepic/vue-datepicker": "^11.0.3",
         "@vueuse/core": "^14.1.0",
         "@wagmi/core": "^3.0.0",
         "@wagmi/vue": "^0.4.3",
@@ -4722,16 +4721,6 @@
         }
       }
     },
-    "node_modules/@synthetixio/ethereum-wallet-mock/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@synthetixio/synpress": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@synthetixio/synpress/-/synpress-4.1.2.tgz",
@@ -7011,21 +7000,6 @@
         }
       }
     },
-    "node_modules/@vuepic/vue-datepicker": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-11.0.3.tgz",
-      "integrity": "sha512-sb2adwqwK2PizLQOpxCYps2SwhVT6/ic2HMIOqHJXuYa6iAJZWGL5YVlS7O4aW+sk6ZyxlDURLO7kDZPL4HB/w==",
-      "license": "MIT",
-      "dependencies": {
-        "date-fns": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "vue": ">=3.3.0"
-      }
-    },
     "node_modules/@vueuse/core": {
       "version": "14.2.1",
       "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.2.1.tgz",
@@ -8526,16 +8500,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dayjs": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -4721,6 +4721,16 @@
         }
       }
     },
+    "node_modules/@synthetixio/ethereum-wallet-mock/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "extraneous": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@synthetixio/synpress": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@synthetixio/synpress/-/synpress-4.1.2.tgz",
@@ -8500,6 +8510,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dayjs": {

--- a/app/package.json
+++ b/app/package.json
@@ -49,7 +49,6 @@
     "@types/pdfmake": "^0.2.11",
     "@types/xlsx": "^0.0.35",
     "@vue/apollo-composable": "^4.2.1",
-    "@vuepic/vue-datepicker": "^11.0.3",
     "@vueuse/core": "^14.1.0",
     "@wagmi/core": "^3.0.0",
     "@wagmi/vue": "^0.4.3",

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -47,7 +47,6 @@
 
 <script setup lang="ts">
 import { VueQueryDevtools } from '@tanstack/vue-query-devtools'
-import '@vuepic/vue-datepicker/dist/main.css'
 import { useChainId, useConnection, useConnectionEffect, useSwitchChain } from '@wagmi/vue'
 import { computed, watch } from 'vue'
 import { RouterView, useRoute } from 'vue-router'

--- a/app/src/components/MonthSelector.vue
+++ b/app/src/components/MonthSelector.vue
@@ -96,7 +96,20 @@ watch(
   }
 )
 
-const monthLabels = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+const monthLabels = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec'
+]
 
 function buildWeekFromMonth(year: number, month: number): Week {
   const day = dayjs.utc().year(year).month(month).startOf('month')
@@ -110,7 +123,9 @@ function buildWeekFromMonth(year: number, month: number): Week {
 }
 
 function isSelected(monthIdx: number): boolean {
-  return Boolean(model.value && model.value.year === viewYear.value && model.value.month === monthIdx)
+  return Boolean(
+    model.value && model.value.year === viewYear.value && model.value.month === monthIdx
+  )
 }
 
 function selectMonth(monthIdx: number) {

--- a/app/src/components/MonthSelector.vue
+++ b/app/src/components/MonthSelector.vue
@@ -7,27 +7,59 @@
       class="flex w-full items-center justify-center whitespace-nowrap sm:w-auto"
       size="sm"
       icon="heroicons:chevron-left"
+      data-test="prev-month"
     />
 
     <div class="relative w-full text-center sm:w-auto">
-      <VueDatePicker
-        v-model="monthPicked"
-        :month-picker="true"
-        :year-picker="true"
-        auto-apply
-        class="w-full rounded-sm bg-white sm:w-auto"
-      >
-        <template #trigger>
-          <UButton
-            @click="toggleMonthPicker"
-            class="flex w-full items-center justify-center whitespace-nowrap sm:w-auto"
-            size="sm"
-          >
-            <span v-if="model">{{ formatMonthYear(model.year, model.month) }}</span>
-            <IconifyIcon icon="heroicons:chevron-down" class="ml-1 h-4 w-4" />
-          </UButton>
+      <UPopover v-model:open="isMonthPickerOpen" :content="{ align: 'center' }">
+        <UButton
+          class="flex w-full items-center justify-center whitespace-nowrap sm:w-auto"
+          size="sm"
+          data-test="month-picker-trigger"
+        >
+          <span v-if="model">{{ formatMonthYear(model.year, model.month) }}</span>
+          <IconifyIcon icon="heroicons:chevron-down" class="ml-1 h-4 w-4" />
+        </UButton>
+        <template #content>
+          <div class="w-64 p-3" data-test="month-picker-panel">
+            <div class="mb-3 flex items-center justify-between">
+              <UButton
+                size="xs"
+                variant="ghost"
+                color="neutral"
+                icon="heroicons:chevron-left"
+                aria-label="Previous year"
+                data-test="prev-year"
+                @click="viewYear -= 1"
+              />
+              <span class="text-sm font-medium">{{ viewYear }}</span>
+              <UButton
+                size="xs"
+                variant="ghost"
+                color="neutral"
+                icon="heroicons:chevron-right"
+                aria-label="Next year"
+                data-test="next-year"
+                @click="viewYear += 1"
+              />
+            </div>
+            <div class="grid grid-cols-3 gap-1">
+              <UButton
+                v-for="(name, idx) in monthLabels"
+                :key="idx"
+                :variant="isSelected(idx) ? 'solid' : 'ghost'"
+                :color="isSelected(idx) ? 'primary' : 'neutral'"
+                size="sm"
+                block
+                :data-test="`month-${idx}`"
+                @click="selectMonth(idx)"
+              >
+                {{ name }}
+              </UButton>
+            </div>
+          </div>
         </template>
-      </VueDatePicker>
+      </UPopover>
     </div>
 
     <UButton
@@ -35,13 +67,13 @@
       class="flex w-full items-center justify-center whitespace-nowrap sm:w-auto"
       size="sm"
       icon="heroicons:chevron-right"
+      data-test="next-month"
     />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import VueDatePicker from '@vuepic/vue-datepicker'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import isoWeek from 'dayjs/plugin/isoWeek'
@@ -54,25 +86,37 @@ dayjs.extend(isoWeek)
 
 const model = defineModel<Week>()
 
-// monthPicked is { month, year, isoWeek }
-const monthPicked = ref<Week | null>(null)
 const isMonthPickerOpen = ref(false)
+const viewYear = ref(model.value?.year ?? dayjs.utc().year())
 
-// When monthPicked changes, update model
-watch(monthPicked, (newVal) => {
-  if (newVal) {
-    const day = dayjs.utc().year(newVal.year).month(newVal.month).startOf('month')
-    model.value = {
-      month: newVal.month,
-      year: newVal.year,
-      isoWeek: day.isoWeek(),
-      formatted: formatIsoWeekRange(day),
-      isoString: day.startOf('isoWeek').toISOString()
-    }
+watch(
+  () => model.value?.year,
+  (year) => {
+    if (year !== undefined) viewYear.value = year
   }
-})
+)
 
-// Formatting helpers imported from utils
+const monthLabels = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+function buildWeekFromMonth(year: number, month: number): Week {
+  const day = dayjs.utc().year(year).month(month).startOf('month')
+  return {
+    month,
+    year,
+    isoWeek: day.isoWeek(),
+    formatted: formatIsoWeekRange(day),
+    isoString: day.startOf('isoWeek').toISOString()
+  }
+}
+
+function isSelected(monthIdx: number): boolean {
+  return Boolean(model.value && model.value.year === viewYear.value && model.value.month === monthIdx)
+}
+
+function selectMonth(monthIdx: number) {
+  model.value = buildWeekFromMonth(viewYear.value, monthIdx)
+  isMonthPickerOpen.value = false
+}
 
 function goToPrevMonth() {
   if (!model.value) return
@@ -83,18 +127,7 @@ function goToPrevMonth() {
   } else {
     month -= 1
   }
-  const monthFirstDate = dayjs.utc(new Date(year, month, 1)).startOf('month')
-  const isoWeek = dayjs.utc(new Date(year, month, 1)).isoWeek()
-
-  const format = formatIsoWeekRange(monthFirstDate)
-
-  model.value = {
-    month,
-    year,
-    isoWeek,
-    formatted: format,
-    isoString: monthFirstDate.startOf('isoWeek').toISOString()
-  }
+  model.value = buildWeekFromMonth(year, month)
 }
 
 function goToNextMonth() {
@@ -106,21 +139,6 @@ function goToNextMonth() {
   } else {
     month += 1
   }
-  const monthFirstDate = dayjs.utc(new Date(year, month, 1)).startOf('month')
-  const isoWeek = dayjs.utc(new Date(year, month, 1)).isoWeek()
-
-  const format = formatIsoWeekRange(monthFirstDate)
-
-  model.value = {
-    month,
-    year,
-    isoWeek,
-    formatted: format,
-    isoString: monthFirstDate.startOf('isoWeek').toISOString()
-  }
-}
-
-function toggleMonthPicker() {
-  isMonthPickerOpen.value = !isMonthPickerOpen.value
+  model.value = buildWeekFromMonth(year, month)
 }
 </script>

--- a/app/src/components/__tests__/MonthSelector.spec.ts
+++ b/app/src/components/__tests__/MonthSelector.spec.ts
@@ -149,6 +149,48 @@ describe('MonthSelector', () => {
     })
   })
 
+  describe('viewYear synchronization', () => {
+    it('falls back to current year when initial modelValue is undefined', async () => {
+      const wrapper = mount(MonthSelector, {
+        global: {
+          components: {
+            UButton: {
+              template:
+                '<button :data-test="$attrs[\'data-test\']" @click="$emit(\'click\', $event)"><slot /></button>'
+            },
+            UPopover: {
+              template: '<div><slot /><slot name="content" /></div>',
+              props: ['open']
+            },
+            IconifyIcon: {
+              template: '<span :class="icon" />',
+              props: ['icon']
+            }
+          }
+        }
+      })
+      const currentYear = dayjs.utc().year()
+      expect(wrapper.text()).toContain(String(currentYear))
+    })
+
+    it('updates viewYear when modelValue.year changes from the parent', async () => {
+      const wrapper = createWrapper({ month: 5, year: 2024 })
+      expect(wrapper.text()).toContain('2024')
+
+      await wrapper.setProps({
+        modelValue: {
+          month: 5,
+          year: 2030,
+          isoWeek: 23,
+          formatted: '2030-W23',
+          isoString: dayjs.utc('2030-06-01').toISOString()
+        }
+      })
+
+      expect(wrapper.text()).toContain('2030')
+    })
+  })
+
   describe('Model Updates Structure', () => {
     it('should emit correct model structure when month changes', async () => {
       const initialModel = {

--- a/app/src/components/__tests__/MonthSelector.spec.ts
+++ b/app/src/components/__tests__/MonthSelector.spec.ts
@@ -29,11 +29,12 @@ describe('MonthSelector', () => {
       global: {
         components: {
           UButton: {
-            template: '<button><slot /></button>'
+            template:
+              '<button :data-test="$attrs[\'data-test\']" @click="$emit(\'click\', $event)"><slot /></button>'
           },
-          VueDatePicker: {
-            template: '<div><slot name="trigger" /></div>',
-            props: ['modelValue', 'monthPicker', 'yearPicker', 'autoApply']
+          UPopover: {
+            template: '<div><slot /><slot name="content" /></div>',
+            props: ['open']
           },
           IconifyIcon: {
             template: '<span :class="icon" />',
@@ -48,25 +49,36 @@ describe('MonthSelector', () => {
     vi.clearAllMocks()
   })
 
-  describe('Watcher', () => {
-    it('updates model when monthPicked changes', async () => {
-      const wrapper = createWrapper()
-      const setup = (wrapper.vm as unknown as { $?: { setupState?: Record<string, unknown> } }).$
-        ?.setupState
-      const payload = { month: 2, year: 2023 }
-      if (!setup) throw new Error('setupState not available')
-      ;(setup as { monthPicked?: unknown }).monthPicked = payload
+  describe('Month selection from picker', () => {
+    it('emits updated model when a month is picked', async () => {
+      const wrapper = createWrapper({ month: 5, year: 2024 })
+      const marchButton = wrapper.find('[data-test="month-2"]')
+      await marchButton.trigger('click')
       await wrapper.vm.$nextTick()
 
       const emitted = wrapper.emitted('update:modelValue')?.[0]?.[0]
-      const d = dayjs.utc().year(2023).month(2).startOf('month')
+      const d = dayjs.utc().year(2024).month(2).startOf('month')
       expect(emitted).toEqual({
         month: 2,
-        year: 2023,
+        year: 2024,
         isoWeek: d.isoWeek(),
         formatted: formatIsoWeekRange(d),
         isoString: d.startOf('isoWeek').toISOString()
       })
+    })
+
+    it('navigates view year forward and selects in the new year', async () => {
+      const wrapper = createWrapper({ month: 5, year: 2024 })
+      await wrapper.find('[data-test="next-year"]').trigger('click')
+      await wrapper.find('[data-test="month-0"]').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      const emitted = wrapper.emitted('update:modelValue')?.[0]?.[0] as {
+        month: number
+        year: number
+      }
+      expect(emitted.month).toBe(0)
+      expect(emitted.year).toBe(2025)
     })
   })
 
@@ -81,9 +93,7 @@ describe('MonthSelector', () => {
       }
 
       const wrapper = createWrapper(initialModel)
-      const prevButton = wrapper.findAll('button')[0]
-
-      await prevButton.trigger('click')
+      await wrapper.find('[data-test="prev-month"]').trigger('click')
       await wrapper.vm.$nextTick()
 
       const emitted = wrapper.emitted('update:modelValue')
@@ -106,9 +116,7 @@ describe('MonthSelector', () => {
       }
 
       const wrapper = createWrapper(initialModel)
-      const prevButton = wrapper.findAll('button')[0]
-
-      await prevButton.trigger('click')
+      await wrapper.find('[data-test="prev-month"]').trigger('click')
       await wrapper.vm.$nextTick()
 
       const emitted = wrapper.emitted('update:modelValue')
@@ -130,9 +138,7 @@ describe('MonthSelector', () => {
       }
 
       const wrapper = createWrapper(initialModel)
-      const nextButton = wrapper.findAll('button')[2]
-
-      await nextButton.trigger('click')
+      await wrapper.find('[data-test="next-month"]').trigger('click')
       await wrapper.vm.$nextTick()
 
       const emitted = wrapper.emitted('update:modelValue')
@@ -154,9 +160,7 @@ describe('MonthSelector', () => {
       }
 
       const wrapper = createWrapper(initialModel)
-      const nextButton = wrapper.findAll('button')[2]
-
-      await nextButton.trigger('click')
+      await wrapper.find('[data-test="next-month"]').trigger('click')
       await wrapper.vm.$nextTick()
 
       const emitted = wrapper.emitted('update:modelValue')
@@ -168,29 +172,6 @@ describe('MonthSelector', () => {
       expect(newValue).toHaveProperty('isoWeek')
       expect(newValue).toHaveProperty('formatted')
       expect(newValue).toHaveProperty('isoString')
-    })
-  })
-
-  describe('toggleMonthPicker', () => {
-    it('toggles isMonthPickerOpen when center button is clicked', async () => {
-      const wrapper = createWrapper()
-      const setup = (
-        wrapper.vm as unknown as { $?: { setupState?: { isMonthPickerOpen?: boolean } } }
-      ).$?.setupState
-      if (!setup) throw new Error('setupState not available')
-
-      // initial value should be false
-      expect(Boolean((setup as { isMonthPickerOpen?: boolean }).isMonthPickerOpen)).toBe(false)
-
-      const centerButton = wrapper.findAll('button')[1]
-      await centerButton.trigger('click')
-      await wrapper.vm.$nextTick()
-      expect((setup as { isMonthPickerOpen?: boolean }).isMonthPickerOpen).toBe(true)
-
-      // clicking again should close
-      await centerButton.trigger('click')
-      await wrapper.vm.$nextTick()
-      expect((setup as { isMonthPickerOpen?: boolean }).isMonthPickerOpen).toBe(false)
     })
   })
 })

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -9,7 +9,6 @@ import router from './router'
 import apolloClient from './apollo-client'
 import { DefaultApolloClient } from '@vue/apollo-composable'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
-import VueDatePicker from '@vuepic/vue-datepicker'
 import * as Sentry from '@sentry/vue'
 import ui from '@nuxt/ui/vue-plugin'
 import { setupAuthInterceptor } from '@/lib/axios'
@@ -38,8 +37,6 @@ export function setupApp() {
   app.use(WagmiPlugin, { config })
   app.use(VueQueryPlugin, { queryClient, enableDevtoolsV6Plugin: true })
   app.provide(DefaultApolloClient, apolloClient)
-
-  app.component('VueDatePicker', VueDatePicker)
 
   // Setup axios interceptors after app initialization
   // This ensures router and Pinia are fully available for the interceptor


### PR DESCRIPTION
# Description

## Initial Issue Description

Fixes #1702 — [Perf] Remove `@vuepic/vue-datepicker` and use a Nuxt UI–native picker. The library was only used to drive the month/year picker inside `MonthSelector.vue`, so the whole dependency is dead weight.

Also progresses #1735 (full migration to Nuxt UI): closes the "Remove vuepic" acceptance criterion. The "Remove DaisyUI" criterion remains open and will be tracked in a follow-up.

## PR Summary

Replaces the `VueDatePicker` trigger in [MonthSelector.vue](app/src/components/MonthSelector.vue) with a self-contained `UPopover` panel:

- 3×4 month grid (Jan–Dec) built from `UButton`s; selected month gets `solid primary`, others `ghost neutral`.
- Year arrows above the grid (`← 2026 →`) instead of the library's separate year picker.
- The prev / next month side buttons keep the same wrap-around behavior they had before.
- The three call sites that built a `Week` from `(year, month)` are deduplicated into one `buildWeekFromMonth` helper, so the model contract (`isoString` = Monday of the ISO week containing the 1st, etc.) is preserved.

Then the dependency itself goes away:

- `@vuepic/vue-datepicker` removed from [package.json](app/package.json) and the lockfile.
- Global `app.component('VueDatePicker', …)` registration removed from [main.ts](app/src/main.ts).
- `import '@vuepic/vue-datepicker/dist/main.css'` removed from [App.vue](app/src/App.vue).

### Alternative considered

Reka UI's `MonthPickerRoot` (the primitive Nuxt UI inherits, currently alpha and not re-exported as `UMonthPicker`) was prototyped. It gives built-in arrow-key navigation and ARIA wiring but requires bridging `Week ↔ CalendarDate` and styling ~10 headless sub-components for a feature that only needs to pick a month. Net code is similar, surface area is larger, and the API is still alpha — so the custom popover wins here. Swapping it in later remains mechanical because the model logic is isolated in `buildWeekFromMonth`.

### Tests

[MonthSelector.spec.ts](app/src/components/__tests__/MonthSelector.spec.ts) is rewritten away from poking the old library's `setupState.monthPicked` and now drives the component through DOM clicks (`data-test="month-N"`, `data-test="next-year"`, `data-test="prev-month"`, …). Eight tests cover: picking a month from the grid, navigating the view year forward then picking, prev / next month with year wrap on both ends, the emitted `Week` shape, `viewYear` falling back to the current year when `modelValue` is undefined, and the parent-driven model.year watcher.

- `npm run test:unit` — 1659+/1659+ pass
- `npm run type-check` — clean
- `npm run lint` — clean

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) — removes a dependency without changing the UX contract
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines (conventional commits + gitmoji, atomic)
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated — n/a, no public-facing API change