### PR TITLE
chore: 🔧 drop stale V3-migration ESLint allow-list

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -97,11 +97,10 @@ const vmCastLegacyExtraFiles = [
 //   - `src/composables/contracts/**` — the V3 implementation itself.
 //   - `src/composables/transactions/useSafeSendTransaction.ts` — Safe SDK
 //     wrapper that legitimately wraps `waitForTransactionReceipt`.
+//   - `src/composables/useContractFunctions.ts` — contract *deployment*
+//     path; `waitForTransactionReceipt` awaits a deploy receipt, not a
+//     write. Deployment is out of scope for the V3 writes migration.
 //   - test-only mock setup files under `tests/`.
-//
-// Legacy allow-list: files pending migration are listed in
-// `v3MigrationLegacyFiles` and tracked in issue #1798. Each migration PR
-// removes its file from the list; when empty, drop the override block.
 const v3WriteRestrictedImports = {
   paths: [
     {
@@ -118,22 +117,6 @@ const v3WriteRestrictedImports = {
     }
   ]
 }
-
-const v3MigrationLegacyFiles = [
-  'src/composables/useContractFunctions.ts',
-  'src/components/forms/DepositSafeForm.vue',
-  'src/components/sections/AdministrationView/BoDElectionDetailsSection.vue',
-  'src/components/sections/AdministrationView/PublishResult.vue',
-  'src/components/sections/ContractManagementView/MainContractActions.vue',
-  'src/components/sections/ContractManagementView/TeamContractAdmins.vue',
-  'src/components/sections/ContractManagementView/TeamContractsDetail.vue',
-  'src/components/sections/ExpenseAccountView/ExpenseAccountTable.vue',
-  'src/components/sections/ExpenseAccountView/TransferAction.vue',
-  'src/components/sections/ProposalsView/ProposalDetail.vue',
-  'src/components/sections/ProposalsView/forms/CreateProposalForm.vue',
-  'src/components/sections/SherTokenView/InvestorActions/DistributeMintAction.vue',
-  'src/components/sections/SherTokenView/forms/MintForm.vue'
-]
 
 export default [
   {
@@ -229,7 +212,7 @@ export default [
       '**/*.spec.ts',
       '**/*.spec.tsx',
       'tests/**',
-      ...v3MigrationLegacyFiles
+      'src/composables/useContractFunctions.ts'
     ],
     rules: {
       'no-restricted-imports': ['error', v3WriteRestrictedImports]


### PR DESCRIPTION
# Description

## Intial Issue Description

Closes #1632 (final reliquat — see also #1798).

The V3 contract-writes migration is complete: every feature-code file has been migrated off the banned `@wagmi/vue` / `@wagmi/core` write hooks. But the `no-restricted-imports` guard in `app/eslint.config.js` still carried a 13-file `v3MigrationLegacyFiles` allow-list. The guard's own comment says to remove each file as it is migrated and drop the block when empty — that cleanup was missed.

While the list stayed over-broad, those 12 already-migrated files were excluded from the rule and could silently regress to V2-shaped patterns without CI catching it.

## PR Summary Or Solution description

Verified every file in `v3MigrationLegacyFiles`:

- 12 component/form files no longer import any banned hook → removed from the allow-list, now covered by the guard again.
- `useContractFunctions.ts` still imports `waitForTransactionReceipt` from `@wagmi/core`, but only on the contract **deployment** path (`deployContract` + receipt-wait) — not a contract write, and out of scope for the V3 writes migration per #1798.

Changes:

- Removed the `v3MigrationLegacyFiles` constant and the legacy-list comment paragraph.
- Replaced the `...v3MigrationLegacyFiles` spread in the rule's `ignores` with a single named exception, `src/composables/useContractFunctions.ts`.
- Documented that file in the "Allowed importers" comment with the deployment-path rationale.

Verification: `npm run lint` and `npm run format-check` pass with zero errors on the config and all 13 files.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (n/a — ESLint config only)
- [ ] Docs have been added / updated (n/a)