### PR TITLE
refactor: ♻️ address review feedback on manual minting toggle

### DIFF
--- a/app/src/components/sections/SherTokenView/forms/MintForm.vue
+++ b/app/src/components/sections/SherTokenView/forms/MintForm.vue
@@ -1,8 +1,10 @@
 <template>
   <UForm
+    ref="form"
     :schema="schema"
     :state="state"
     :validate-on="['blur', 'change', 'input']"
+    :validate-on-input-delay="0"
     @submit="onSubmit"
   >
     <div class="flex flex-col gap-6">
@@ -22,7 +24,7 @@
 
       <MintStakeSection
         :recipientAddress="state.address"
-        :stakeValidationMessage="stakeValidationMessage"
+        :hasValidationError="!isStakeValid"
         @update:issuedAmount="(v) => (issuedAmount = v)"
         @update:stakePayload="onStakePayloadUpdate"
       />
@@ -61,7 +63,7 @@
 <script setup lang="ts">
 import { z } from 'zod'
 import { isAddress, parseUnits } from 'viem'
-import { reactive, ref, computed } from 'vue'
+import { reactive, ref, computed, watch } from 'vue'
 import SelectMemberContractsInput from '@/components/utils/SelectMemberContractsInput.vue'
 import MintStakeSection from './MintStakeSection.vue'
 import { useIndividualMint } from '@/composables/investor/writes'
