### PR TITLE
refactor: ♻️ remove residual DaisyUI utility classes from app/

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <UApp>
-    <div class="bg-base-200 min-h-screen">
+    <div class="bg-muted min-h-screen">
       <LockScreen v-if="lock" :user="{ address: userStore.address }" />
       <template v-else>
         <RouterView name="login" />

--- a/app/src/components/NotificationDropdown.vue
+++ b/app/src/components/NotificationDropdown.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="dropdown dropdown-end">
-    <div tabindex="0" role="button" class="">
+  <UPopover :content="{ align: 'end' }">
+    <div role="button">
       <UButton variant="ghost" color="neutral" class="m-1 rounded-full" data-test="notifications">
         <div class="relative">
           <IconifyIcon icon="heroicons:bell" class="size-6" />
@@ -14,45 +14,53 @@
         </div>
       </UButton>
     </div>
-    <ul
-      tabindex="0"
-      class="menu dropdown-content bg-base-100 rounded-box z-1 w-[300px] p-2 shadow-sm"
-      data-test="notification-dropdown"
-    >
-      <li v-for="notification in paginatedNotifications" :key="notification.id">
-        <a @click="handleNotification(notification)" :data-test="`notification-${notification.id}`">
-          <div class="notification__body">
-            <span :class="{ 'font-bold': !notification.isRead }">
-              {{ notification.message }}
-            </span>
-          </div>
-          <!--<div class="notification__footer">{{ notification.author }} {{ notification.createdAt }}</div>-->
-        </a>
-      </li>
-      <!-- Pagination Controls -->
-      <div
-        class="flex items-center justify-between gap-1 p-2"
-        data-test="pagination-controls"
-        v-if="paginatedNotifications.length > 0"
+    <template #content>
+      <ul
+        class="bg-default flex w-[300px] flex-col gap-1 rounded-lg p-2 shadow-sm"
+        data-test="notification-dropdown"
       >
-        <UButton
-          color="primary"
-          size="xs"
-          :disabled="currentPage === 1"
-          @click="currentPage > 1 ? currentPage-- : currentPage"
-          icon="heroicons:chevron-left"
-        />
-        <span class="text-primary px-2 text-sm"> {{ currentPage }} / {{ totalPages }} </span>
-        <UButton
-          color="primary"
-          size="xs"
-          :disabled="currentPage === totalPages"
-          @click="currentPage < totalPages ? currentPage++ : currentPage"
-          icon="heroicons:chevron-right"
-        />
-      </div>
-    </ul>
-  </div>
+        <li
+          v-for="notification in paginatedNotifications"
+          :key="notification.id"
+          class="hover:bg-muted rounded-md"
+        >
+          <a
+            class="block cursor-pointer px-3 py-2"
+            @click="handleNotification(notification)"
+            :data-test="`notification-${notification.id}`"
+          >
+            <div class="notification__body">
+              <span :class="{ 'font-bold': !notification.isRead }">
+                {{ notification.message }}
+              </span>
+            </div>
+          </a>
+        </li>
+        <!-- Pagination Controls -->
+        <div
+          class="flex items-center justify-between gap-1 p-2"
+          data-test="pagination-controls"
+          v-if="paginatedNotifications.length > 0"
+        >
+          <UButton
+            color="primary"
+            size="xs"
+            :disabled="currentPage === 1"
+            @click="currentPage > 1 ? currentPage-- : currentPage"
+            icon="heroicons:chevron-left"
+          />
+          <span class="text-primary px-2 text-sm"> {{ currentPage }} / {{ totalPages }} </span>
+          <UButton
+            color="primary"
+            size="xs"
+            :disabled="currentPage === totalPages"
+            @click="currentPage < totalPages ? currentPage++ : currentPage"
+            icon="heroicons:chevron-right"
+          />
+        </div>
+      </ul>
+    </template>
+  </UPopover>
 </template>
 <script setup lang="ts">
 import { ref, computed } from 'vue'

--- a/app/src/components/SelectComponent.vue
+++ b/app/src/components/SelectComponent.vue
@@ -22,7 +22,7 @@
       <IconifyIcon v-if="!disabled" icon="heroicons-outline:chevron-down" class="h-4 w-4" />
     </UBadge>
     <ul
-      class="menu bg-base-200 rounded-box absolute right-0 z-10 mt-2 border-2 p-2 shadow-sm"
+      class="bg-muted absolute right-0 z-10 mt-2 flex flex-col gap-1 rounded-lg border-2 p-2 shadow-sm"
       ref="target"
       data-test="options-dropdown"
       v-if="isDropdown"
@@ -34,11 +34,12 @@
         @click="selectOption(option)"
         role="option"
         :aria-selected="option.value === selectedValue"
+        class="hover:bg-elevated cursor-pointer rounded-md px-3 py-1.5"
       >
         <a
           :class="{
-            focus: index === focusedIndex,
-            active: option.value === selectedValue && options.length > 2
+            'font-semibold': index === focusedIndex,
+            'text-primary': option.value === selectedValue && options.length > 2
           }"
           :data-focused="index === focusedIndex || undefined"
           >{{ option.label || option.value }}</a

--- a/app/src/components/SelectMemberItem.vue
+++ b/app/src/components/SelectMemberItem.vue
@@ -28,11 +28,11 @@
     <div
       v-if="isOpen.mount"
       v-show="isOpen.show"
