### PR TITLE
refactor: ♻️ migrate daisy collapse to UCollapsible

### DIFF
--- a/app/src/components/sections/DashboardView/TeamMetaSection.vue
+++ b/app/src/components/sections/DashboardView/TeamMetaSection.vue
@@ -1,11 +1,15 @@
 <template>
   <div class="flex w-full justify-between gap-5">
-    <div
-      class="collapse-arrow collapse static border"
+    <UCollapsible
+      class="w-full rounded-md border"
       :class="`${currentTeam?.ownerAddress == address ? 'bg-green-100' : 'bg-blue-100'}`"
+      :ui="{ content: 'px-4 pb-4' }"
+      :unmount-on-hide="false"
     >
-      <input type="checkbox" />
-      <div class="collapse-title text-xl font-medium">
+      <button
+        type="button"
+        class="flex w-full items-center justify-between px-4 py-3 text-xl font-medium"
+      >
         <div class="flex items-center justify-center">
           <h2 class="pl-5">{{ currentTeam?.name }}</h2>
           <UBadge
@@ -19,8 +23,12 @@
           </UBadge>
           <UBadge size="sm" color="secondary" variant="solid" class="ml-2" v-else>Employee</UBadge>
         </div>
-      </div>
-      <div class="collapse-content">
+        <UIcon
+          name="i-lucide-chevron-down"
+          class="size-5 transition-transform duration-200 group-data-[state=open]:rotate-180"
+        />
+      </button>
+      <template #content>
         <p class="pl-5">{{ currentTeam?.description }}</p>
 
         <div class="mt-5 flex flex-row items-center justify-center gap-2 pl-5">
@@ -119,8 +127,8 @@
             </UModal>
           </template>
         </div>
-      </div>
-    </div>
+      </template>
+    </UCollapsible>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
Replaces daisy `collapse` / `collapse-arrow` / `collapse-title` / `collapse-content` with Nuxt UI v4 `<UCollapsible>` in `TeamMetaSection.vue`.

Closes #1939

## Test plan
- [x] npm run lint
- [x] npm run format-check
- [x] npm run type-check
- [x] npm run test:unit -- --run
- [x] npm run build
- [ ] Visual diff: Dashboard → company details collapse panel