@@ -102,52 +104,70 @@ if (props.memberInput) {
 const queryClient = useQueryClient()
 const toast = useToast()
 
-const schema = computed(() =>
-  z.object({
-    address: z.string().refine((v) => isAddress(v), { message: 'Invalid address' }),
-    stake: z.object({
-      amount: z
-        .number()
-        .positive('Amount must be greater than 0')
-        .refine((v) => v !== 0, { message: 'Amount cannot be zero' }),
-      percentage:
-        state.stake.stakeMode === 'add'
-          ? z
-              .number()
-              .positive('Add % must be greater than 0')
-              .max(
-                stakeContext.addMax,
-                `Add % must be less than ${formatAmountWithPrecision(stakeContext.addMax, 0, 2)}%`
-              )
-          : z
-              .number()
-              .gt(
-                stakeContext.endingMin,
-                `Ending % must be greater than ${formatAmountWithPrecision(stakeContext.endingMin, 0, 2)}%`
-              )
-              .lt(100, 'Ending % must stay below 100%'),
-      stakeMode: z.enum(['add', 'ending'])
-    })
+// Every stake rule lives here and reports on `amount`, so `UForm`/`UFormField` render the
+// message natively under the Ownership stake field — no manual message wiring.
+const stakeSchema = z
+  .object({
+    amount: z.number(),
+    percentage: z.number(),
+    stakeMode: z.enum(['add', 'ending'])
   })
-)
+  .superRefine((stake, ctx) => {
+    const fail = (message: string) =>
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['amount'], message })
+
+    // Untouched form: stay silent — the empty case is guarded by the submit button.
+    if (stake.amount === 0 && stake.percentage === 0) return
+
+    if (stake.stakeMode === 'ending' && stakeContext.totalSupply <= 0) {
+      fail('Ending % is unavailable while supply is 0. Switch to Add mode.')
+      return
+    }
+
+    if (!(stake.amount > 0)) fail('Amount must be greater than 0')
+
+    if (stake.stakeMode === 'add') {
+      if (!(stake.percentage > 0)) fail('Add % must be greater than 0')
+      else if (stake.percentage > stakeContext.addMax)
+        fail(`Add % must be less than ${formatAmountWithPrecision(stakeContext.addMax, 0, 2)}%`)
+    } else {
+      if (!(stake.percentage > stakeContext.endingMin))
+        fail(
+          `Ending % must be greater than ${formatAmountWithPrecision(stakeContext.endingMin, 0, 2)}%`
+        )
+      else if (stake.percentage >= 100) fail('Ending % must stay below 100%')
+    }
+  })
+
+const schema = z.object({
+  address: z.string().refine((v) => isAddress(v), { message: 'Invalid address' }),
+  stake: stakeSchema
+})
 
 const { mutate: mint, isPending: isMintPending } = useIndividualMint()
 
-const stakeValidationMessage = computed(() => {
-  if (state.stake.amount === 0 && state.stake.percentage === 0) return null
-
-  if (state.stake.stakeMode === 'ending' && stakeContext.totalSupply <= 0) {
-    return 'Ending % is unavailable while supply is 0. Switch to Add mode.'
-  }
-
-  const result = schema.value.safeParse(state)
-  if (result.success) return null
-  const stakeIssue = result.error.issues.find((issue) => issue.path[0] === 'stake')
-  return stakeIssue?.message ?? null
-})
+const isStakeValid = computed(() => stakeSchema.safeParse(state.stake).success)
 
 const isSubmitDisabled = computed(
-  () => isMintPending.value || !!stakeValidationMessage.value || (issuedAmount.value ?? 0) <= 0
+  () => isMintPending.value || !isStakeValid.value || (issuedAmount.value ?? 0) <= 0
+)
+
+// The stake fields live in MintStakeSection and reach this form through an emitted
+// payload, so they land after the input event UForm validates on. Re-validate whenever
+// that payload settles to keep the natively-rendered message in sync.
+const form = ref<{ validate: (opts?: Record<string, unknown>) => Promise<unknown> } | null>(null)
+watch(
+  () => [
+    state.stake.amount,
+    state.stake.percentage,
+    state.stake.stakeMode,
+    stakeContext.addMax,
+    stakeContext.endingMin,
+    stakeContext.totalSupply
+  ],
+  () => {
+    form.value?.validate({ name: 'stake.amount', silent: true }).catch(() => {})
+  }
 )
 
 const onStakePayloadUpdate = (payload: StakePayload) => {

--- a/app/src/components/sections/SherTokenView/forms/MintRecapCard.vue
+++ b/app/src/components/sections/SherTokenView/forms/MintRecapCard.vue
@@ -26,18 +26,23 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { formatUnits } from 'viem'
+import { formatUnits, parseUnits } from 'viem'
 import {
   useInvestorSymbol,
   useInvestorTotalSupply,
   useInvestorBalanceOf
 } from '@/composables/investor/reads'
-import { getMintRecap, TOKEN_DECIMALS } from '@/utils/investorMintAllocation'
+import {
+  getMintRecap,
+  formatStakePercentageFromSupply,
+  TOKEN_DECIMALS
+} from '@/utils/investorMintAllocation'
 import { formatAmountWithPrecision } from '@/utils/currencyUtil'
 
 const props = defineProps<{
   recipientAddress: string
   issuedAmount: number | null
+  /** Target stake the user asked for — shown only when the issuance is mathematically unsolvable. */
   requestedStakePercentage?: number
   hasValidationError?: boolean
 }>()
@@ -46,39 +51,59 @@ const { data: tokenSymbol } = useInvestorSymbol()
 const { data: totalSupplyRaw } = useInvestorTotalSupply()
 const { data: recipientBalanceRaw } = useInvestorBalanceOf(computed(() => props.recipientAddress))
 
-const totalSupplyNumber = computed(() => {
-  if (typeof totalSupplyRaw.value !== 'bigint') return 0
-  return Number(formatUnits(totalSupplyRaw.value, TOKEN_DECIMALS))
-})
+const supplyBeforeRaw = computed<bigint>(() =>
+  typeof totalSupplyRaw.value === 'bigint' ? totalSupplyRaw.value : 0n
+)
+const balanceBeforeRaw = computed<bigint>(() =>
+  typeof recipientBalanceRaw.value === 'bigint' ? recipientBalanceRaw.value : 0n
+)
 
-const recipientBalanceNumber = computed(() => {
-  if (typeof recipientBalanceRaw.value !== 'bigint') return 0
-  return Number(formatUnits(recipientBalanceRaw.value, TOKEN_DECIMALS))
+// Issued delta in base units. parseUnits keeps full token precision and supports the
+// negative deltas produced by an under-target ending amount.
+const issuedRaw = computed<bigint>(() => {
+  const issued = props.issuedAmount
+  if (issued == null || !Number.isFinite(issued) || issued === 0) return 0n
+  return parseUnits(issued.toFixed(TOKEN_DECIMALS), TOKEN_DECIMALS)
 })
 
 const recap = computed(() =>
   getMintRecap(
     props.issuedAmount ?? 0,
     tokenSymbol.value as string,
-    totalSupplyNumber.value,
-    recipientBalanceNumber.value
+    Number(formatUnits(supplyBeforeRaw.value, TOKEN_DECIMALS)),
+    Number(formatUnits(balanceBeforeRaw.value, TOKEN_DECIMALS))
   )
 )
 
-const recapStakeAfterDisplay = computed(() => {
+// Stake percentages use the same bigint-truncation formatter as ShareholderList, so the
+// recap never promises a stake the holders table will then contradict.
+const stakeBefore = computed(() =>
+  formatStakePercentageFromSupply(balanceBeforeRaw.value, supplyBeforeRaw.value, 2, true)
+)
+
+const stakeAfter = computed(() => {
+  const supplyAfter = supplyBeforeRaw.value + issuedRaw.value
+  const balanceAfter = balanceBeforeRaw.value + issuedRaw.value
+  if (supplyAfter > 0n && balanceAfter >= 0n) {
+    return formatStakePercentageFromSupply(balanceAfter, supplyAfter, 2, true)
+  }
+  // Unsolvable target (e.g. requested ending stake ≥ 100%): echo what the user asked for.
   if (
     typeof props.requestedStakePercentage === 'number' &&
-    Number.isFinite(props.requestedStakePercentage) &&
-    props.requestedStakePercentage > 0
+    Number.isFinite(props.requestedStakePercentage)
   ) {
-    return props.requestedStakePercentage
+    return formatAmountWithPrecision(props.requestedStakePercentage, 2, 2)
   }
-  return recap.value.recipientStakeAfter
+  return stakeBefore.value
 })
+
+const stakeIssued = computed(() =>
+  formatAmountWithPrecision(Number(stakeAfter.value) - Number(stakeBefore.value), 2, 2)
+)
 
 const recapStakeLine = computed(
   () =>
-    `Recipient stake → ${formatAmountWithPrecision(recapStakeAfterDisplay.value, 0, 2)}% (was ${formatAmountWithPrecision(recap.value.recipientStakeBefore, 0, 2)}%; issuing ${formatAmountWithPrecision(recapStakeAfterDisplay.value - recap.value.recipientStakeBefore, 0, 2)}%)`
+    `Recipient stake → ${stakeAfter.value}% (was ${stakeBefore.value}%; issuing ${stakeIssued.value}%)`
 )
 
 const recapTokenStakeLine = computed(

--- a/app/src/components/sections/SherTokenView/forms/MintStakeSection.vue
+++ b/app/src/components/sections/SherTokenView/forms/MintStakeSection.vue
@@ -24,11 +24,7 @@
         />
       </div>
     </div>
-    <UFormField
-      name="stake.amount"
-      label="Ownership stake"
-      :error="props.stakeValidationMessage ?? false"
-    >
+    <UFormField name="stake.amount" label="Ownership stake">
       <TwinAmountInputs
         :percentage="state.percentage"
         :amount="state.amount"
@@ -48,7 +44,7 @@
       :requestedStakePercentage="
         state.stakeMode === 'ending' ? state.percentage : currentStakePercentage + state.percentage
       "
-      :hasValidationError="!!props.stakeValidationMessage"
+      :hasValidationError="!!props.hasValidationError"
     />
   </div>
 </template>
@@ -70,7 +66,8 @@ import { type Address } from 'viem'
 
 const props = defineProps<{
   recipientAddress: Address
-  stakeValidationMessage?: string | null
+  /** Whether the parent form's schema currently rejects the stake — drives the recap's error state. */
+  hasValidationError?: boolean
 }>()
 
 const emit = defineEmits<{

--- a/app/src/components/sections/SherTokenView/forms/TwinAmountInputs.vue
+++ b/app/src/components/sections/SherTokenView/forms/TwinAmountInputs.vue
@@ -17,6 +17,7 @@
 
     <div class="flex items-center gap-2 md:gap-3">
       <UInput
+        ref="percentageInput"
         class="flex-1"
         data-test="percentage-input"
         :color="inputColor"
@@ -33,6 +34,7 @@
       <UIcon name="i-lucide-equal" class="size-5 shrink-0 text-gray-400" />
 
       <UInput
+        ref="amountInput"
         class="flex-1"
         data-test="amount-input"
         :color="inputColor"
@@ -49,7 +51,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, nextTick, useTemplateRef } from 'vue'
 import { useInvestorSymbol, useInvestorTotalSupply } from '@/composables/investor/reads'
 import { formatAmountWithPrecision } from '@/utils/currencyUtil'
 
@@ -72,13 +74,37 @@ const { data: totalSupplyRaw } = useInvestorTotalSupply()
 const totalSupplyBigInt = computed<bigint>(() => (totalSupplyRaw.value as bigint | undefined) ?? 0n)
 const hasTotalSupply = computed(() => totalSupplyRaw.value !== undefined)
 
+const percentageInput = useTemplateRef<{ inputRef: HTMLInputElement | null }>('percentageInput')
+const amountInput = useTemplateRef<{ inputRef: HTMLInputElement | null }>('amountInput')
+
 const parseInput = (value: string | number) => {
   const parsed = Number(String(value).replace(/,/g, '').trim())
   if (!Number.isFinite(parsed)) return 0
   return parsed < 0 ? 0 : parsed
 }
 
-const handlePercentageUpdate = (value: string | number) =>
-  emit('update:percentage', parseInput(value))
-const handleAmountUpdate = (value: string | number) => emit('update:amount', parseInput(value))
+// When a typed value is clamped (e.g. a negative) the bound model may not change, so Vue
+// won't repaint the field. Reflect the clamped value into the input element directly.
+const reflectClamp = (
+  input: { inputRef: HTMLInputElement | null } | null,
+  raw: string | number,
+  parsed: number
+) => {
+  if (String(raw) === String(parsed)) return
+  nextTick(() => {
+    if (input?.inputRef) input.inputRef.value = String(parsed)
+  })
+}
+
+const handlePercentageUpdate = (value: string | number) => {
+  const parsed = parseInput(value)
+  emit('update:percentage', parsed)
+  reflectClamp(percentageInput.value, value, parsed)
+}
+
+const handleAmountUpdate = (value: string | number) => {
+  const parsed = parseInput(value)
+  emit('update:amount', parsed)
+  reflectClamp(amountInput.value, value, parsed)
+}
 </script>

--- a/app/src/components/sections/SherTokenView/forms/__tests__/MintForm.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/MintForm.spec.ts
@@ -34,6 +34,14 @@ const setSupplyAndBalance = (supply: bigint, balance: bigint) => {
   recipientBalanceRef.value = balance
 }
 
+// Stake fields reach the form via an emitted payload, then UForm re-validates — let both
+// the reactive payload chain and the (debounced) validation settle before asserting.
+const settle = async () => {
+  await flushPromises()
+  await new Promise((resolve) => setTimeout(resolve))
+  await flushPromises()
+}
+
 const mountForm = (props: Record<string, unknown> = {}) =>
   mount(MintForm, {
     props,
@@ -156,6 +164,7 @@ describe('MintForm.vue', () => {
     const wrapper = mountForm({ memberInput: { name: 'Bob', address: VALID_ADDRESS } })
 
     await wrapper.find('[data-test="percentage-input"]').setValue('20')
+    await settle()
 
     expect(wrapper.find('[data-test="ending-stake-validation-message"]').text()).toContain(
       'Ending % must be greater than 23%'
@@ -167,6 +176,7 @@ describe('MintForm.vue', () => {
     const wrapper = mountForm({ memberInput: { name: 'Bob', address: VALID_ADDRESS } })
 
     await wrapper.find('[data-test="amount-input"]').setValue('10')
+    await settle()
 
     expect(wrapper.find('[data-test="ending-stake-validation-message"]').text()).toContain(
       'Ending % must be greater than 12%'
@@ -195,13 +205,13 @@ describe('MintForm.vue', () => {
 
     await wrapper.find('[data-test="add-mode-button"]').trigger('click')
     await wrapper.find('[data-test="percentage-input"]').setValue('46')
-    await flushPromises()
+    await settle()
 
     expect(wrapper.find('[data-test="ending-stake-validation-message"]').text()).toContain(
       'Amount must be greater than 0'
     )
     expect(wrapper.find('[data-test="recap-stake-line"]').text()).toContain(
-      'Recipient stake → 102%'
+      'Recipient stake → 102.00%'
     )
     expect(wrapper.find('[data-test="recap-token-stake-line"]').text()).not.toContain(
       'issuing 0 SHER'
@@ -213,6 +223,7 @@ describe('MintForm.vue', () => {
     const wrapper = mountForm({ memberInput: { name: 'Bob', address: VALID_ADDRESS } })
 
     await wrapper.find('[data-test="percentage-input"]').setValue('20')
+    await settle()
 
     expect(wrapper.find('[data-test="submit-button"]').attributes('disabled')).toBeDefined()
   })
@@ -222,10 +233,11 @@ describe('MintForm.vue', () => {
     const wrapper = mountForm({ memberInput: { name: 'Bob', address: VALID_ADDRESS } })
 
     await wrapper.find('[data-test="percentage-input"]').setValue('20')
+    await settle()
     expect(wrapper.find('[data-test="ending-stake-validation-message"]').exists()).toBe(true)
 
     await wrapper.find('[data-test="add-mode-button"]').trigger('click')
-    await flushPromises()
+    await settle()
     expect(wrapper.find('[data-test="ending-stake-validation-message"]').exists()).toBe(false)
   })
 
@@ -235,11 +247,11 @@ describe('MintForm.vue', () => {
 
     await wrapper.find('[data-test="percentage-input"]').setValue('20')
     await wrapper.find('[data-test="add-mode-button"]').trigger('click')
-    await flushPromises()
+    await settle()
     expect(wrapper.find('[data-test="ending-stake-validation-message"]').exists()).toBe(false)
 
     await wrapper.find('[data-test="ending-mode-button"]').trigger('click')
-    await flushPromises()
+    await settle()
     expect(wrapper.find('[data-test="ending-stake-validation-message"]').text()).toContain(
       'Ending % must be greater than 23%'
     )
@@ -263,6 +275,7 @@ describe('MintForm.vue', () => {
     await wrapper.find('[data-test="emit-member-input"]').trigger('click')
     await wrapper.find('[data-test="add-mode-button"]').trigger('click')
     await wrapper.find('[data-test="amount-input"]').setValue('10')
+    await settle()
     await wrapper.find('form').trigger('submit')
     await flushPromises()
     expect(mintMutation.mutate).toHaveBeenCalled()
@@ -272,6 +285,7 @@ describe('MintForm.vue', () => {
     setSupplyAndBalance(100_000_000n, 20_000_000n) // 100 tokens, recipient 20
     const wrapper = mountForm({ memberInput: { name: 'Bob', address: VALID_ADDRESS } })
     await wrapper.find('[data-test="amount-input"]').setValue('30') // ending balance target
+    await settle()
     await wrapper.find('form').trigger('submit')
     await flushPromises()
     expect(mintMutation.mutate).toHaveBeenCalled()
@@ -286,6 +300,7 @@ describe('MintForm.vue', () => {
     await wrapper.find('[data-test="emit-member-input"]').trigger('click')
     await wrapper.find('[data-test="add-mode-button"]').trigger('click')
     await wrapper.find('[data-test="amount-input"]').setValue('10')
+    await settle()
 
     mintMutation.mutate.mockImplementationOnce((_p: unknown, opts?: MintOptions) => {
       opts?.onError?.({ shortMessage: 'Insufficient funds' })
@@ -314,6 +329,7 @@ describe('MintForm.vue', () => {
     await wrapper.find('[data-test="emit-member-input"]').trigger('click')
     await wrapper.find('[data-test="add-mode-button"]').trigger('click')
     await wrapper.find('[data-test="amount-input"]').setValue('10')
+    await settle()
     await wrapper.find('form').trigger('submit')
     await flushPromises()
 

--- a/app/src/components/sections/SherTokenView/forms/__tests__/MintRecapCard.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/MintRecapCard.spec.ts
@@ -73,15 +73,16 @@ describe('MintRecapCard.vue', () => {
     )
   })
 
-  it('does not round recap stake up to 100% when it is only near 100%', () => {
+  it('truncates a near-100% recap stake instead of rounding it up', () => {
     totalSupplyRef.value = 50_000_000n
     recipientBalanceRef.value = 28_000_000n
     symbolRef.value = 'shr'
 
     const wrapper = mountRecap({ issuedAmount: 219_999_949.871549 })
 
+    // bigint truncation, matching ShareholderList — never rounds up to a misleading 100%
     expect(wrapper.find('[data-test="recap-stake-line"]').text()).toContain(
-      'Recipient stake → 100%'
+      'Recipient stake → 99.99%'
     )
   })
 
@@ -96,7 +97,7 @@ describe('MintRecapCard.vue', () => {
     })
 
     expect(wrapper.find('[data-test="recap-stake-line"]').text()).toContain(
-      'Recipient stake → 56% (was 56%; issuing 0%)'
+      'Recipient stake → 56.00% (was 56.00%; issuing 0.00%)'
     )
     expect(wrapper.find('[data-test="recap-token-stake-line"]').text()).toBe(
       'Recipient shr stake → 28 shr (was 28 shr; issuing 0 shr)'

--- a/app/src/components/sections/SherTokenView/forms/__tests__/MintStakeSection.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/MintStakeSection.spec.ts
@@ -16,7 +16,7 @@ vi.mock('@/composables/investor/reads', () => ({
 
 const mountSection = (recipientAddress = VALID_ADDRESS) =>
   mount(MintStakeSection, {
-    props: { recipientAddress, stakeValidationMessage: null },
+    props: { recipientAddress, hasValidationError: false },
     global: {
       plugins: [createTestingPinia({ createSpy: vi.fn })],
       stubs: {

--- a/app/src/types/investor.ts
+++ b/app/src/types/investor.ts
@@ -1,12 +1,5 @@
 export type StakeMode = 'add' | 'ending'
 
-export type MintStakeFormState = {
-  address: string
-  amount: string
-  percentage: string
-  stakeMode: StakeMode
-}
-
 export type StakePayload = {
   amount: number
   percentage: number
@@ -20,9 +13,6 @@ export type MintRecapData = {
   showRecap: boolean
   symbol: string
   issuedAmount: number
-  recipientStakeBefore: number
-  recipientStakeAfter: number
-  recipientStakeIssued: number
   recipientBalanceBefore: number
   recipientBalanceAfter: number
   totalSupplyBefore: number

--- a/app/src/utils/investorMintAllocation.ts
+++ b/app/src/utils/investorMintAllocation.ts
@@ -1,5 +1,21 @@
 import { type MintRecapData, type StakeMode } from '@/types/investor'
 
+/**
+ * Mint allocation maths and stake-percentage formatting.
+ *
+ * Two precision regimes coexist here, on purpose:
+ *
+ * - **Form maths** (`computeIssuedDelta`, the `compute*Input` helpers, `getMintRecap`)
+ *   work in floating point. The mint form is a float domain — users type decimal
+ *   percentages and token amounts, and the issuance equation
+ *   `(balance + X) / (supply + X) = p` needs real division. Precision only degrades
+ *   above ~2^53 base units, far beyond any realistic token supply.
+ * - **Display formatting** (`formatStakePercentageFromSupply`) is bigint-pure. It is the
+ *   shared stake-percentage formatter used by both `ShareholderList` and the mint recap,
+ *   so a stake percentage is computed identically wherever it is shown — no rounding
+ *   drift between what the recap promises and what the holders table displays.
+ */
+
 export const TOKEN_DECIMALS = 6
 const EPSILON = 1e-9
 
@@ -52,20 +68,6 @@ export const computeIssuedAmountFromAmountInput = (
   return issuedAmount
 }
 
-// Computes final recipient stake percentage after applying an issued delta.
-const getFinalStakeFromAmount = (amount: number, supply: number, balance: number): number => {
-  if (supply <= 0) return 0
-  if (amount === 0) {
-    const currentStake = (balance / supply) * 100
-    if (!Number.isFinite(currentStake)) return 0
-    return currentStake
-  }
-  if (amount < 0) return 0
-  const stake = ((balance + amount) / (supply + amount)) * 100
-  if (!Number.isFinite(stake)) return 0
-  return stake
-}
-
 // Converts an amount input into the paired percentage field value for the current mode.
 export const computePercentageFromAmountInput = (
   amountInput: number,
@@ -114,7 +116,9 @@ export const formatStakePercentageFromSupply = (
   return `${integerPart}.${fractionalString}`
 }
 
-// Produces structured recap metrics (no UI strings) from the current issuance context.
+// Produces structured token/supply recap metrics (no UI strings) for the current issuance.
+// Stake percentages are intentionally excluded: the recap derives them in bigint via
+// `formatStakePercentageFromSupply` so they match the holders table exactly.
 export const getMintRecap = (
   amount: number,
   symbol: string,
@@ -126,9 +130,6 @@ export const getMintRecap = (
       showRecap: false,
       symbol: '',
       issuedAmount: 0,
-      recipientStakeBefore: 0,
-      recipientStakeAfter: 0,
-      recipientStakeIssued: 0,
       recipientBalanceBefore: 0,
       recipientBalanceAfter: 0,
       totalSupplyBefore: 0,
@@ -137,17 +138,12 @@ export const getMintRecap = (
   }
 
   const normalizedAmount = Number.isFinite(amount) && Math.abs(amount) > EPSILON ? amount : 0
-  const recipientStakeBefore = getFinalStakeFromAmount(0, supply, recipientBalance)
-  const recipientStakeAfter = getFinalStakeFromAmount(normalizedAmount, supply, recipientBalance)
   const totalSupplyBefore = Math.max(0, supply)
 
   return {
     showRecap: true,
     symbol,
     issuedAmount: normalizedAmount,
-    recipientStakeBefore,
-    recipientStakeAfter,
-    recipientStakeIssued: recipientStakeAfter - recipientStakeBefore,
     recipientBalanceBefore: Math.max(0, recipientBalance),
     recipientBalanceAfter: Math.max(0, recipientBalance + normalizedAmount),
     totalSupplyBefore,


### PR DESCRIPTION
## Description

Follow-up to the review on #1900 — addresses the outstanding feedback so it can merge back into `feat/1863-manual-minting-ending-toggle`.

Relates to #1869.

## What changed

### 🐛 Recap stake % now matches the holders table
The recap formatted percentages with `formatAmountWithPrecision` (float, **rounding**) while `ShareholderList` uses `formatStakePercentageFromSupply` (bigint, **truncation**) — the recap could promise `→ 29%` and the table show `28.99%` right after. `MintRecapCard` now derives before/after stake from raw bigint balances through the shared formatter, so the two are always consistent.

### 📝 Precision regimes documented
`investorMintAllocation.ts` now documents why two regimes coexist on purpose: float for the form maths (user input domain, needs real division), bigint for display formatting (on-chain parity).

### ♻️ Native UForm validation
The stake validation re-implemented three layers the framework already provides (a `stakeValidationMessage` computed re-parsing the schema, an `:error` prop drilled into the child, a hand-routed message). It is now a single `stakeSchema` with `superRefine` reporting on `stake.amount`, so `UForm`/`UFormField` render the message natively. `TwinAmountInputs` reflects a clamped value back into the input element directly instead of relying on an incidental validation re-render.

### 🧹 Dead code removed
`MintStakeFormState`, the float stake fields (`recipientStakeBefore/After/Issued`) and `getFinalStakeFromAmount` were unused — dropped.

## Verification

- `npm run type-check` — no new errors (4 pre-existing errors in unrelated election/proposal forms remain)
- `npx vitest run` — **205 files / 1728 tests pass**
- `eslint` + `prettier` clean on changed files