### PR TITLE
docs: 📝 organize Swagger endpoints and improve API documentation

### DIFF
--- a/backend/src/config/serverConfig.ts
+++ b/backend/src/config/serverConfig.ts
@@ -41,14 +41,46 @@ const options = {
   definition: {
     openapi: '3.0.0',
     info: {
-      title: 'API Documentation',
+      title: 'CNC Portal API',
       version: '1.0.0',
+      description:
+        'REST API for the CNC Portal. Most endpoints require a JWT obtained from `POST /auth/siwe`; ' +
+        'use the **Authorize** button to set the bearer token before trying protected routes.',
     },
     servers: [
       {
         url: '/api',
         description: 'API base path',
       },
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description: 'JWT issued by `POST /auth/siwe`.',
+        },
+      },
+    },
+    tags: [
+      { name: 'Auth', description: 'SIWE authentication and JWT validation' },
+      { name: 'Users', description: 'User accounts and profiles' },
+      { name: 'Teams', description: 'Team creation, membership and settings' },
+      { name: 'Contracts', description: 'Team smart-contract registration and sync' },
+      { name: 'Claims', description: 'Worked-minutes claims' },
+      { name: 'Weekly Claims', description: 'Weekly aggregated claims and on-chain sync' },
+      { name: 'Wages', description: 'Team member wages' },
+      { name: 'Expenses', description: 'Team expenses' },
+      { name: 'Board Actions', description: 'Board of Directors actions' },
+      { name: 'Elections', description: 'Board elections and notifications' },
+      { name: 'Notifications', description: 'User notifications' },
+      { name: 'Files', description: 'File download access' },
+      { name: 'Upload', description: 'File and asset uploads' },
+      { name: 'Statistics', description: 'Platform statistics (admin only)' },
+      { name: 'Features', description: 'Feature flags (admin only)' },
+      { name: 'Health', description: 'Service health checks' },
+      { name: 'Development', description: 'Development-only helpers' },
     ],
   },
   apis: ['./src/routes/*.ts'], // Point to route files containing JSDoc comments
@@ -175,7 +207,6 @@ class Server {
       console.log('🔧 Dev routes enabled for development environment');
     }
 
-    this.app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
     this.app.use(this.paths.elections, authorizeUser, electionsRoute);
     this.app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
     // The error handler must be registered before any other error middleware and after all controllers

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -10,6 +10,7 @@ const authRoutes = express.Router();
  * /auth/siwe:
  *   post:
  *     summary: Authenticate using Sign-In with Ethereum (SIWE)
+ *     tags: [Auth]
  *     requestBody:
  *       required: true
  *       content:
@@ -70,6 +71,7 @@ authRoutes.post('/siwe', validateBody(siweAuthRequestSchema), authenticateSiwe);
  * /auth/token:
  *   get:
  *     summary: Validate JWT token
+ *     tags: [Auth]
  *     security:
  *       - bearerAuth: []
  *     responses:

--- a/backend/src/routes/claimRoute.ts
+++ b/backend/src/routes/claimRoute.ts
@@ -73,6 +73,9 @@ const claimRoutes = express.Router();
  * /claim:
  *  post:
  *   summary: Add a claim for minutes worked
+ *   tags: [Claims]
+ *   security:
+ *     - bearerAuth: []
  *   requestBody:
  *     required: true
  *     content:
@@ -116,6 +119,9 @@ claimRoutes.post('/', validateBody(addClaimBodySchema), addClaim);
  * /claim:
  *  get:
  *   summary: Retrieve claims for a specific team
+ *   tags: [Claims]
+ *   security:
+ *     - bearerAuth: []
  *   parameters:
  *     - in: query
  *       name: teamId