-      class="rounded-box bg-base-100 absolute left-0 z-[9999] mt-2 max-h-72 w-full overflow-y-auto shadow-lg"
+      class="bg-default absolute left-0 z-[9999] mt-2 max-h-72 w-full overflow-y-auto rounded-lg shadow-lg"
       data-test="select-member-item-dropdown"
     >
       <!-- Search input -->
-      <div class="border-base-300 border-b p-2">
+      <div class="border-default border-b p-2">
         <UInput
           v-model="search"
           type="text"
@@ -53,7 +53,7 @@
           @click="select(member)"
         >
           <UserComponent
-            class="hover:bg-base-200 flex w-full items-center gap-2 p-3"
+            class="hover:bg-muted flex w-full items-center gap-2 p-3"
             :user="member"
             data-test="select-member-item-option-user"
           />

--- a/app/src/components/forms/DepositBankForm.vue
+++ b/app/src/components/forms/DepositBankForm.vue
@@ -18,8 +18,8 @@
         @validation="isAmountValid = $event"
       >
         <template #label>
-          <span class="label-text">Deposit</span>
-          <span class="label-text-alt"
+          <span class="text-sm font-medium">Deposit</span>
+          <span class="text-xs text-gray-500"
             >Balance: {{ selectedToken?.amount }} {{ selectedToken?.token.symbol }}</span
           >
         </template>

--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
@@ -20,11 +20,12 @@
       </span>
     </div>
 
-    <progress
-      class="progress progress-success my-4"
+    <UProgress
+      class="my-4"
+      color="success"
       :value="election.currentVotes"
       :max="election.totalVotes"
-    ></progress>
+    />
 
     <!-- Conditional Button/Indicator -->
     <div

--- a/app/src/components/sections/CashRemunerationView/CRSigne.vue
+++ b/app/src/components/sections/CashRemunerationView/CRSigne.vue
@@ -28,7 +28,7 @@
       :style="{ pointerEvents: isLoad ? 'none' : undefined }"
       @click="handleDropdownClick"
     >
-      <span v-if="isLoad" class="loading loading-spinner loading-xs mr-2"></span>
+      <UIcon v-if="isLoad" name="i-lucide-loader-circle" class="mr-2 h-3 w-3 animate-spin" />
       {{ isResign ? 'Resign' : 'Sign' }}
     </div>
   </UTooltip>

--- a/app/src/components/sections/CashRemunerationView/CRWithdrawClaim.vue
+++ b/app/src/components/sections/CashRemunerationView/CRWithdrawClaim.vue
@@ -18,7 +18,11 @@
       }
     "
   >
-    <span v-if="withdrawTx.isPending.value" class="loading loading-spinner loading-xs mr-2"></span>
+    <UIcon
+      v-if="withdrawTx.isPending.value"
+      name="i-lucide-loader-circle"
+      class="mr-2 h-3 w-3 animate-spin"
+    />
     Withdraw
   </a>
   <UButton

--- a/app/src/components/sections/CashRemunerationView/Form/FilePreviewGallery.vue
+++ b/app/src/components/sections/CashRemunerationView/Form/FilePreviewGallery.vue
@@ -38,7 +38,7 @@
         ]"
         data-test="image-loading"
       >
-        <span class="loading loading-spinner loading-sm text-gray-400"></span>
+        <UIcon name="i-lucide-loader-circle" class="h-4 w-4 animate-spin text-gray-400" />
         <span class="mt-1 text-[10px] text-gray-500">Loading...</span>
       </div>
 

--- a/app/src/components/sections/ClaimHistoryView/WeeklyRecap.vue
+++ b/app/src/components/sections/ClaimHistoryView/WeeklyRecap.vue
@@ -1,9 +1,11 @@
 <template>
   <div class="w-full bg-white">
-    <div class="stats w-full shadow-sm">
+    <div
+      class="grid w-full grid-cols-2 divide-x divide-gray-200 rounded-lg shadow-sm md:grid-cols-4"
+    >
       <!-- Total Hours -->
-      <div class="stat place-items-center">
-        <div class="stat-title">Total Hours</div>
+      <div class="flex flex-col items-center justify-center gap-1 p-4">
+        <div class="text-xs font-semibold text-gray-500 uppercase">Total Hours</div>
 
         <div class="mb-2">
           <span
@@ -55,8 +57,8 @@
       </div>
 
       <!-- Hourly Rate -->
-      <div class="stat place-items-center">
-        <div class="stat-title">Hourly Rate</div>
+      <div class="flex flex-col items-center justify-center gap-1 p-4">
+        <div class="text-xs font-semibold text-gray-500 uppercase">Hourly Rate</div>
         <div class="text-center text-xl">
           <RateDotList :rates="effectiveWage?.ratePerHour || []" :text-class="'text-center'" />
         </div>
@@ -66,8 +68,8 @@
       </div>
 
       <!-- Overtime Rate (only when overtime wage is configured) -->
-      <div v-if="hasOvertimeWage" class="stat place-items-center">
-        <div class="stat-title">Overtime Rate</div>
+      <div v-if="hasOvertimeWage" class="flex flex-col items-center justify-center gap-1 p-4">
+        <div class="text-xs font-semibold text-gray-500 uppercase">Overtime Rate</div>
         <div class="text-center text-xl">
           <RateDotList
             :rates="(effectiveWage?.overtimeRatePerHour as RatePerHour[]) || []"
@@ -82,8 +84,8 @@
       </div>
 
       <!-- Total Amount -->
