### PR TITLE
refactor: ♻️ migrate daisy input/label-text to UInput + UFormField

### DIFF
--- a/app/src/components/SelectMemberItem.vue
+++ b/app/src/components/SelectMemberItem.vue
@@ -5,7 +5,7 @@
       <span class="text-xl font-bold">Select a User</span>
     </div>
     <div
-      class="input input-bordered input-lg flex cursor-pointer items-center gap-2"
+      class="border-default flex h-12 cursor-pointer items-center gap-2 rounded-md border bg-white px-3 dark:bg-gray-900"
       data-test="select-member-item-trigger"
       @click="toggleOpen"
     >
@@ -33,10 +33,10 @@
     >
       <!-- Search input -->
       <div class="border-base-300 border-b p-2">
-        <input
+        <UInput
           v-model="search"
           type="text"
-          class="input input-bordered input-md w-full"
+          class="w-full"
           placeholder="Search…"
           data-test="select-member-item-search"
         />

--- a/app/src/components/forms/CompensationAmount.vue
+++ b/app/src/components/forms/CompensationAmount.vue
@@ -1,13 +1,23 @@
 <template>
-  <label class="form-control mt-6 w-full" data-test="compensation-amount">
-    <div class="label">
+  <UFormField
+    name="compensation"
+    class="mt-6 w-full"
+    :ui="{ container: 'mt-0' }"
+    data-test="compensation-amount"
+  >
+    <template #label>
       <slot name="label">
-        <span class="label-text">{{ safeTokenSymbol }} to Receive</span>
-        <span class="label-text-alt">
-          Rate: 1 {{ depositTokenSymbol }} = {{ formattedRate }} {{ safeTokenSymbol }}
-        </span>
+        <div class="flex w-full items-center justify-between text-sm font-medium">
+          <span data-test="compensation-label-text">{{ safeTokenSymbol }} to Receive</span>
+          <span
+            class="text-xs text-gray-500 dark:text-gray-400"
+            data-test="compensation-label-text-alt"
+          >
+            Rate: 1 {{ depositTokenSymbol }} = {{ formattedRate }} {{ safeTokenSymbol }}
+          </span>
+        </div>
       </slot>
-    </div>
+    </template>
     <UInput
       :model-value="displayValue"
       placeholder="0"
@@ -30,7 +40,7 @@
         </UBadge>
       </template>
     </UInput>
-  </label>
+  </UFormField>
 </template>
 
 <script setup lang="ts">

--- a/app/src/components/forms/SafeDepositRouterForm.vue
+++ b/app/src/components/forms/SafeDepositRouterForm.vue
@@ -13,13 +13,15 @@
         data-test="token-amount"
       >
         <template #label>
-          <span class="label-text">Deposit</span>
-          <span class="label-text-alt"
-            >{{
-              selectedToken?.token.symbol ? `${selectedToken.token.symbol} Balance:` : 'Balance:'
-            }}
-            {{ selectedToken?.amount }} {{ selectedToken?.token.symbol }}
-          </span>
+          <div class="flex w-full items-center justify-between text-sm font-medium">
+            <span>Deposit</span>
+            <span class="text-xs text-gray-500 dark:text-gray-400"
+              >{{
+                selectedToken?.token.symbol ? `${selectedToken.token.symbol} Balance:` : 'Balance:'
+              }}
+              {{ selectedToken?.amount }} {{ selectedToken?.token.symbol }}
+            </span>
+          </div>
         </template>
       </TokenAmount>
     </UFormField>

