### PR TITLE
style: 💄 define light theme tokens and use semantic surface colors

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -14,7 +14,7 @@
               }"
             >
               <template #header>
-                <UDashboardNavbar :title="pageTitle" :ui="{ right: 'gap-3' }" class="bg-white">
+                <UDashboardNavbar :title="pageTitle" :ui="{ right: 'gap-3' }" class="bg-default">
                   <template #leading>
                     <UDashboardSidebarCollapse
                       icon="heroicons:arrow-left-start-on-rectangle"

--- a/app/src/assets/main.css
+++ b/app/src/assets/main.css
@@ -4,6 +4,50 @@
 
 @import '@nuxt/ui';
 
+@theme default {
+  /* name: 'light'; */
+  /* default: true; set as default */
+  /* prefersdark: false; set as default dark mode (prefers-color-scheme:dark) */
+  /* color-scheme: light; color of browser-provided UI */
+
+  --color-base-100: #ffffff;
+  --color-base-200: #f3fcf9;
+  --color-base-300: #e6f7f0;
+  --color-base-content: #333333;
+  --color-primary: #00bf7a;
+  --color-primary-content: #000;
+  --color-secondary: #3366ff;
+  /* --color-secondary-content: #000; */
+  --color-accent: #00b8d9;
+  /* --color-accent-content: #ffffff; */
+  --color-neutral: #0f3d2e;
+  /* --color-neutral-content: #ffffff; */
+  --color-info: #00b8d9;
+  /* --color-info-content: #ffffff; */
+  --color-success: #36b37e;
+  --color-success-content: #000;
+  --color-warning: #ffab00;
+  /* --color-warning-content: #000; */
+  --color-error: #ff5630;
+  /* --color-error-content: #ffffff; */
+
+  /* border radius */
+  --radius-selector: 1rem;
+  --radius-field: 0.5rem;
+  --radius-box: 1rem;
+
+  /* base sizes */
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+
+  /* border size */
+  --border: 1px;
+
+  /* effects */
+  --depth: 1;
+  --noise: 0;
+}
+
 /*
   The default border color has changed to `currentcolor` in Tailwind CSS v4,
   so we've added these compatibility styles to make sure everything still

--- a/app/src/components/ui/SidebarLayout.vue
+++ b/app/src/components/ui/SidebarLayout.vue
@@ -2,7 +2,7 @@
   <UDashboardSidebar
     collapsible
     resizable
-    class="bg-white"
+    class="bg-default"
     :ui="{ root: 'min-w-24', footer: 'border-t border-default' }"
   >
     <template #header="{ collapsed }">


### PR DESCRIPTION
## Summary
- Add a `@theme default` block in `main.css` defining brand colors, radii, and base sizes.
- Replace hardcoded `bg-white` with semantic `bg-default` on the dashboard navbar and sidebar.

Closes #1958

## Test plan
- [ ] Navbar and sidebar render with the correct surface color in light mode.
- [ ] Brand primary/secondary/accent colors apply consistently across components.