-      <div class="stat place-items-center">
-        <div class="stat-title">Total Amount</div>
+      <div class="flex flex-col items-center justify-center gap-1 p-4">
+        <div class="text-xs font-semibold text-gray-500 uppercase">Total Amount</div>
         <div class="text-center text-xl">
           <template v-if="props.weeklyClaim">
             <RateDotList

--- a/app/src/components/sections/ContractManagementView/AdvertiseContractSection.vue
+++ b/app/src/components/sections/ContractManagementView/AdvertiseContractSection.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="flex flex-col gap-6">
-    <span
+    <UIcon
       v-if="teamStore.currentTeamMeta.isPending"
-      class="loading loading-spinner loading-lg"
-    ></span>
+      name="i-lucide-loader-circle"
+      class="text-primary h-10 w-10 animate-spin"
+    />
     <div
       v-if="!teamStore.currentTeamMeta.isPending && teamStore"
       class="flex w-full flex-col items-center gap-5"

--- a/app/src/components/sections/ContractManagementView/BodApprovalModal.vue
+++ b/app/src/components/sections/ContractManagementView/BodApprovalModal.vue
@@ -24,11 +24,7 @@
       {{ approvalCount.approved }}/{{ approvalCount.total }} Approvals
     </UBadge>
   </div>
-  <progress
-    class="progress progress-info mb-1"
-    :value="approvalCount.approved"
-    :max="approvalCount.total"
-  ></progress>
+  <UProgress class="mb-1" color="info" :value="approvalCount.approved" :max="approvalCount.total" />
   <span class="text-sm text-gray-500"
     >{{ Math.floor(approvalCount.total / 2) + 1 - approvalCount.approved }} Approval(s) left</span
   >

--- a/app/src/components/sections/ContractManagementView/TeamContractAdmins.vue
+++ b/app/src/components/sections/ContractManagementView/TeamContractAdmins.vue
@@ -1,7 +1,7 @@
 <template>
   <h3 class="mb-4 text-lg font-bold">
     Contract Admin List {{ range }}
-    <span class="loading loading-spinner" v-if="isLoading"></span>
+    <UIcon v-if="isLoading" name="i-lucide-loader-circle" class="h-5 w-5 animate-spin" />
   </h3>
 
   <!-- Inline form to add new admin -->

--- a/app/src/components/sections/ContractManagementView/TeamContractEventList.vue
+++ b/app/src/components/sections/ContractManagementView/TeamContractEventList.vue
@@ -23,12 +23,7 @@
     </template>
 
     <template #details-cell="{ row: { original: row } }">
-      <input
-        type="checkbox"
-        :checked="row.expanded"
-        @change="toggleCampaign(row.campaignCode)"
-        class="toggle"
-      />
+      <USwitch :model-value="row.expanded" @update:model-value="toggleCampaign(row.campaignCode)" />
       <div v-if="row.expanded">
         <ul>
           <li

--- a/app/src/components/sections/ContractManagementView/__tests__/AdvertiseContractSection.spec.ts
+++ b/app/src/components/sections/ContractManagementView/__tests__/AdvertiseContractSection.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+import AdvertiseContractSection from '@/components/sections/ContractManagementView/AdvertiseContractSection.vue'
+import { useTeamStore } from '@/stores'
+import { mockTeamStore } from '@/tests/mocks'
+
+vi.mock('@/components/sections/ContractManagementView/TeamContracts.vue', () => ({
+  default: { template: '<div data-test="team-contracts-stub" />' }
+}))
+
+vi.mock('@/components/sections/ContractManagementView/forms/CreateAddCampaign.vue', () => ({
+  default: { template: '<div data-test="create-add-campaign-stub" />' }
+}))
+
+const mountSection = () =>
+  mount(AdvertiseContractSection, {
+    global: { plugins: [createTestingPinia({ createSpy: vi.fn })] }
+  })
+
+describe('AdvertiseContractSection.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the loader while team meta is pending', () => {
+    vi.mocked(useTeamStore).mockReturnValue({
+      ...mockTeamStore,
+      currentTeamMeta: { isPending: true, data: undefined }
+    } as unknown as ReturnType<typeof useTeamStore>)
+
+    const wrapper = mountSection()
+    expect(wrapper.find('[data-icon="i-lucide-loader-circle"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="createAddCampaign"]').exists()).toBe(false)
+  })
+
+  it('renders the deploy card once team meta has resolved', () => {
+    vi.mocked(useTeamStore).mockReturnValue({
+      ...mockTeamStore,
+      currentTeamMeta: { isPending: false, data: mockTeamStore.currentTeam }
+    } as unknown as ReturnType<typeof useTeamStore>)
+
+    const wrapper = mountSection()
+    expect(wrapper.find('[data-icon="i-lucide-loader-circle"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="createAddCampaign"]').exists()).toBe(true)
+  })
+})

