### PR TITLE
feat: ✨ support wildcard origins in backend FRONTEND_URL (CORS)

### DIFF
--- a/backend/src/config/serverConfig.ts
+++ b/backend/src/config/serverConfig.ts
@@ -30,7 +30,7 @@ import featureRoutes from '../routes/featureRoutes';
 
 import { authorizeUser } from '../middleware/authMiddleware';
 import { requireAdmin } from '../middleware/roleMiddleware';
-import { errorMessages } from '../utils/serverConfigUtil';
+import { errorMessages, wildcardToRegex } from '../utils/serverConfigUtil';
 
 // Swagger import
 
@@ -118,13 +118,36 @@ class Server {
 
   private middleware() {
     this.app.use(express.json());
-    const allowedOrigins = process.env.FRONTEND_URL
-      ? process.env.FRONTEND_URL.split(',').map((origin) => origin.trim())
+    const rawOrigins = process.env.FRONTEND_URL
+      ? process.env.FRONTEND_URL.split(',')
+          .map((o) => o.trim())
+          .filter(Boolean)
       : [];
+    const exactOrigins: string[] = [];
+    const patternOrigins: RegExp[] = [];
+    for (const origin of rawOrigins) {
+      if (origin.includes('*')) {
+        patternOrigins.push(wildcardToRegex(origin));
+      } else {
+        exactOrigins.push(origin);
+      }
+    }
     console.log('FRONTEND_URL:', process.env.FRONTEND_URL);
-    console.log('Allowed Origins for CORS:', allowedOrigins);
+    console.log('Allowed exact origins for CORS:', exactOrigins);
+    console.log('Allowed origin patterns for CORS:', patternOrigins);
 
-    this.app.use(cors({ origin: allowedOrigins, credentials: true }));
+    this.app.use(
+      cors({
+        origin: (origin, callback) => {
+          if (!origin) return callback(null, true);
+          if (exactOrigins.includes(origin) || patternOrigins.some((re) => re.test(origin))) {
+            return callback(null, true);
+          }
+          return callback(new Error(`Origin ${origin} not allowed by CORS`));
+        },
+        credentials: true,
+      })
+    );
   }
 
   private routes() {

--- a/backend/src/utils/serverConfigUtil.ts
+++ b/backend/src/utils/serverConfigUtil.ts
@@ -1,3 +1,13 @@
+/**
+ * Convert a wildcard origin pattern (e.g. `https://frontend-cnc-portal-pr-*.up.railway.app`)
+ * into an anchored RegExp. `*` matches one or more chars that are not a dot, so wildcards
+ * stay within a single subdomain label and cannot cross domain boundaries.
+ */
+export const wildcardToRegex = (pattern: string): RegExp => {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^.]*');
+  return new RegExp(`^${escaped}$`);
+};
+
 export const errorMessages = {
   frontendUrl: `
         Required environment variable 'FRONTEND_URL' not set.


### PR DESCRIPTION
Closes #1923

## What

Allow `FRONTEND_URL` entries to contain `*`, so a single comma-separated entry covers every Railway PR preview URL instead of editing the env var on every new pull request.

Example value:

```
FRONTEND_URL=https://app.cnc-portal.com,http://localhost:5173,https://frontend-cnc-portal-pr-*.up.railway.app
```

## Why

Railway gives each PR a preview at `https://frontend-cnc-portal-pr-<n>.up.railway.app`. Only the PR number changes. Until now, every preview had to be added by hand to `FRONTEND_URL` or it would fail CORS.

## How

- Parse `FRONTEND_URL` entries; split them into `exactOrigins` (no `*`) and `patternOrigins` (with `*`).
- `wildcardToRegex` escapes regex metacharacters and turns each `*` into `[^.]*` — wildcards stay within a single subdomain label and cannot cross domain boundaries (`*.foo.com` cannot match `evil.com.foo.com.attacker.io`).
- Anchored with `^…$`.
- The `cors` `origin` option is now a function: accepts no-`Origin` requests (curl, server-to-server), exact matches, and pattern matches; rejects anything else.

Helper lives in `backend/src/utils/serverConfigUtil.ts` so it can be unit-tested independently.

## Test plan

- [ ] Set `FRONTEND_URL=https://frontend-cnc-portal-pr-*.up.railway.app` locally and confirm a request from `https://frontend-cnc-portal-pr-1919.up.railway.app` is allowed.
- [ ] Confirm a request from `https://frontend-cnc-portal-pr-1919.up.railway.app.attacker.com` is rejected.
- [ ] Confirm exact entries (no `*`) still match exactly.
- [ ] Confirm requests with no `Origin` header still go through.