### PR TITLE
feat: ✨ allow clearing wage rates back to 0

### DIFF
--- a/app/src/components/sections/DashboardView/SetMemberWageOvertimeStep.vue
+++ b/app/src/components/sections/DashboardView/SetMemberWageOvertimeStep.vue
@@ -135,6 +135,7 @@
 </template>
 
 <script setup lang="ts">
+import { watch } from 'vue'
 import * as z from 'zod'
 import { NETWORK } from '@/constant'
 import type { WageWithForm } from '@/types'
@@ -148,6 +149,24 @@ defineProps<{
   isPending: boolean
   errorMessage?: string
 }>()
+
+watch(
+  () => wageData.value.overtimeRatePerHour.map((r) => Number(r.amount)),
+  (amounts) => {
+    wageData.value.overtimeRatePerHour.forEach((rate, i) => {
+      if (amounts[i] === 0 && rate.enabled) rate.enabled = false
+    })
+  }
+)
+
+watch(
+  () => wageData.value.overtimeRatePerHour.map((r) => r.enabled),
+  (enabled) => {
+    wageData.value.overtimeRatePerHour.forEach((rate, i) => {
+      if (!enabled[i] && Number(rate.amount) !== 0) rate.amount = 0
+    })
+  }
+)
 
 const rateSchema = z.object({
   type: z.enum(['native', 'usdc', 'sher', 'usdc.e']),
@@ -168,15 +187,6 @@ const overtimeSchema = z.object({
         path: [],
         message: 'Enable at least one overtime rate'
       })
-    }
-    for (const [index, rate] of rates.entries()) {
-      if (rate.enabled && rate.amount <= 0) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: [index, 'amount'],
-          message: 'Enabled overtime rates must be greater than 0'
-        })
-      }
     }
   })
 })

--- a/app/src/components/sections/DashboardView/SetMemberWageStandardStep.vue
+++ b/app/src/components/sections/DashboardView/SetMemberWageStandardStep.vue
@@ -127,6 +127,7 @@
 </template>
 
 <script setup lang="ts">
+import { watch } from 'vue'
 import * as z from 'zod'
 import { NETWORK } from '@/constant'
 import type { Wage, WageWithForm } from '@/types'
@@ -140,6 +141,24 @@ defineProps<{
   wage?: Wage
   errorMessage?: string
 }>()
+
+watch(
+  () => wageData.value.ratePerHour.map((r) => Number(r.amount)),
+  (amounts) => {
+    wageData.value.ratePerHour.forEach((rate, i) => {
+      if (amounts[i] === 0 && rate.enabled) rate.enabled = false
+    })
+  }
+)
+
+watch(
+  () => wageData.value.ratePerHour.map((r) => r.enabled),
+  (enabled) => {
+    wageData.value.ratePerHour.forEach((rate, i) => {
+      if (!enabled[i] && Number(rate.amount) !== 0) rate.amount = 0
+    })
+  }
+)
 
 const rateSchema = z.object({
   type: z.enum(['native', 'usdc', 'sher', 'usdc.e']),
@@ -156,15 +175,6 @@ const standardSchema = z.object({
   ratePerHour: z.array(rateSchema).superRefine((rates, ctx) => {
     if (rates.filter((r) => r.enabled).length === 0) {
       ctx.addIssue({ code: z.ZodIssueCode.custom, path: [], message: 'Enable at least one rate' })
-    }
-    for (const [index, rate] of rates.entries()) {
-      if (rate.enabled && rate.amount <= 0) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: [index, 'amount'],
-          message: 'Enabled rates must be greater than 0'
-        })
-      }
     }
   })
 })