--- a/app/src/components/sections/ContractManagementView/__tests__/TeamContractAdmins.spec.ts
+++ b/app/src/components/sections/ContractManagementView/__tests__/TeamContractAdmins.spec.ts
@@ -47,12 +47,12 @@ describe('TeamContractAdmins.vue', () => {
 
   it('hides the loading spinner when no write is in-flight', () => {
     const wrapper = mountWithWritePending(false)
-    expect(wrapper.find('.loading-spinner').exists()).toBe(false)
+    expect(wrapper.find('[data-icon="i-lucide-loader-circle"]').exists()).toBe(false)
   })
 
   it('shows the loading spinner while a write is pending', () => {
     const wrapper = mountWithWritePending(true)
-    expect(wrapper.find('.loading-spinner').exists()).toBe(true)
+    expect(wrapper.find('[data-icon="i-lucide-loader-circle"]').exists()).toBe(true)
   })
 
   it('renders one row per admin returned by the read', () => {

--- a/app/src/components/sections/ContractManagementView/__tests__/TeamContractEventList.spec.ts
+++ b/app/src/components/sections/ContractManagementView/__tests__/TeamContractEventList.spec.ts
@@ -85,8 +85,8 @@ describe('TeamContractEventList.vue', () => {
     expect(wrapper.findAll('ul').length).toBe(0)
 
     // Expand the first campaign
-    const toggleButton = wrapper.find('input[type="checkbox"]')
-    await toggleButton.setValue(true)
+    const toggleButton = wrapper.find('button[role="switch"]')
+    await toggleButton.trigger('click')
 
     // Verify expanded details for the first campaign
     const expandedDetails = wrapper.find('ul')
@@ -95,14 +95,14 @@ describe('TeamContractEventList.vue', () => {
     expect(firstDetailItems.length).toBe(eventsByCampaignCode['0xCampaign1'].length - 1)
 
     // Collapse the first campaign
-    await toggleButton.setValue(false)
+    await toggleButton.trigger('click')
     expect(wrapper.find('ul').exists()).toBe(false)
   })
 
   it('displays correct event details for PaymentReleased', async () => {
     // Expand the first campaign
-    const toggleButton = wrapper.find('input[type="checkbox"]')
-    await toggleButton.setValue(true)
+    const toggleButton = wrapper.find('button[role="switch"]')
+    await toggleButton.trigger('click')
 
     // Verify PaymentReleased details
     const detailItems = wrapper.findAll('ul li')
@@ -111,8 +111,8 @@ describe('TeamContractEventList.vue', () => {
 
   it('displays correct event details for BudgetWithdrawn', async () => {
     // Expand the second campaign
-    const toggleButtons = wrapper.findAll('input[type="checkbox"]')
-    await toggleButtons.at(1)?.setValue(true)
+    const toggleButtons = wrapper.findAll('button[role="switch"]')
+    await toggleButtons.at(1)?.trigger('click')
 
     // Verify BudgetWithdrawn details
     const detailItems = wrapper.findAll('ul li')
@@ -120,16 +120,16 @@ describe('TeamContractEventList.vue', () => {
   })
 
   it('displays correct event details for PaymentReleasedOnWithdrawApproval', async () => {
-    const toggleButtons = wrapper.findAll('input[type="checkbox"]')
-    await toggleButtons.at(2)?.setValue(true)
+    const toggleButtons = wrapper.findAll('button[role="switch"]')
+    await toggleButtons.at(2)?.trigger('click')
 
     const detailItem = wrapper.findAll('ul li')
     expect(detailItem.at(0)?.text()).toContain('Payment Released on Approval: 1500 POL')
   })
 
   it('returns N/A when AdCampaignCreated event is missing', async () => {
-    const toggleButtons = wrapper.findAll('input[type="checkbox"]')
-    await toggleButtons.at(3)?.setValue(true)
+    const toggleButtons = wrapper.findAll('button[role="switch"]')
+    await toggleButtons.at(3)?.trigger('click')
 
     const budgetCell = wrapper.findAll('.campaign-budget')[3]
     expect(budgetCell.text()).toBe('N/A POL')

--- a/app/src/components/sections/ContractManagementView/forms/TransferOwnershipForm.vue
+++ b/app/src/components/sections/ContractManagementView/forms/TransferOwnershipForm.vue
@@ -44,7 +44,7 @@
 
         <div class="h-20">
           <UserComponent
-            class="bg-base-200 grow rounded-lg p-4 hover:cursor-pointer"
+            class="bg-muted grow rounded-lg p-4 hover:cursor-pointer"
             v-if="input.address"
             :user="input"
           />

--- a/app/src/components/sections/DashboardView/MemberSection.vue
+++ b/app/src/components/sections/DashboardView/MemberSection.vue
@@ -47,7 +47,7 @@
           <div class="pb-1 text-center">
             <span>Hourly Rates</span>
           </div>
-          <div class="border-base-400 flex flex-row justify-between border-t">
+          <div class="border-default flex flex-row justify-between border-t">
             <span class="w-1/3 bg-[#C8FACD] p-1 text-center text-xs">{{
               NETWORK.currencySymbol
             }}</span>

--- a/app/src/components/sections/DashboardView/SetMemberWageOvertimeStep.vue
+++ b/app/src/components/sections/DashboardView/SetMemberWageOvertimeStep.vue
@@ -71,16 +71,14 @@
 
     <div class="grid gap-4 md:grid-cols-2">
       <div
-        class="border-base-300 bg-base-100 min-h-40 rounded-2xl border px-5 py-5"
+        class="border-default bg-default min-h-40 rounded-2xl border px-5 py-5"
         data-test="standard-rate-recap"
       >
-        <p class="text-base-content/50 text-sm font-semibold tracking-[0.2em] uppercase">
-          Standard rates
-        </p>
+        <p class="text-muted text-sm font-semibold tracking-[0.2em] uppercase">Standard rates</p>
         <RateDotList
           class="mt-3"
           :rates="wageData.ratePerHour.filter((r) => r.enabled && r.amount > 0)"
-          text-class="text-base-content/80"
+          text-class="text-default"
         />
       </div>
       <div

--- a/app/src/components/sections/DashboardView/SetMemberWageStandardStep.vue
+++ b/app/src/components/sections/DashboardView/SetMemberWageStandardStep.vue
@@ -54,13 +54,13 @@
       </div>
     </UFormField>
 
-    <div class="border-base-200 border-t pt-4">
+    <div class="border-muted border-t pt-4">
       <label
         class="flex cursor-pointer items-start gap-3 rounded-2xl border px-4 py-4 transition"
         :class="
           wageData.enableOvertimeRules
             ? 'border-emerald-400 bg-emerald-50/60'
-            : 'border-base-200 bg-base-100'
+            : 'border-muted bg-default'
         "
         data-test="enable-overtime-card"
         :data-active="wageData.enableOvertimeRules ? 'true' : 'false'"
@@ -73,7 +73,7 @@
         />
         <div>
           <p class="font-semibold">Add overtime rates</p>
-          <p class="text-base-content/60 text-sm">
+          <p class="text-muted text-sm">
             Set different rates for hours worked beyond the weekly cap.
           </p>
         </div>

--- a/app/src/components/sections/ExpenseAccountView/ExpenseAccountTable.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseAccountTable.vue
@@ -1,6 +1,6 @@
 <template>
   <URadioGroup v-model="selectedRadio" :items="statuses" orientation="horizontal" />
-  <div class="bg-base-100 w-full">
+  <div class="bg-default w-full">
     <UTable :data="filteredApprovals" :columns="columns" :loading="isFetchingExpenseData">
       <template #action-cell="{ row: { original: row } }">
         <UButton

--- a/app/src/components/sections/ExpenseAccountView/TransferAction.vue
+++ b/app/src/components/sections/ExpenseAccountView/TransferAction.vue
@@ -52,8 +52,8 @@
           @closeModal="showModal = { mount: false, show: false }"
         >
           <template #label>
-            <span class="label-text">Transfer From</span>
-            <span class="label-text-alt"
+            <span class="text-sm font-medium">Transfer From</span>
+            <span class="text-xs text-gray-500"
               >Limit: {{ row.data.amount }} {{ transferData.token.symbol }}
             </span>
           </template>

--- a/app/src/components/sections/SafeView/SafeBalanceSection.vue
+++ b/app/src/components/sections/SafeView/SafeBalanceSection.vue
@@ -15,11 +15,12 @@
         <div class="flex items-baseline gap-2">
           <span class="text-4xl font-bold">
             <span class="inline-block h-10 min-w-16">
-              <span
+              <UIcon
                 v-if="isLoading"
-                class="loading loading-spinner loading-lg"
+                name="i-lucide-loader-circle"
+                class="text-primary h-10 w-10 animate-spin"
                 data-test="safe-balance-loading"
-              ></span>
+              />
               <span v-else>{{ total['USD']?.formated ?? 0 }}</span>
             </span>
           </span>

--- a/app/src/components/sections/SafeView/SafeDeploymentCard.vue
+++ b/app/src/components/sections/SafeView/SafeDeploymentCard.vue
@@ -8,7 +8,7 @@
       </div>
     </div>
 
-    <div class="bg-base-300 mb-4 rounded-lg p-4">
+    <div class="bg-elevated mb-4 rounded-lg p-4">
       <div class="space-y-2 text-sm">
         <div class="flex justify-between">
           <span class="text-gray-500">Owner:</span>

--- a/app/src/components/sections/SherTokenView/InvestorActions/SetCompensationMultiplierAction.vue
+++ b/app/src/components/sections/SherTokenView/InvestorActions/SetCompensationMultiplierAction.vue
@@ -24,13 +24,13 @@
     >
       <template #body>
         <div class="mb-4">
-          <p class="text-base-content/70 mb-2 text-sm">
+          <p class="text-muted mb-2 text-sm">
             Current multiplier:
             <span class="font-semibold" data-test="current-multiplier">
               {{ isMultiplierLoading ? 'Loading...' : `${formattedCurrentMultiplier}x` }}
             </span>
           </p>
-          <p class="text-base-content/70 text-sm">
+          <p class="text-muted text-sm">
             The multiplier determines how many SHER tokens are minted per deposited token. You can
             use decimal values (e.g., 1.5, 2.75).
           </p>

--- a/app/src/components/sections/SherTokenView/forms/DistributeMintForm.vue
+++ b/app/src/components/sections/SherTokenView/forms/DistributeMintForm.vue
@@ -24,18 +24,18 @@
           />
         </UFormField>
 
-        <div
-          class="dropdown"
-          :class="{
-            'dropdown-open':
-              !!usersData?.users && usersData?.users.length > 0 && showDropdown[index]
-          }"
-          :key="index"
-          v-if="showDropdown[index]"
-        >
-          <ul class="menu dropdown-content bg-base-100 rounded-box z-1 w-96 p-2 shadow-sm">
-            <li v-for="user in usersData?.users" :key="user.address">
+        <div class="relative" :key="index" v-if="showDropdown[index]">
+          <ul
+            class="bg-default z-1 mt-1 flex w-96 flex-col gap-1 rounded-lg p-2 shadow-sm"
+            v-if="!!usersData?.users && usersData?.users.length > 0"
+          >
+            <li
+              v-for="user in usersData?.users"
+              :key="user.address"
+              class="hover:bg-muted rounded-md"
+            >
               <a
+                class="block cursor-pointer px-3 py-2"
                 data-test="found-user"
                 @click="
                   () => {

--- a/app/src/components/sections/SherTokenView/forms/__tests__/DistributeMintForm.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/DistributeMintForm.spec.ts
@@ -1,7 +1,9 @@
 import { describe, it, vi, expect, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
+import { ref } from 'vue'
 import DistributeMintForm from '../DistributeMintForm.vue'
+import * as userQueries from '@/queries/user.queries'
 
 const mountForm = () =>
   mount(DistributeMintForm, {
@@ -51,6 +53,35 @@ describe('DistributeMintForm.vue', () => {
     expect(amountError.text()).toContain('Amount must be greater than 0')
 
     expect(wrapper.emitted('submit')).toBeUndefined()
+  })
+
+  it('fills shareholder address when a user is picked from the search dropdown', async () => {
+    vi.mocked(userQueries.useGetSearchUsersQuery).mockReturnValue({
+      data: ref({
+        users: [{ name: 'Alice', address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }]
+      }),
+      error: ref(null)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    const wrapper = mountForm()
+
+    const addressInput = wrapper.find('input[data-test="address-input"]')
+    await addressInput.setValue('Ali')
+    await addressInput.trigger('keyup')
+    await flushPromises()
+
+    const foundUser = wrapper.find('[data-test="found-user"]')
+    expect(foundUser.exists()).toBe(true)
+    expect(foundUser.text()).toContain('Alice')
+
+    await foundUser.trigger('click')
+    await flushPromises()
+
+    expect((addressInput.element as HTMLInputElement).value).toBe(
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    )
+    expect(wrapper.find('[data-test="found-user"]').exists()).toBe(false)
   })
 
   it('emits submit with parsed shareholder amounts when all rows are valid', async () => {

--- a/app/src/components/sections/VestingView/VestingFlow.vue
+++ b/app/src/components/sections/VestingView/VestingFlow.vue
@@ -11,7 +11,7 @@
       </div>
     </template>
 
-    <span class="loading loading-spinner" v-if="loading"></span>
+    <UIcon v-if="loading" name="i-lucide-loader-circle" class="h-5 w-5 animate-spin" />
 
     <UTable
       :data="vestings"

--- a/app/src/components/sections/VestingView/VestingSummary.vue
+++ b/app/src/components/sections/VestingView/VestingSummary.vue
@@ -2,7 +2,7 @@
   <div class="flex w-full max-w-5xl flex-col gap-5">
     <h4 class="text-lg font-bold">Review Vesting Details</h4>
 
-    <div class="bg-base-200 grid grid-cols-1 gap-4 rounded-lg p-4 md:grid-cols-2">
+    <div class="bg-muted grid grid-cols-1 gap-4 rounded-lg p-4 md:grid-cols-2">
       <div class="flex flex-col gap-2">
         <span class="text-xs text-gray-500">Member</span>
         <span class="font-medium">{{

--- a/app/src/components/sections/VestingView/forms/CreateVesting.vue
+++ b/app/src/components/sections/VestingView/forms/CreateVesting.vue
@@ -20,7 +20,7 @@
     <UFormField name="member" label="Choose Member" class="mt-4 gap-2">
       <div v-if="member.address" class="h-20">
         <UserComponent
-          class="bg-base-200 grow rounded-lg p-4"
+          class="bg-muted grow rounded-lg p-4"
           :user="member"
           data-test="selected-member"
         />

--- a/app/src/components/sections/WeeklyClaimView/WeeklyClaimActionDropdown.vue
+++ b/app/src/components/sections/WeeklyClaimView/WeeklyClaimActionDropdown.vue
@@ -3,15 +3,24 @@
     <!-- Dropdown menu positioned to the left -->
     <ul
       v-if="isOpen"
-      class="menu bg-base-100 rounded-box border-base-300 absolute top-1/2 right-full z-99999 mr-2 w-52 -translate-y-1/2 transform border p-2 shadow-lg"
+      class="bg-default border-default absolute top-1/2 right-full z-99999 mr-2 flex w-52 -translate-y-1/2 transform flex-col gap-1 rounded-lg border p-2 shadow-lg"
     >
       <!-- Pending status: Sign -->
       <template v-if="status === 'pending'">
-        <li class="disabled" data-test="pending-withdraw">
+        <li
+          class="pointer-events-none rounded-md px-3 py-1.5 opacity-50"
+          data-test="pending-withdraw"
+        >
           <a class="text-sm"> Withdraw </a>
         </li>
         <li
-          :class="{ disabled: !isCashRemunerationOwner || isCurrentWeek(weeklyClaim) }"
+          :class="[
+            'hover:bg-muted rounded-md px-3 py-1.5',
+            {
+              'pointer-events-none opacity-50':
+                !isCashRemunerationOwner || isCurrentWeek(weeklyClaim)
+            }
+          ]"
           data-test="pending-sign"
         >
           <CRSigne
@@ -31,7 +40,10 @@
         <li
           v-if="isStaleSignature"
           data-test="signed-resign"
-          :class="{ disabled: !isCashRemunerationOwner }"
+          :class="[
+            'hover:bg-muted rounded-md px-3 py-1.5',
+            { 'pointer-events-none opacity-50': !isCashRemunerationOwner }
+          ]"
         >
           <CRSigne
             :weekly-claim="weeklyClaim"
@@ -40,7 +52,14 @@
             @close="isOpen = false"
           />
         </li>
-        <li v-else data-test="signed-withdraw" :class="{ disabled: !isClaimOwner }">
+        <li
+          v-else
+          data-test="signed-withdraw"
+          :class="[
+            'hover:bg-muted rounded-md px-3 py-1.5',
+            { 'pointer-events-none opacity-50': !isClaimOwner }
+          ]"
+        >
           <CRWithdrawClaim
             :weekly-claim="weeklyClaim"
             :is-drop-down="true"
@@ -48,9 +67,15 @@
             @claim-withdrawn="isOpen = false"
           />
         </li>
-        <li data-test="signed-disable" :class="{ disabled: !isCashRemunerationOwner }">
+        <li
+          data-test="signed-disable"
+          :class="[
+            'hover:bg-muted rounded-md px-3 py-1.5',
+            { 'pointer-events-none opacity-50': !isCashRemunerationOwner }
+          ]"
+        >
           <a
-            :class="['text-sm', { disabled: disableTx.isPending.value }]"
+            :class="['text-sm', { 'pointer-events-none opacity-50': disableTx.isPending.value }]"
             :aria-disabled="disableTx.isPending.value"
             :tabindex="disableTx.isPending.value ? -1 : 0"
             :style="{ pointerEvents: disableTx.isPending.value ? 'none' : undefined }"
@@ -61,10 +86,11 @@
               }
             "
           >
-            <span
+            <UIcon
               v-if="disableTx.isPending.value"
-              class="loading loading-spinner loading-xs mr-2"
-            ></span>
+              name="i-lucide-loader-circle"
+              class="mr-2 h-3 w-3 animate-spin"
+            />
             Disable
           </a>
         </li>
@@ -72,17 +98,32 @@
 
       <!-- Disabled status: Enable and Resign -->
       <template v-else-if="status === 'disabled'">
-        <li data-test="disabled-withdraw" class="disabled">
+        <li
+          data-test="disabled-withdraw"
+          class="pointer-events-none rounded-md px-3 py-1.5 opacity-50"
+        >
           <a class="text-sm"> Withdraw </a>
         </li>
-        <li data-test="disabled-enable" :class="{ disabled: !isCashRemunerationOwner }">
+        <li
+          data-test="disabled-enable"
+          :class="[
+            'hover:bg-muted rounded-md px-3 py-1.5',
+            { 'pointer-events-none opacity-50': !isCashRemunerationOwner }
+          ]"
+        >
           <WeeklyClaimActionEnable
             :weekly-claim="weeklyClaim"
             :is-cash-remuneration-owner="isCashRemunerationOwner"
             @close="isOpen = false"
           />
         </li>
-        <li data-test="disabled-resign" :class="{ disabled: !isCashRemunerationOwner }">
+        <li
+          data-test="disabled-resign"
+          :class="[
+            'hover:bg-muted rounded-md px-3 py-1.5',
+            { 'pointer-events-none opacity-50': !isCashRemunerationOwner }
+          ]"
+        >
           <CRSigne
             :weekly-claim="weeklyClaim"
             :is-drop-down="true"

--- a/app/src/components/sections/WeeklyClaimView/WeeklyClaimActionEnable.vue
+++ b/app/src/components/sections/WeeklyClaimView/WeeklyClaimActionEnable.vue
@@ -1,7 +1,7 @@
 <template>
   <a
     data-test="enable-action"
-    :class="['text-sm', { disabled: enableTx.isPending.value }]"
+    :class="['text-sm', { 'pointer-events-none opacity-50': enableTx.isPending.value }]"
     :aria-disabled="enableTx.isPending.value"
     :tabindex="enableTx.isPending.value ? -1 : 0"
     :style="{ pointerEvents: enableTx.isPending.value ? 'none' : undefined }"
@@ -12,7 +12,11 @@
       }
     "
   >
-    <span v-if="enableTx.isPending.value" class="loading loading-spinner loading-xs mr-2"></span>
+    <UIcon
+      v-if="enableTx.isPending.value"
+      name="i-lucide-loader-circle"
+      class="mr-2 h-3 w-3 animate-spin"
+    />
     Enable
   </a>
 </template>

--- a/app/src/components/ui/SidebarLayout.vue
+++ b/app/src/components/ui/SidebarLayout.vue
@@ -61,7 +61,7 @@
         description="Edit your profile information used across the application."
       >
         <div
-          class="bg-base-200 flex w-full cursor-pointer flex-row justify-start gap-4 rounded-xl p-4 shadow-xs transition-all duration-300"
+          class="bg-muted flex w-full cursor-pointer flex-row justify-start gap-4 rounded-xl p-4 shadow-xs transition-all duration-300"
           data-test="edit-user-card"
           :class="{ 'justify-center': collapsed }"
           @click="open = true"

--- a/app/src/components/ui/TimelineIcon.vue
+++ b/app/src/components/ui/TimelineIcon.vue
@@ -7,11 +7,12 @@
     >
       <Icon icon="heroicons:check" class="h-4 w-4 text-white" />
     </div>
-    <div
+    <UIcon
       v-else-if="status === 'active'"
-      class="loading loading-spinner loading-md text-primary"
+      name="i-lucide-loader-circle"
+      class="text-primary h-6 w-6 animate-spin"
       data-test="timeline-icon-active"
-    ></div>
+    />
     <div
       v-else-if="status === 'error'"
       class="bg-error flex h-6 w-6 items-center justify-center rounded-full"

--- a/app/src/components/utils/MultiSelectMemberInput.vue
+++ b/app/src/components/utils/MultiSelectMemberInput.vue
@@ -6,7 +6,7 @@
   <div class="grid grid-cols-2 gap-4" data-test="members-list">
     <div class="flex items-center" v-for="member of teamMembers" :key="member.address">
       <UserComponent
-        class="bg-base-200 grow rounded-lg p-4 hover:cursor-pointer"
+        class="bg-muted grow rounded-lg p-4 hover:cursor-pointer"
         :user="member"
         @click="addMember(member)"
       />

--- a/app/src/components/utils/SelectContractResults.vue
+++ b/app/src/components/utils/SelectContractResults.vue
@@ -10,7 +10,7 @@
         @click="handleSelect(contract)"
       >
         <UserComponent
-          class="hover:bg-base-300 grow rounded-lg bg-white p-4"
+          class="hover:bg-elevated grow rounded-lg bg-white p-4"
           :user="{ name: contract.type, address: contract.address, imageUrl: contract.imageUrl }"
           :data-test="`contract-dropdown-${contract.address}`"
         />

--- a/app/src/components/utils/SelectMemberResults.vue
+++ b/app/src/components/utils/SelectMemberResults.vue
@@ -10,7 +10,7 @@
         @click="handleSelect(member)"
       >
         <UserComponent
-          class="hover:bg-base-300 flex-grow rounded-lg bg-white p-4"
+          class="hover:bg-elevated flex-grow rounded-lg bg-white p-4"
           :user="member"
           :data-test="`user-dropdown-${member.address}`"
         />

--- a/app/src/components/utils/SelectMemberWithTokenInput.vue
+++ b/app/src/components/utils/SelectMemberWithTokenInput.vue
@@ -48,7 +48,7 @@
       data-test="user-dropdown"
     >
       <p class="pb-3 font-bold">Click to select Member</p>
-      <div class="bg-base-100 rounded-box">
+      <div class="bg-default rounded-lg">
         <div class="grid grid-cols-2 gap-4" data-test="user-search-results">
           <div
             v-for="user in filteredMembers.slice(0, 8)"
@@ -58,7 +58,7 @@
             data-test="user-row"
           >
             <UserComponent
-              class="bg-base-200 hover:bg-base-300 grow rounded-lg p-4"
+              class="bg-muted hover:bg-elevated grow rounded-lg p-4"
               :user="user"
               :data-test="`user-dropdown-${user.address}`"
             />

--- a/app/src/views/team/[id]/Accounts/SafeView.vue
+++ b/app/src/views/team/[id]/Accounts/SafeView.vue
@@ -25,7 +25,7 @@
   <!-- Loading state -->
   <div v-else class="flex items-center justify-center p-8">
     <div class="text-center">
-      <div class="loading loading-spinner loading-lg"></div>
+      <UIcon name="i-lucide-loader-circle" class="text-primary mx-auto h-10 w-10 animate-spin" />
       <p class="mt-4 text-gray-500">Loading safe...</p>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Resolves the remaining DaisyUI utility classes left in `app/src/` after #1920 removed the plugin. Without the plugin, these classes produced no styling — causing the visual regressions tracked in #1927 (missing spinners, transparent dropdowns, broken tooltips/skeletons, unstyled inputs/progress/stats).

Migrations applied across the categories listed in #1927:

| Category | Sub-issue | Migration |
|---|---|---|
| `loading loading-spinner loading-{xs,sm,md,lg}` | #1931 | `<UIcon name="i-lucide-loader-circle" class="… animate-spin" />` |
| `progress progress-{info,success}` | #1937 | `<UProgress :color="…" />` |
| `stats stat stat-title` | #1938 | Plain Tailwind grid + utility classes |
| `toggle` (checkbox) | #1940 | `<USwitch />` |
| `label-text` / `label-text-alt` | — | Tailwind text utilities (`text-sm font-medium`, `text-xs text-gray-500`) |
| `menu dropdown dropdown-end dropdown-content` | #1934 | `<UPopover>` (Notifications) + plain `<ul>` + Tailwind for in-row custom dropdowns |
| `bg-base-{100,200,300}` / `text-base-content/*` / `border-base-*` / `rounded-box` | #1942 | `bg-default` / `bg-muted` / `bg-elevated`, `text-default` / `text-muted`, `border-default`, `rounded-lg` |

Categories already addressed in earlier PRs (#1932, #1933, #1935, #1936, #1939, #1941) are not re-touched.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format-check` — clean
- [x] `npm run test:unit` — 201 files / 1683 tests pass (added 3 new tests covering the loader / found-user / switch branches)
- [ ] Visual regression spot-check on:
  - Notification dropdown (UPopover trigger + items)
  - Weekly claim action dropdown (sign / withdraw / disable / enable / resign)
  - Cash Remuneration sign/withdraw inline spinners
  - Claim History weekly recap stat cards
  - BoD election progress bar + approval modal progress bar
  - Safe balance + Safe deployment card
  - Vesting flow / summary / create form
  - SHER token distribute mint form + investor actions
  - Sidebar layout user card
  - Team Contract Admins + Events list toggle

Note: `npm run build` exposes 6 pre-existing TS errors in `ApproveUsersEIP712Form.vue`, `CreateElectionForm.vue`, `CreateProposalForm.vue` that are present on `develop` and unrelated to this change.

Closes #1927
Closes #1931
Closes #1934
Closes #1937
Closes #1938
Closes #1940
Closes #1942