--- a/app/src/components/forms/__tests__/CompensationAmount.advanced.spec.ts
+++ b/app/src/components/forms/__tests__/CompensationAmount.advanced.spec.ts
@@ -8,8 +8,8 @@ import { mockInvestorReads, resetContractMocks } from '@/tests/mocks'
 const SELECTORS = {
   compensationAmount: '[data-test="compensation-amount"]',
   compensationInput: '[data-test="compensation-input"]',
-  labelTextAlt: '.label-text-alt',
-  labelText: '.label-text'
+  labelTextAlt: '[data-test="compensation-label-text-alt"]',
+  labelText: '[data-test="compensation-label-text"]'
 } as const
 
 const MOCK_DATA = {

--- a/app/src/components/forms/__tests__/CompensationAmout.spec.ts
+++ b/app/src/components/forms/__tests__/CompensationAmout.spec.ts
@@ -9,8 +9,8 @@ const SELECTORS = {
   compensationAmount: '[data-test="compensation-amount"]',
   compensationInput: '[data-test="compensation-input"]',
   tokenSymbolBadge: '[data-test="token-symbol-badge"]',
-  labelText: '.label-text',
-  labelTextAlt: '.label-text-alt'
+  labelText: '[data-test="compensation-label-text"]',
+  labelTextAlt: '[data-test="compensation-label-text-alt"]'
 } as const
 
 const MOCK_DATA = {

--- a/app/src/components/sections/ContractManagementView/TeamContractAdmins.vue
+++ b/app/src/components/sections/ContractManagementView/TeamContractAdmins.vue
@@ -9,12 +9,13 @@
     @submit.prevent="handleAdminAction(newAdminAddress as `0x${string}`, 'addAdmin')"
     class="mb-4 flex items-center space-x-2"
   >
-    <input
+    <UInput
       v-model="newAdminAddress"
       type="text"
+      size="sm"
       placeholder="Enter new admin address"
-      class="input input-bordered input-sm w-full max-w-xs"
-      required
+      class="w-full max-w-xs"
+      :required="true"
     />
     <div>
       <UButton type="submit" color="primary" size="sm"> Add Admin</UButton>

--- a/app/src/components/sections/ContractManagementView/TeamContractsDetail.vue
+++ b/app/src/components/sections/ContractManagementView/TeamContractsDetail.vue
@@ -15,18 +15,20 @@
     >
       <template #value-cell="{ row: { original: row } }">
         <template v-if="row.key.startsWith('cost')">
-          <input
+          <UInput
             type="number"
             step="any"
-            :value="row.value"
-            @input="
-              updateValue(
-                datas.findIndex((d) => d.key === row.key),
-                Math.abs(parseFloat(($event.target as HTMLInputElement).value) || 0)
-              )
+            size="sm"
+            :model-value="row.value"
+            :required="true"
+            class="w-24"
+            @update:model-value="
+              (v: string | number) =>
+                updateValue(
+                  datas.findIndex((d) => d.key === row.key),
+                  Math.abs(parseFloat(String(v)) || 0)
+                )
             "
-            class="input input-bordered w-24 text-sm"
-            required
           />
           ETH
         </template>

--- a/app/src/components/sections/SherTokenView/forms/DistributeMintForm.vue
+++ b/app/src/components/sections/SherTokenView/forms/DistributeMintForm.vue
@@ -5,26 +5,23 @@
         <UBadge color="primary" variant="solid">Shareholder {{ index + 1 }}</UBadge>
         <UFormField
           :name="`shareholders.${index}.shareholder`"
+          label="Address"
           :error="rowErrors[index]?.shareholder"
           :ui="{ error: 'pl-4', root: 'mt-2' }"
           data-test="error-message-shareholder"
         >
-          <label class="input input-bordered input-md flex w-full items-center gap-2">
-            <p>Address</p>
-            |
-            <UInput
-              type="text"
-              class="grow"
-              data-test="address-input"
-              v-model="shareholder.shareholder"
-              @keyup.stop="
-                () => {
-                  searchUsers(shareholder.shareholder ?? '')
-                  showDropdown[index] = true
-                }
-              "
-            />
-          </label>
+          <UInput
+            type="text"
+            class="w-full"
+            data-test="address-input"
+            v-model="shareholder.shareholder"
+            @keyup.stop="
+              () => {
+                searchUsers(shareholder.shareholder ?? '')
+                showDropdown[index] = true
+              }
+            "
+          />
         </UFormField>
 
         <div
@@ -57,22 +54,22 @@
 
         <UFormField
           :name="`shareholders.${index}.amount`"
+          label="Amount"
           :error="rowErrors[index]?.amount"
           :ui="{ error: 'pl-4', root: 'mt-2' }"
           data-test="error-message-amount"
         >
-          <label class="input input-bordered input-md flex w-full items-center gap-2">
-            <p>Amount</p>
-            |
-            <UInput
-              type="number"
-              class="grow"
-              data-test="amount-input"
-              :model-value="shareholder.amount"
-              @update:model-value="(v: string | number) => (shareholder.amount = Number(v))"
-            />
-            {{ tokenSymbol }}
-          </label>
+          <UInput
+            type="number"
+            class="w-full"
+            data-test="amount-input"
+            :model-value="shareholder.amount"
+            @update:model-value="(v: string | number) => (shareholder.amount = Number(v))"
+          >
+            <template #trailing>
+              <span class="text-sm font-semibold text-gray-500 select-none">{{ tokenSymbol }}</span>
+            </template>
+          </UInput>
         </UFormField>
       </div>
     </div>

--- a/app/src/components/sections/SherTokenView/forms/PayDividendsForm.vue
+++ b/app/src/components/sections/SherTokenView/forms/PayDividendsForm.vue
@@ -23,8 +23,12 @@
 
     <TokenAmount v-model="tokenAmountModel" :tokens="tokens" :loading="loading">
       <template #label>
-        <span class="label-text">Amount</span>
-        <span class="label-text-alt">Available: {{ formattedUnlockedBalance }}</span>
+        <div class="flex w-full items-center justify-between text-sm font-medium">
+          <span>Amount</span>
+          <span class="text-xs text-gray-500 dark:text-gray-400"
+            >Available: {{ formattedUnlockedBalance }}</span
+          >
+        </div>
       </template>
     </TokenAmount>
 

--- a/app/src/components/sections/VestingView/forms/CreateVesting.vue
+++ b/app/src/components/sections/VestingView/forms/CreateVesting.vue
@@ -63,31 +63,25 @@
     </UFormField>
 
     <div class="mt-4 flex w-full items-start gap-3">
-      <UFormField name="totalAmount" class="min-w-0 flex-1">
-        <label class="input input-bordered input-md flex w-full items-center gap-2">
-          <span class="shrink-0 text-xs">Amount</span>
-          <UInput
-            data-test="total-amount"
-            type="number"
-            class="grow border-none shadow-none"
-            :model-value="totalAmount"
-            @update:model-value="(v: string | number) => (totalAmount = Number(v))"
-            required
-          />
-        </label>
+      <UFormField name="totalAmount" label="Amount" class="min-w-0 flex-1">
+        <UInput
+          data-test="total-amount"
+          type="number"
+          class="w-full"
+          :model-value="totalAmount"
+          @update:model-value="(v: string | number) => (totalAmount = Number(v))"
+          :required="true"
+        />
       </UFormField>
-      <UFormField name="cliff" class="min-w-0 flex-1">
-        <label class="input input-bordered flex w-full items-center gap-2">
-          <span class="shrink-0 text-xs">Cliff(days)</span>
-          <UInput
-            data-test="cliff"
-            type="number"
-            class="grow border-none text-sm shadow-none"
-            :model-value="cliff"
-            @update:model-value="(v: string | number) => (cliff = Number(v))"
-            required
-          />
-        </label>
+      <UFormField name="cliff" label="Cliff (days)" class="min-w-0 flex-1">
+        <UInput
+          data-test="cliff"
+          type="number"
+          class="w-full"
+          :model-value="cliff"
+          @update:model-value="(v: string | number) => (cliff = Number(v))"
+          :required="true"
+        />
       </UFormField>
     </div>
 

--- a/app/src/components/utils/SelectMemberWithTokenInput.vue
+++ b/app/src/components/utils/SelectMemberWithTokenInput.vue
@@ -5,8 +5,8 @@
     ref="formRef"
     data-test="member-input"
   >
-    <label
-      class="input input-bordered input-md flex w-full items-center gap-2"
+    <div
+      class="border-default flex h-12 w-full items-center gap-2 rounded-md border bg-white px-3 dark:bg-gray-900"
       :data-test="`member-input`"
     >
       <UInput
@@ -40,7 +40,7 @@
           }
         "
       />
-    </label>
+    </div>
     <!-- Dropdown positioned relative to the input -->
     <div
       v-if="showDropdown && filteredMembers && filteredMembers.length > 0"


### PR DESCRIPTION
## Summary
Replaces daisy `input` / `input-bordered` / `input-{sm,md,lg}` and `label-text` / `label-text-alt` / `form-control` with Nuxt UI v4 `<UInput>` inside `<UFormField>` across 10 form components (SherToken, Vesting, ContractManagement, member/token selectors, deposit form).

Closes #1933

## Test plan
- [x] npm run lint
- [x] npm run format-check
- [x] npm run type-check
- [x] npm run test:unit -- --run
- [x] npm run build
- [ ] Visual diff: SherToken Mint / Distribute / Pay Dividends forms, Vesting create form, Contract Admins/Details, Compensation amount, Safe deposit router