--- a/app/src/components/sections/DashboardView/__tests__/SetMemberWageOvertimeStep.spec.ts
+++ b/app/src/components/sections/DashboardView/__tests__/SetMemberWageOvertimeStep.spec.ts
@@ -145,16 +145,6 @@ describe('SetMemberWageOvertimeStep.vue', () => {
     await invalidNoRate.get('[data-test="overtime-rules-step"]').trigger('submit')
     expect(invalidNoRate.find('[data-test="save-overtime-wage-button"]').exists()).toBe(true)
 
-    const invalidAmount = createWrapper(
-      createWageData({
-        overtimeRatePerHour: [
-          { type: 'native', amount: 0, enabled: true }
-        ] as WageWithForm['overtimeRatePerHour']
-      })
-    )
-    await invalidAmount.get('[data-test="overtime-rules-step"]').trigger('submit')
-    expect(invalidAmount.find('[data-test="save-overtime-wage-button"]').exists()).toBe(true)
-
     const validWrapper = createWrapper(
       createWageData({
         overtimeRatePerHour: [
@@ -164,5 +154,38 @@ describe('SetMemberWageOvertimeStep.vue', () => {
     )
     await validWrapper.get('[data-test="overtime-rules-step"]').trigger('submit')
     expect(validWrapper.find('[data-test="save-overtime-wage-button"]').exists()).toBe(true)
+  })
+
+  it('auto-disables the overtime toggle when the rate amount is cleared to 0', async () => {
+    const wageData = createWageData({
+      overtimeRatePerHour: [
+        { type: 'native', amount: 15, enabled: true },
+        { type: 'usdc', amount: 0, enabled: false },
+        { type: 'sher', amount: 0, enabled: false }
+      ]
+    })
+    const wrapper = createWrapper(wageData)
+    const overtimeAmountInputs = wrapper.findAll('input[type="number"]')
+
+    await overtimeAmountInputs[1]?.setValue('0')
+
+    expect(wageData.overtimeRatePerHour[0]?.enabled).toBe(false)
+    expect(Number(wageData.overtimeRatePerHour[0]?.amount)).toBe(0)
+  })
+
+  it('auto-zeroes the overtime rate amount when the toggle is turned off', async () => {
+    const wageData = createWageData({
+      overtimeRatePerHour: [
+        { type: 'native', amount: 15, enabled: true },
+        { type: 'usdc', amount: 0, enabled: false },
+        { type: 'sher', amount: 0, enabled: false }
+      ]
+    })
+    const wrapper = createWrapper(wageData)
+
+    await wrapper.findAll('button[role="switch"]')?.[0]?.trigger('click')
+
+    expect(wageData.overtimeRatePerHour[0]?.enabled).toBe(false)
+    expect(Number(wageData.overtimeRatePerHour[0]?.amount)).toBe(0)
   })
 })

--- a/app/src/components/sections/DashboardView/__tests__/SetMemberWageStandardStep.spec.ts
+++ b/app/src/components/sections/DashboardView/__tests__/SetMemberWageStandardStep.spec.ts
@@ -150,14 +150,6 @@ describe('SetMemberWageStandardStep.vue', () => {
     await invalidNoRate.get('[data-test="standard-wage-step"]').trigger('submit')
     expect(invalidNoRate.find('[data-test="add-wage-button"]').exists()).toBe(true)
 
-    const invalidAmount = createWrapper(
-      createWageData({
-        ratePerHour: [{ type: 'native', amount: 0, enabled: true }] as WageWithForm['ratePerHour']
-      })
-    )
-    await invalidAmount.get('[data-test="standard-wage-step"]').trigger('submit')
-    expect(invalidAmount.find('[data-test="add-wage-button"]').exists()).toBe(true)
-
     const validWrapper = createWrapper(
       createWageData({
         ratePerHour: [{ type: 'native', amount: 12, enabled: true }] as WageWithForm['ratePerHour']
@@ -165,5 +157,38 @@ describe('SetMemberWageStandardStep.vue', () => {
     )
     await validWrapper.get('[data-test="standard-wage-step"]').trigger('submit')
     expect(validWrapper.find('[data-test="add-wage-button"]').exists()).toBe(true)
+  })
+
+  it('auto-disables the toggle when the rate amount is cleared to 0', async () => {
+    const wageData = createWageData({
+      ratePerHour: [
+        { type: 'native', amount: 10, enabled: true },
+        { type: 'usdc', amount: 0, enabled: false },
+        { type: 'sher', amount: 0, enabled: false }
+      ]
+    })
+    const wrapper = createWrapper(wageData)
+    const firstAmountInput = wrapper.findAll('input[type="number"]')[1]
+
+    await firstAmountInput?.setValue('0')
+
+    expect(wageData.ratePerHour[0]?.enabled).toBe(false)
+    expect(Number(wageData.ratePerHour[0]?.amount)).toBe(0)
+  })
+
+  it('auto-zeroes the rate amount when the toggle is turned off', async () => {
+    const wageData = createWageData({
+      ratePerHour: [
+        { type: 'native', amount: 10, enabled: true },
+        { type: 'usdc', amount: 0, enabled: false },
+        { type: 'sher', amount: 0, enabled: false }
+      ]
+    })
+    const wrapper = createWrapper(wageData)
+
+    await wrapper.findAll('button[role="switch"]')?.[0]?.trigger('click')
+
+    expect(wageData.ratePerHour[0]?.enabled).toBe(false)
+    expect(Number(wageData.ratePerHour[0]?.amount)).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

Closes #1441.

- Drop the `Enabled rates must be greater than 0` Zod check in both `SetMemberWageStandardStep.vue` and `SetMemberWageOvertimeStep.vue` so a team owner can save a rate back to `0`.
- Sync the row's toggle and amount in both directions:
  - clearing the amount to `0` auto-disables the toggle;
  - turning the toggle off resets the amount to `0`.
- Keeps the form state consistent with `buildRatePayload` (`enabled && amount > 0`), so disabled rows are dropped from the payload as before.

## Test plan

- [x] `npm run lint`, `npm run format-check`, `npm run type-check` (in `app/`) — no new errors.
- [x] `npm run test:unit -- --run` — 199 files / 1677 tests pass, including new cases:
  - Standard step: setting amount to 0 auto-disables the toggle.
  - Standard step: turning the toggle off auto-zeroes the amount.
  - Overtime step: same two cases for overtime rates.
- [ ] Manual: open the Set Wage modal, set USDC to `0`, save → wage row clears, payload no longer includes USDC.
- [ ] Manual: toggle off SHER → input value becomes `0` and is disabled.