### PR TITLE
refactor: ♻️ replace SkeletonLoading wrapper with USkeleton

### DIFF
--- a/app/src/components/OverviewCard.vue
+++ b/app/src/components/OverviewCard.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-col items-center gap-4">
       <img :src="cardIcon" alt="icon" class="h-16 w-16" data-test="card-icon" />
       <span v-if="!loading" class="text-4xl font-bold" data-test="amount">{{ title }}</span>
-      <SkeletonLoading v-else class="h-8 w-24 opacity-20" />
+      <USkeleton v-else class="h-8 w-24 opacity-20" />
       <span class="text-sm font-semibold" data-test="subtitle">{{ subtitle }}</span>
       <slot></slot>
     </div>
@@ -11,7 +11,6 @@
 </template>
 <script lang="ts" setup>
 import { computed } from 'vue'
-import SkeletonLoading from './SkeletonLoading.vue'
 
 const props = defineProps({
   title: {

--- a/app/src/components/SkeletonLoading.vue
+++ b/app/src/components/SkeletonLoading.vue
@@ -1,3 +1,0 @@
-<template>
-  <div class="skeleton"></div>
-</template>

--- a/app/src/components/__tests__/OverviewCard.spec.ts
+++ b/app/src/components/__tests__/OverviewCard.spec.ts
@@ -45,7 +45,7 @@ describe('OverviewCard', () => {
     })
 
     expect(wrapper.find('[data-test="amount"]').exists()).toBe(false)
-    expect(wrapper.findComponent({ name: 'SkeletonLoading' }).exists()).toBe(true)
+    expect(wrapper.find('[aria-busy="true"]').exists()).toBe(true)
   })
 
   it('renders slot content', () => {

--- a/app/src/components/sections/SafeView/TransferSenderCell.vue
+++ b/app/src/components/sections/SafeView/TransferSenderCell.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="isLoading" class="skeleton h-10 w-32"></div>
+  <USkeleton v-if="isLoading" class="h-10 w-32" />
   <UserComponent v-else :user="userInfo" />
 </template>
 

--- a/app/src/components/sections/SafeView/__tests__/TransferSenderCell.spec.ts
+++ b/app/src/components/sections/SafeView/__tests__/TransferSenderCell.spec.ts
@@ -50,7 +50,7 @@ describe('TransferSenderCell', () => {
 
     const wrapper = createWrapper()
 
-    expect(wrapper.find('.skeleton').exists()).toBe(true)
+    expect(wrapper.find('[aria-busy="true"]').exists()).toBe(true)
     expect(wrapper.find('[data-test="user-component"]').exists()).toBe(false)
   })
 
@@ -99,12 +99,12 @@ describe('TransferSenderCell', () => {
 
     const wrapper = createWrapper()
 
-    expect(wrapper.find('.skeleton').exists()).toBe(true)
+    expect(wrapper.find('[aria-busy="true"]').exists()).toBe(true)
 
     response.isLoading.value = false
     await nextTick()
 
-    expect(wrapper.find('.skeleton').exists()).toBe(false)
+    expect(wrapper.find('[aria-busy="true"]').exists()).toBe(false)
     expect(wrapper.find('[data-test="user-component"]').exists()).toBe(true)
   })
 })

--- a/app/src/components/sections/SherTokenView/InvestorsActions.vue
+++ b/app/src/components/sections/SherTokenView/InvestorsActions.vue
@@ -20,12 +20,7 @@
       "
     >
       <div class="grid grid-cols-2 gap-2.5 md:grid-cols-3 xl:grid-cols-6">
-        <div
-          v-for="i in 6"
-          :key="i"
-          class="skeleton h-20 rounded-lg"
-          :data-test="`skeleton-${i}`"
-        />
+        <USkeleton v-for="i in 6" :key="i" class="h-20 rounded-lg" :data-test="`skeleton-${i}`" />
       </div>
     </template>
     <template v-else>

--- a/app/src/views/team/ListIndex.vue
+++ b/app/src/views/team/ListIndex.vue
@@ -6,10 +6,10 @@
     <!-- Loader -->
     <div class="flex gap-3" data-test="loader" v-if="teamsAreFetching">
       <div class="flex w-1/4 flex-col gap-4" v-for="i in 4" :key="i">
-        <div class="skeleton h-32 w-full"></div>
-        <div class="skeleton h-4 w-28"></div>
-        <div class="skeleton h-4 w-full"></div>
-        <div class="skeleton h-4 w-full"></div>
+        <USkeleton class="h-32 w-full" />
+        <USkeleton class="h-4 w-28" />
+        <USkeleton class="h-4 w-full" />
+        <USkeleton class="h-4 w-full" />
       </div>
     </div>
 

--- a/app/src/views/team/__tests__/ListIndex.spec.ts
+++ b/app/src/views/team/__tests__/ListIndex.spec.ts
@@ -69,7 +69,7 @@ describe('ListIndex - Team List View', () => {
       await wrapper.vm.$nextTick()
 
       expect(wrapper.find('[data-test="loader"]').exists()).toBe(true)
-      expect(wrapper.findAll('[data-test="loader"] .skeleton')).toHaveLength(16) // 4 skeletons × 4 items
+      expect(wrapper.findAll('[data-test="loader"] [aria-busy="true"]')).toHaveLength(16) // 4 skeletons × 4 items
     })
 
     it('should hide team list during loading', async () => {


### PR DESCRIPTION
## Summary
The local `SkeletonLoading.vue` is a daisy `skeleton` one-liner that renders nothing once daisy is dropped. Every call site is migrated to Nuxt UI's `<USkeleton>` and the wrapper is deleted.

Closes #1936

## Test plan
- [x] npm run lint
- [x] npm run format-check
- [x] npm run type-check
- [x] npm run test:unit -- --run
- [x] npm run build
- [ ] Visual diff: SherToken investor actions, Safe transfer sender cell, team list loading state