### PR TITLE
chore: 🔧 enforce useContractWritesV3 via ESLint + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ function archive() {
 
 **Web3 stack.** wagmi + viem for chain reads/writes, Apollo Client for subgraph queries, Safe SDK (`@safe-global/*`) for multisig flows.
 
+**Contract writes — always V3.** All on-chain writes go through `useContractWritesV3` from `@/composables/contracts`. Do **not** import `useWriteContract` / `useWaitForTransactionReceipt` from `@wagmi/vue`, and do **not** import `writeContract` / `waitForTransactionReceipt` from `@wagmi/core` in feature code (components, services, feature composables). Read paths — `readContract`, `estimateGas`, `simulateContract` — stay as-is. The V3 composable owns simulation, send, receipt-wait, error classification, and lifecycle callbacks; reaching past it splinters error handling and breaks the migration tracked in #1798. The rule is enforced by ESLint (`no-restricted-imports` in `app/eslint.config.js`); a legacy allow-list there names the files still pending migration, and each migration PR removes its file from that list.
+
 **Frontend authoring — keep components small and readable (DX-first).** A component should fit on a screen and read like a description of the UI, not like a script. Whenever you edit a Vue file, take it as an opportunity to make it leaner.
 
 - **Extract logic, not just markup.** Push pure data shaping into `app/src/utils/` (utility functions) and stateful/reactive logic into `app/src/composables/` (`useXxx`). The component is left declaring *what* it shows — the *how* lives outside.

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -87,6 +87,54 @@ const vmCastLegacyExtraFiles = [
   'src/components/sections/SherTokenView/InvestorActions/__tests__/MintTokenAction.spec.ts'
 ]
 
+// Contract-writes V3 enforcement (issues #1798, #1926).
+//
+// All on-chain writes must go through `useContractWritesV3` from
+// `@/composables/contracts`. Raw wagmi write hooks are banned in feature
+// code so AI agents and humans cannot regress to V2-shaped patterns.
+//
+// Allowed importers (override below):
+//   - `src/composables/contracts/**` — the V3 implementation itself.
+//   - `src/composables/transactions/useSafeSendTransaction.ts` — Safe SDK
+//     wrapper that legitimately wraps `waitForTransactionReceipt`.
+//   - test-only mock setup files under `tests/`.
+//
+// Legacy allow-list: files pending migration are listed in
+// `v3MigrationLegacyFiles` and tracked in issue #1798. Each migration PR
+// removes its file from the list; when empty, drop the override block.
+const v3WriteRestrictedImports = {
+  paths: [
+    {
+      name: '@wagmi/vue',
+      importNames: ['useWriteContract', 'useWaitForTransactionReceipt'],
+      message:
+        'Use `useContractWritesV3` from `@/composables/contracts` for on-chain writes. See AGENTS.md and issue #1798.'
+    },
+    {
+      name: '@wagmi/core',
+      importNames: ['writeContract', 'waitForTransactionReceipt'],
+      message:
+        'Use `useContractWritesV3` from `@/composables/contracts` for on-chain writes. `readContract` / `estimateGas` / `simulateContract` remain allowed. See AGENTS.md and issue #1798.'
+    }
+  ]
+}
+
+const v3MigrationLegacyFiles = [
+  'src/composables/useContractFunctions.ts',
+  'src/components/forms/DepositSafeForm.vue',
+  'src/components/sections/AdministrationView/BoDElectionDetailsSection.vue',
+  'src/components/sections/AdministrationView/PublishResult.vue',
+  'src/components/sections/ContractManagementView/MainContractActions.vue',
+  'src/components/sections/ContractManagementView/TeamContractAdmins.vue',
+  'src/components/sections/ContractManagementView/TeamContractsDetail.vue',
+  'src/components/sections/ExpenseAccountView/ExpenseAccountTable.vue',
+  'src/components/sections/ExpenseAccountView/TransferAction.vue',
+  'src/components/sections/ProposalsView/ProposalDetail.vue',
+  'src/components/sections/ProposalsView/forms/CreateProposalForm.vue',
+  'src/components/sections/SherTokenView/InvestorActions/DistributeMintAction.vue',
+  'src/components/sections/SherTokenView/forms/MintForm.vue'
+]
+
 export default [
   {
     // TODO turn this rule into an error by march 2025
@@ -169,6 +217,22 @@ export default [
         tailwindClassAssertionOptional,
         tailwindClassIncludes
       ]
+    }
+  },
+  {
+    name: 'app/contract-writes-v3-only',
+    files: ['src/**/*.{ts,tsx,vue}'],
+    ignores: [
+      'src/composables/contracts/**',
+      'src/composables/transactions/useSafeSendTransaction.ts',
+      '**/__tests__/**',
+      '**/*.spec.ts',
+      '**/*.spec.tsx',
+      'tests/**',
+      ...v3MigrationLegacyFiles
+    ],
+    rules: {
+      'no-restricted-imports': ['error', v3WriteRestrictedImports]
     }
   },
   skipFormatting


### PR DESCRIPTION
## Summary

Install the guardrail that turns the V3 migration (#1798) into a build-time rule instead of tribal knowledge.

- **`app/eslint.config.js`** — new `no-restricted-imports` rule bans `useWriteContract` / `useWaitForTransactionReceipt` from `@wagmi/vue` and `writeContract` / `waitForTransactionReceipt` from `@wagmi/core` in feature code. The V3 wrapper (`src/composables/contracts/**`), the Safe SDK wrapper (`src/composables/transactions/useSafeSendTransaction.ts`), and test files keep their imports through an `ignores` override. Read paths (`readContract`, `estimateGas`, `simulateContract`) remain allowed.
- **Legacy allow-list** — the 13 files still importing the raw wagmi write hooks are listed in `v3MigrationLegacyFiles` so CI stays green. Each migration PR under #1798 removes its file from the list. When the list is empty, drop the override block (this satisfies task 5 of #1798: the grep check becomes the lint check).
- **`AGENTS.md`** — new "Contract writes — always V3" rule in the Architecture-notes section so AI agents (Copilot, Cursor, Codex, Claude Code, …) pick it up before they generate any wagmi-shaped write code.

## Why

Today nothing prevents an agent or a human from importing `useWriteContract` from `@wagmi/vue` in a new form — the rule lives only in PR-review tribal knowledge, and AI agents bias toward popular library APIs from their training data. A lint rule turns the convention into a build error every agent already knows how to read and self-correct against, and the legacy list doubles as the live TODO for the rest of #1798.

## Scope

This PR only installs the guardrail. It does **not** migrate any of the 13 listed files and does **not** delete `useContractWritesV2.ts` — that remains the work of #1798.

## Test plan

- [x] `npm run lint` in `app/` passes with the rule + allow-list.
- [x] `npm run format-check` in `app/` passes.
- [x] Probe file under `src/components/forms/` importing `useWriteContract` / `useWaitForTransactionReceipt` / `writeContract` / `waitForTransactionReceipt` fails lint with the V3 message (verified locally, then removed).
- [x] `bash scripts/audit-doc-drift.sh` clean after `AGENTS.md` change.
- [ ] Reviewer sanity check: pick any one file in the legacy allow-list, remove it locally, run `npm run lint` — should fail with the V3 message.

Closes #1926
Refs #1798