### PR TITLE
refactor: ♻️ remove daisy join classes from NotificationDropdown

### DIFF
--- a/app/src/components/NotificationDropdown.vue
+++ b/app/src/components/NotificationDropdown.vue
@@ -31,24 +31,21 @@
       </li>
       <!-- Pagination Controls -->
       <div
-        class="join flex items-center justify-between p-2"
+        class="flex items-center justify-between gap-1 p-2"
+        data-test="pagination-controls"
         v-if="paginatedNotifications.length > 0"
       >
         <UButton
           color="primary"
           size="xs"
-          class="join-item"
           :disabled="currentPage === 1"
           @click="currentPage > 1 ? currentPage-- : currentPage"
           icon="heroicons:chevron-left"
         />
-        <span class="join-item text-primary px-2 text-sm">
-          {{ currentPage }} / {{ totalPages }}
-        </span>
+        <span class="text-primary px-2 text-sm"> {{ currentPage }} / {{ totalPages }} </span>
         <UButton
           color="primary"
           size="xs"
-          class="join-item"
           :disabled="currentPage === totalPages"
           @click="currentPage < totalPages ? currentPage++ : currentPage"
           icon="heroicons:chevron-right"

--- a/app/src/components/__tests__/NotificationDropdown.spec.ts
+++ b/app/src/components/__tests__/NotificationDropdown.spec.ts
@@ -54,7 +54,7 @@ describe('NotificationDropdown.vue', () => {
     mockNotificationsRef.value = []
     await nextTick()
 
-    expect(wrapper.find('.join').exists()).toBe(false)
+    expect(wrapper.find('[data-test="pagination-controls"]').exists()).toBe(false)
   })
 
   it('handles notification click and redirects to team route', async () => {


### PR DESCRIPTION
## Summary
Drops daisy `join` / `join-item` from the NotificationDropdown pagination row in favor of plain Tailwind utilities.

Closes #1941

## Test plan
- [x] npm run lint
- [x] npm run format-check
- [x] npm run type-check
- [x] npm run test:unit -- --run
- [x] npm run build
- [ ] Visual diff: notification dropdown pagination row layout