@@ -168,6 +174,9 @@ claimRoutes.get(
  * /claim/{claimId}:
  *  put:
  *   summary: Update claim details (minutes worked, memo, or date)
+ *   tags: [Claims]
+ *   security:
+ *     - bearerAuth: []
  *   description: Allows the claim owner to edit their own pending claim details.
  *   parameters:
  *     - in: path
@@ -240,6 +249,9 @@ claimRoutes.put(
  * /claim/{claimId}:
  *  delete:
  *   summary: Delete a pending claim
+ *   tags: [Claims]
+ *   security:
+ *     - bearerAuth: []
  *   description: Allows the claim owner to delete their own pending claim.
  *   parameters:
  *     - in: path

--- a/backend/src/routes/contractRoutes.ts
+++ b/backend/src/routes/contractRoutes.ts
@@ -62,6 +62,9 @@ const contractRoutes = express.Router();
  * /contract:
  *  post:
  *   summary: Add a new contract to a team
+ *   tags: [Contracts]
+ *   security:
+ *     - bearerAuth: []
  *   requestBody:
  *     required: true
  *     content:
@@ -117,6 +120,9 @@ contractRoutes.post(
  * /contract:
  *  get:
  *   summary: Retrieve contracts for a specific team
+ *   tags: [Contracts]
+ *   security:
+ *     - bearerAuth: []
  *   parameters:
  *     - in: query
  *       name: teamId
@@ -160,6 +166,9 @@ contractRoutes.get('/', validateQuery(getContractsQuerySchema), getContracts);
  * /contract/sync:
  *  put:
  *   summary: Sync contracts for a specific team
+ *   tags: [Contracts]
+ *   security:
+ *     - bearerAuth: []
  *   requestBody:
  *     required: true
  *     content:
@@ -213,6 +222,9 @@ contractRoutes.put(
  * /contract/officer:
  *  post:
  *   summary: Register a freshly deployed Officer contract on a team
+ *   tags: [Contracts]
+ *   security:
+ *     - bearerAuth: []
  *   description: Inserts a new TeamOfficer row at the head of the team's
  *     Officer linked list (linking it to the previous head if any) and syncs
  *     the contracts the new Officer governs in a single call. Intended to be
@@ -271,6 +283,9 @@ contractRoutes.post('/officer', validateBody(createOfficerBodySchema), createOff
  * /contract/officers:
  *  get:
  *   summary: List Officer contract history for a team
+ *   tags: [Contracts]
+ *   security:
+ *     - bearerAuth: []
  *   parameters:
  *     - in: query
  *       name: teamId

--- a/backend/src/routes/expenseRoute.ts
+++ b/backend/src/routes/expenseRoute.ts
@@ -18,6 +18,9 @@ const expenseRoutes = express.Router();
  * /expense:
  *  post:
  *   summary: Add a new expense
+ *   tags: [Expenses]
+ *   security:
+ *     - bearerAuth: []
  *   requestBody:
  *     required: true
  *     content:
@@ -49,6 +52,9 @@ expenseRoutes.post('/', validateBody(addExpenseBodySchema), addExpense);
  * /expense:
  *  get:
  *   summary: Get expenses for a team
+ *   tags: [Expenses]
+ *   security:
+ *     - bearerAuth: []
  *   parameters:
  *     - in: query
  *       name: teamId
@@ -78,6 +84,9 @@ expenseRoutes.get(
  * /expense/{id}:
  *  patch:
  *   summary: Update an expense
+ *   tags: [Expenses]
+ *   security:
+ *     - bearerAuth: []
  *   parameters:
  *     - in: path
  *       name: id

--- a/backend/src/routes/teamRoutes.ts
+++ b/backend/src/routes/teamRoutes.ts
@@ -102,6 +102,9 @@ const teamRoutes = express.Router();
  * /teams:
  *  post:
  *   summary: Create a new team
+ *   tags: [Teams]
+ *   security:
+ *     - bearerAuth: []
  *   description: Creates a new team with the specified members. The caller is automatically added as a member.
  *   requestBody:
  *     required: true
@@ -162,6 +165,9 @@ teamRoutes.post('/', validateBody(addTeamBodySchema), addTeam);
  * /teams:
  *  get:
  *   summary: Get all teams or teams for a specific user
+ *   tags: [Teams]
+ *   security:
+ *     - bearerAuth: []
  *   description: Retrieves all teams, or teams filtered by userAddress if provided. Caller can only request their own teams.
  *   parameters:
  *     - in: query
@@ -267,6 +273,9 @@ teamRoutes.get(
  * /teams/{id}/member:
  *  post:
  *   summary: Add members to a team
+ *   tags: [Teams]
+ *   security:
+ *     - bearerAuth: []
  *   description: Adds one or more members to a team. Only the team owner can add members.
  *   parameters:
  *     - in: path
@@ -336,6 +345,9 @@ teamRoutes.post(
  * /teams/{id}/member/{memberAddress}:
  *  delete:
  *   summary: Remove a member from a team
+ *   tags: [Teams]
+ *   security:
+ *     - bearerAuth: []
  *   description: Removes a specific member from a team. Only the team owner can remove members. The owner cannot be removed.
  *   parameters:
  *     - in: path
@@ -391,6 +403,9 @@ teamRoutes.delete(
  * /teams/{id}:
  *  get:
  *   summary: Get a specific team by ID
+ *   tags: [Teams]
+ *   security:
+ *     - bearerAuth: []
  *   description: Retrieves team details including members and contracts. Caller must be a team member.
  *   parameters:
  *     - in: path
@@ -438,6 +453,9 @@ teamRoutes.get('/:id', validateParams(teamIdParamsSchema), getTeam);
  * /teams/{id}:
  *  put:
  *   summary: Update a team
+ *   tags: [Teams]
+ *   security:
+ *     - bearerAuth: []
  *   description: Updates team metadata (name, description). Only the team owner can update. The current Officer is managed via POST /contract/officer.
  *   parameters:
  *     - in: path
@@ -503,6 +521,9 @@ teamRoutes.put(
  * /teams/{id}:
  *  delete:
  *   summary: Delete a team
+ *   tags: [Teams]
+ *   security:
+ *     - bearerAuth: []
  *   description: Deletes a team and all related records (cascading). Only the team owner can delete.
  *   parameters:
  *     - in: path

--- a/backend/src/routes/wageRoute.ts
+++ b/backend/src/routes/wageRoute.ts
@@ -79,6 +79,9 @@ const wageRoutes = express.Router();
  * /wage/setWage:
  *  put:
  *   summary: Set wage for a user
+ *   tags: [Wages]
+ *   security:
+ *     - bearerAuth: []
  *   description: Sets or updates the wage configuration for a team member including rates and maximum hours.
  *   requestBody:
  *     required: true
@@ -198,6 +201,9 @@ wageRoutes.put(
  * /wage:
  *  get:
  *   summary: Get Team members wages
+ *   tags: [Wages]
+ *   security:
+ *     - bearerAuth: []
  *   description: Retrieves all wage records for members of a specific team.
  *   parameters:
  *     - in: query
@@ -265,6 +271,9 @@ wageRoutes.get(
  * /wage/{wageId}:
  *  put:
  *   summary: Toggle wage status (disable or enable)
+ *   tags: [Wages]
+ *   security:
+ *     - bearerAuth: []
  *   description: Disables or enables a member wage. A disabled wage prevents the member from submitting claims.
  *   parameters:
  *     - in: path

--- a/backend/src/routes/weeklyClaimRoute.ts
+++ b/backend/src/routes/weeklyClaimRoute.ts
@@ -92,6 +92,9 @@ const weeklyClaimRoutes = express.Router();
  * /weekly-claim:
  *  get:
  *   summary: Get weekly claims for a team
+ *   tags: [Weekly Claims]
+ *   security:
+ *     - bearerAuth: []
  *   description: Retrieves weekly claims for a specific team with optional filtering by status and member address.
  *   parameters:
  *     - in: query
@@ -165,6 +168,9 @@ weeklyClaimRoutes.get(
  * /weekly-claim/sync:
  *  post:
  *   summary: Sync weekly claims with smart contract state
+ *   tags: [Weekly Claims]
+ *   security:
+ *     - bearerAuth: []
  *   description: Synchronizes weekly claim statuses against the on-chain CashRemunerationEIP712 contract to detect paid or disabled claims.
  *   parameters:
  *     - in: query
@@ -230,6 +236,9 @@ weeklyClaimRoutes.post(
  * /weekly-claim/{id}:
  *  put:
  *   summary: Update a weekly claim
+ *   tags: [Weekly Claims]
+ *   security:
+ *     - bearerAuth: []
  *   description: Performs an action on a weekly claim (sign, withdraw, enable, or disable). Requires appropriate permissions.
  *   parameters:
  *     - in: path


### PR DESCRIPTION
## Summary

Reorganizes the Swagger documentation served at `/docs` so business endpoints no longer land in the catch-all `default` group, and makes the doc usable for developers.

Closes #1961.

## Changes

- **Tagged ~27 previously untagged endpoints** — `Auth`, `Teams` (7/8 were untagged), `Contracts`, `Claims`, `Wages`, `Weekly Claims`, `Expenses`. The `default` group is now empty.
- **`bearerAuth` (JWT) security scheme** — the Swagger UI **Authorize** button now works; protected operations declare `security: [bearerAuth]` so the lock icon shows.
- **Global `tags` array** in the OpenAPI definition with descriptions and a logical order (Auth → Users → Teams → … → Health → Development).
- **Enriched `info` block** — real title (`CNC Portal API`) and description instead of the generic `API Documentation`.
- **Removed the duplicate** `app.use('/docs', ...)` registration in `serverConfig.ts`.

## Verification

- `npx tsc --noEmit` — passes
- `npx eslint` on changed files — passes
- `swagger-jsdoc` smoke test — 48 paths across 17 tags, **0 in `default`**

## Out of scope

Inline `$ref` schema duplication across route files (each redefines `ErrorResponse`, etc.) — worth a follow-up to centralize in `components/schemas`.
