### PR TITLE
fix: 🐛 expense page critical UI issues (empty/error states, hardcoded values, a11y)

### DIFF
--- a/app/src/components/OverviewCard.vue
+++ b/app/src/components/OverviewCard.vue
@@ -1,7 +1,13 @@
 <template>
   <div class="w-full rounded-2xl py-6" :class="[bgColor, textColor]" :data-variant="variant">
     <div class="flex flex-col items-center gap-4">
-      <img :src="cardIcon" alt="icon" class="h-16 w-16" data-test="card-icon" />
+      <img
+      :src="cardIcon"
+      alt=""
+      aria-hidden="true"
+      class="h-16 w-16"
+      data-test="card-icon"
+    />
       <span v-if="!loading" class="text-4xl font-bold" data-test="amount">{{ title }}</span>
       <USkeleton v-else class="h-8 w-24 opacity-20" />
       <span class="text-sm font-semibold" data-test="subtitle">{{ subtitle }}</span>

--- a/app/src/components/OverviewCard.vue
+++ b/app/src/components/OverviewCard.vue
@@ -1,13 +1,7 @@
 <template>
   <div class="w-full rounded-2xl py-6" :class="[bgColor, textColor]" :data-variant="variant">
     <div class="flex flex-col items-center gap-4">
-      <img
-      :src="cardIcon"
-      alt=""
-      aria-hidden="true"
-      class="h-16 w-16"
-      data-test="card-icon"
-    />
+      <img :src="cardIcon" alt="" aria-hidden="true" class="h-16 w-16" data-test="card-icon" />
       <span v-if="!loading" class="text-4xl font-bold" data-test="amount">{{ title }}</span>
       <USkeleton v-else class="h-8 w-24 opacity-20" />
       <span class="text-sm font-semibold" data-test="subtitle">{{ subtitle }}</span>

--- a/app/src/components/sections/ExpenseAccountView/ExpenseAccountBalance.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseAccountBalance.vue
@@ -6,19 +6,10 @@
     color="success"
     :card-icon="bagIcon"
     :loading="isLoading"
-  >
-    <div class="flex flex-row gap-1 text-black">
-      <img :src="uptrendIcon" alt="status-icon" />
-      <div>
-        <span class="text-sm font-semibold" data-test="percentage-increase">+ 41.3% </span>
-        <span class="text-xs font-medium text-[#637381]">than last week</span>
-      </div>
-    </div>
-  </OverviewCard>
+  />
 </template>
 <script setup lang="ts">
 import bagIcon from '@/assets/bag.svg'
-import uptrendIcon from '@/assets/uptrend.svg'
 import OverviewCard from '@/components/OverviewCard.vue'
 import { useContractBalance } from '@/composables/useContractBalance'
 import { useTeamStore } from '@/stores'

--- a/app/src/components/sections/ExpenseAccountView/ExpenseAccountTable.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseAccountTable.vue
@@ -50,6 +50,7 @@
       <template #status-cell="{ row: { original: row } }">
         <UBadge
           :label="row.status"
+          :icon="statusIcon(row.status)"
           variant="outline"
           class="rounded-full"
           :color="
@@ -66,6 +67,22 @@
       </template>
       <template #amountTransferred-cell="{ row: { original: row } }">
         <span>{{ row.balances[1] }}/{{ row.amount }} {{ tokenSymbol(row.tokenAddress) }}</span>
+      </template>
+      <template #empty>
+        <div
+          v-if="errorFetchingExpenseData"
+          class="py-6 text-center text-sm text-error"
+          data-test="approvals-error"
+        >
+          Failed to load spending approvals.
+        </div>
+        <div v-else class="py-6 text-center text-sm text-gray-500" data-test="approvals-empty">
+          {{
+            selectedRadio === 'all'
+              ? 'No spending approvals yet.'
+              : `No ${selectedRadio} approvals.`
+          }}
+        </div>
       </template>
     </UTable>
   </div>
@@ -96,7 +113,11 @@ const selectedRadio = ref('all')
 const signatureToUpdate = ref('')
 const isLoadingSetStatus = ref(false)
 
-const { data: expenseData, isLoading: isFetchingExpenseData } = useGetExpensesQuery({
+const {
+  data: expenseData,
+  isLoading: isFetchingExpenseData,
+  error: errorFetchingExpenseData
+} = useGetExpensesQuery({
   queryParams: { teamId: computed(() => teamStore.currentTeamId) }
 })
 
@@ -112,6 +133,13 @@ const formattedExpenseData = computed(() => {
 const expenseAccountEip712Address = computed(() =>
   teamStore.getContractAddressByType('ExpenseAccountEIP712')
 )
+
+// Pairs each status with an icon so it is not conveyed by color alone.
+const statusIcon = (status: string): string => {
+  if (status === 'enabled') return 'i-lucide-circle-check'
+  if (status === 'disabled') return 'i-lucide-circle-x'
+  return 'i-lucide-clock'
+}
 const columns = [
   {
     accessorKey: 'member',

--- a/app/src/components/sections/ExpenseAccountView/ExpenseAccountTable.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseAccountTable.vue
@@ -71,7 +71,7 @@
       <template #empty>
         <div
           v-if="errorFetchingExpenseData"
-          class="py-6 text-center text-sm text-error"
+          class="text-error py-6 text-center text-sm"
           data-test="approvals-error"
         >
           Failed to load spending approvals.

--- a/app/src/components/sections/ExpenseAccountView/ExpenseAccountTotalApproved.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseAccountTotalApproved.vue
@@ -1,17 +1,28 @@
 <template>
-  <OverviewCard :title="10" subtitle="Total Approved" color="info" :card-icon="personIcon">
-    <div class="flex flex-row gap-1 text-black">
-      <img :src="uptrendIcon" alt="status-icon" />
-      <div>
-        <span class="text-sm font-semibold" data-test="percentage-increase">+ 12.3% </span>
-        <span class="text-xs font-medium text-[#637381]">TODO: Update this</span>
-        <!-- <span class="font-medium text-[#637381] text-xs">than last week</span> -->
-      </div>
-    </div>
-  </OverviewCard>
+  <OverviewCard
+    :title="totalApproved"
+    subtitle="Total Approved"
+    color="info"
+    :card-icon="personIcon"
+    :loading="isLoading"
+  />
 </template>
 <script setup lang="ts">
 import personIcon from '@/assets/person.svg'
-import uptrendIcon from '@/assets/uptrend.svg'
 import OverviewCard from '@/components/OverviewCard.vue'
+import { computed } from 'vue'
+import { useTeamStore } from '@/stores'
+import { useGetExpensesQuery } from '@/queries'
+
+const teamStore = useTeamStore()
+
+const { data: expenseData, isLoading } = useGetExpensesQuery({
+  queryParams: { teamId: computed(() => teamStore.currentTeamId) }
+})
+
+// Number of distinct members with at least one approved expense.
+const totalApproved = computed(() => {
+  const approvals = expenseData.value ?? []
+  return new Set(approvals.map((expense) => expense.userAddress.toLowerCase())).size
+})
 </script>

--- a/app/src/components/sections/ExpenseAccountView/ExpenseMonthSpent.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseMonthSpent.vue
@@ -6,11 +6,18 @@
     :card-icon="cartIcon"
     :loading="loading"
   >
-    <div class="flex flex-row gap-1 text-black">
-      <img :src="uptrendIcon" alt="status-icon" />
+    <div v-if="spendingDelta" class="flex flex-row gap-1 text-black">
+      <img
+        :src="uptrendIcon"
+        alt=""
+        aria-hidden="true"
+        :class="{ 'rotate-180': spendingDelta.direction === 'down' }"
+      />
       <div>
-        <span class="text-sm font-semibold" data-test="percentage-increase">+ 26.3% </span>
-        <span class="text-xs font-medium text-[#637381]">than last week</span>
+        <span class="text-sm font-semibold" data-test="percentage-change">
+          {{ spendingDelta.direction === 'up' ? '+' : '-' }} {{ spendingDelta.percent }}%
+        </span>
+        <span class="text-xs font-medium text-[#637381]">than last month</span>
       </div>
     </div>
   </OverviewCard>
@@ -24,8 +31,7 @@ import { formatCurrencyShort, log } from '@/utils'
 import { useQuery } from '@vue/apollo-composable'
 import gql from 'graphql-tag'
 import { formatUnits } from 'viem'
-import { watch } from 'vue'
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import { SUPPORTED_TOKENS } from '@/constant'
 
 const teamStore = useTeamStore()
@@ -33,44 +39,54 @@ const toast = useToast()
 const currencyStore = useCurrencyStore()
 const contractAddress = computed(() => teamStore.getContractAddressByType('ExpenseAccountEIP712'))
 
+const EXPENSE_TRANSACTIONS_QUERY = gql`
+  query GetExpenseTransactions($contractAddress: Bytes!, $startDate: BigInt!, $endDate: BigInt!) {
+    transactions(
+      where: {
+        contractAddress: $contractAddress
+        blockTimestamp_gte: $startDate
+        blockTimestamp_lte: $endDate
+        transactionType: transfer
+      }
+    ) {
+      amount
+      tokenAddress
+    }
+  }
+`
+
 const now = new Date()
 const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1).getTime() / 1000
 const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getTime() / 1000
-const { result, loading, error } = useQuery(
-  gql`
-    query GetExpenseTransactions($contractAddress: Bytes!, $startDate: BigInt!, $endDate: BigInt!) {
-      transactions(
-        where: {
-          contractAddress: $contractAddress
-          blockTimestamp_gte: $startDate
-          blockTimestamp_lte: $endDate
-          transactionType: transfer
-        }
-      ) {
-        amount
-        tokenAddress
-      }
-    }
-  `,
-  { contractAddress, startDate: startOfMonth, endDate: endOfMonth }
-)
+const startOfPrevMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1).getTime() / 1000
+const endOfPrevMonth = new Date(now.getFullYear(), now.getMonth(), 0).getTime() / 1000
 
-const totalMonthlySpentAmount = computed(() => {
-  const transactions = result.value?.transactions || []
-  // Map: tokenId -> total amount spent for that token
+const { result, loading, error } = useQuery(EXPENSE_TRANSACTIONS_QUERY, {
+  contractAddress,
+  startDate: startOfMonth,
+  endDate: endOfMonth
+})
+
+const { result: prevResult, error: prevError } = useQuery(EXPENSE_TRANSACTIONS_QUERY, {
+  contractAddress,
+  startDate: startOfPrevMonth,
+  endDate: endOfPrevMonth
+})
+
+/** Sums `transfer` transactions, converted to the local currency. */
+const sumInLocalCurrency = (
+  transactions: { amount: bigint; tokenAddress: string }[]
+): number => {
   const spentByToken: Record<string, number> = {}
   for (const token of SUPPORTED_TOKENS) {
     spentByToken[token.id] = 0
   }
-  transactions.forEach((transaction: { amount: bigint; tokenAddress: string }) => {
+  transactions.forEach((transaction) => {
     const token = SUPPORTED_TOKENS.find(
       (t) => t.address.toLowerCase() === transaction.tokenAddress.toLowerCase()
     )
-    if (token) {
-      const decimals = token.decimals
-      if (spentByToken[token.id] !== undefined) {
-        spentByToken[token.id]! += parseFloat(formatUnits(transaction.amount, decimals))
-      }
+    if (token && spentByToken[token.id] !== undefined) {
+      spentByToken[token.id]! += parseFloat(formatUnits(transaction.amount, token.decimals))
     }
   })
 
@@ -78,18 +94,35 @@ const totalMonthlySpentAmount = computed(() => {
   for (const token of SUPPORTED_TOKENS) {
     const price =
       currencyStore.getTokenInfo(token.id)?.prices.find((p) => p.id === 'local')?.price || 0
-    const spent = spentByToken[token.id]
-    if (spent !== undefined) {
-      totalInLocal += spent * price
-    }
+    totalInLocal += (spentByToken[token.id] ?? 0) * price
   }
-  return formatCurrencyShort(totalInLocal, currencyStore.localCurrency.code)
+  return totalInLocal
+}
+
+const monthlySpentLocal = computed(() => sumInLocalCurrency(result.value?.transactions ?? []))
+const prevMonthlySpentLocal = computed(() =>
+  sumInLocalCurrency(prevResult.value?.transactions ?? [])
+)
+
+const totalMonthlySpentAmount = computed(() =>
+  formatCurrencyShort(monthlySpentLocal.value, currencyStore.localCurrency.code)
+)
+
+const spendingDelta = computed<{ percent: string; direction: 'up' | 'down' } | null>(() => {
+  const previous = prevMonthlySpentLocal.value
+  // No baseline to compare against — hide the delta rather than show a fake one.
+  if (previous <= 0) return null
+  const change = ((monthlySpentLocal.value - previous) / previous) * 100
+  return {
+    percent: Math.abs(change).toFixed(1),
+    direction: change >= 0 ? 'up' : 'down'
+  }
 })
 
-watch(error, (err) => {
-  if (err) {
+watch([error, prevError], ([err, prevErr]) => {
+  if (err || prevErr) {
     toast.add({ title: 'Failed to fetch monthly spent amount', color: 'error' })
-    log.error('Failed to fetch monthly spent amount', err)
+    log.error('Failed to fetch monthly spent amount', err ?? prevErr)
   }
 })
 </script>

--- a/app/src/components/sections/ExpenseAccountView/ExpenseMonthSpent.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseMonthSpent.vue
@@ -74,9 +74,7 @@ const { result: prevResult, error: prevError } = useQuery(EXPENSE_TRANSACTIONS_Q
 })
 
 /** Sums `transfer` transactions, converted to the local currency. */
-const sumInLocalCurrency = (
-  transactions: { amount: bigint; tokenAddress: string }[]
-): number => {
+const sumInLocalCurrency = (transactions: { amount: bigint; tokenAddress: string }[]): number => {
   const spentByToken: Record<string, number> = {}
   for (const token of SUPPORTED_TOKENS) {
     spentByToken[token.id] = 0

--- a/app/src/components/sections/ExpenseAccountView/ExpenseTransactions.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseTransactions.vue
@@ -53,7 +53,7 @@
       <template #empty>
         <div
           v-if="hasError"
-          class="py-6 text-center text-sm text-error"
+          class="text-error py-6 text-center text-sm"
           data-test="expense-transactions-error"
         >
           Failed to load transactions. Please try again later.

--- a/app/src/components/sections/ExpenseAccountView/ExpenseTransactions.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseTransactions.vue
@@ -49,6 +49,23 @@
       <template #valueLocal-cell="{ row: { original: row } }">
         {{ formatCurrencyShort(row.amountLocal, currencyStore.localCurrency.code) }}
       </template>
+
+      <template #empty>
+        <div
+          v-if="hasError"
+          class="py-6 text-center text-sm text-error"
+          data-test="expense-transactions-error"
+        >
+          Failed to load transactions. Please try again later.
+        </div>
+        <div
+          v-else
+          class="py-6 text-center text-sm text-gray-500"
+          data-test="expense-transactions-empty"
+        >
+          No transactions for the selected filters.
+        </div>
+      </template>
     </UTable>
   </UCard>
 </template>
@@ -122,6 +139,7 @@ const {
 )
 
 const loading = computed(() => expenseLoading.value || incomingTokenTransfersLoading.value)
+const hasError = computed(() => Boolean(error.value || incomingTokenTransfersError.value))
 
 const parseAmount = (value: string): bigint => {
   try {

--- a/app/src/components/sections/ExpenseAccountView/MyApprovedExpenseSection.vue
+++ b/app/src/components/sections/ExpenseAccountView/MyApprovedExpenseSection.vue
@@ -1,37 +1,37 @@
 <template>
   <UCard>
     <template #header>My Approved Expense</template>
-    <div v-if="newExpenseData">
-      <!-- TODO display this only if the use have an approved expense -->
-      <!-- Expense A/c Info Section -->
-      <!-- New Header -->
-      <UTable :data="getCurrentUserExpenses(newExpenseData, currentUserAddress)" :columns="columns">
-        <template #action-cell="{ row: { original: row } }">
-          <TransferAction :row="row" />
-        </template>
-        <template #startDate-cell="{ row: { original: row } }">
-          <span>{{ new Date(Number(row.data.startDate) * 1000).toLocaleString('en-US') }}</span>
-        </template>
-        <template #endDate-cell="{ row: { original: row } }">
-          <span>{{ new Date(Number(row.data.endDate) * 1000).toLocaleString('en-US') }}</span>
-        </template>
-        <template #frequencyType-cell="{ row: { original: row } }">
-          <span>
-            {{
-              row.data.frequencyType == 4
-                ? getCustomFrequency(Number(row.data.customFrequency))
-                : getFrequencyType(row.data.frequencyType)
-            }}
-          </span>
-        </template>
-        <template #amountTransferred-cell="{ row: { original: row } }">
-          <span
-            >{{ row.balances[1] }}/{{ row.data.amount }}
-            {{ tokenSymbol(row.data.tokenAddress) }}</span
-          >
-        </template>
-      </UTable>
-    </div>
+    <UTable :data="myExpenses" :columns="columns" :loading="isLoading">
+      <template #action-cell="{ row: { original: row } }">
+        <TransferAction :row="row" />
+      </template>
+      <template #startDate-cell="{ row: { original: row } }">
+        <span>{{ new Date(Number(row.data.startDate) * 1000).toLocaleString('en-US') }}</span>
+      </template>
+      <template #endDate-cell="{ row: { original: row } }">
+        <span>{{ new Date(Number(row.data.endDate) * 1000).toLocaleString('en-US') }}</span>
+      </template>
+      <template #frequencyType-cell="{ row: { original: row } }">
+        <span>
+          {{
+            row.data.frequencyType == 4
+              ? getCustomFrequency(Number(row.data.customFrequency))
+              : getFrequencyType(row.data.frequencyType)
+          }}
+        </span>
+      </template>
+      <template #amountTransferred-cell="{ row: { original: row } }">
+        <span
+          >{{ row.balances[1] }}/{{ row.data.amount }}
+          {{ tokenSymbol(row.data.tokenAddress) }}</span
+        >
+      </template>
+      <template #empty>
+        <div class="py-6 text-center text-sm text-gray-500" data-test="my-expenses-empty">
+          You have no approved expenses yet.
+        </div>
+      </template>
+    </UTable>
   </UCard>
 </template>
 
@@ -48,9 +48,13 @@ import { getFrequencyType, getCustomFrequency } from '@/utils'
 const teamStore = useTeamStore()
 const currentUserAddress = useUserDataStore().address
 
-const { data: newExpenseData } = useGetExpensesQuery({
+const { data: newExpenseData, isLoading } = useGetExpensesQuery({
   queryParams: { teamId: computed(() => teamStore.currentTeamId) }
 })
+
+const myExpenses = computed(() =>
+  getCurrentUserExpenses(newExpenseData.value ?? [], currentUserAddress)
+)
 
 const columns = [
   {

--- a/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseAccountTotalApproved.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseAccountTotalApproved.spec.ts
@@ -1,19 +1,28 @@
-import { shallowMount } from '@vue/test-utils'
-import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import ExpenseAccountTotalApproved from '../ExpenseAccountTotalApproved.vue'
-import { createTestingPinia } from '@pinia/testing'
+import { createMockQueryResponse } from '@/tests/mocks'
+import { useGetExpensesQuery } from '@/queries/expense.queries'
 
 describe('ExpenseAccountTotalApproved', () => {
-  const createComponent = () => {
-    return shallowMount(ExpenseAccountTotalApproved, {
-      global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn })]
-      }
-    })
-  }
+  beforeEach(() => {
+    vi.mocked(useGetExpensesQuery).mockReturnValue(createMockQueryResponse([]))
+  })
 
-  it('should render correctly', () => {
-    const wrapper = createComponent()
-    expect(wrapper.exists).toBeTruthy()
+  const amountText = () => mount(ExpenseAccountTotalApproved).find('[data-test="amount"]').text()
+
+  it('counts distinct approved members, ignoring address casing', () => {
+    vi.mocked(useGetExpensesQuery).mockReturnValue(
+      createMockQueryResponse([
+        { userAddress: '0xAAA' },
+        { userAddress: '0xaaa' },
+        { userAddress: '0xBBB' }
+      ])
+    )
+    expect(amountText()).toBe('2')
+  })
+
+  it('reports zero when there are no approvals', () => {
+    expect(amountText()).toBe('0')
   })
 })

--- a/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseMonthSpent.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseMonthSpent.spec.ts
@@ -35,12 +35,8 @@ const usdc = (whole: number) => ({
   tokenAddress: USDC_ADDRESS
 })
 
-const createWrapper = (): VueWrapper =>
-  mount(ExpenseMonthSpent, {
-    global: {
-      stubs: { OverviewCard: { template: '<div><slot /></div>' } }
-    }
-  })
+const createWrapper = (): VueWrapper => mount(ExpenseMonthSpent)
+const delta = (wrapper: VueWrapper) => wrapper.find('[data-test="percentage-change"]')
 
 describe('ExpenseMonthSpent', () => {
   beforeEach(() => {
@@ -50,41 +46,26 @@ describe('ExpenseMonthSpent', () => {
     apolloState.error.value = null
   })
 
-  it('formats the current month spent total', () => {
+  it('renders the current month spent total', () => {
     apolloState.current.value = { transactions: [usdc(250)] }
-    const vm = createWrapper().vm as unknown as { totalMonthlySpentAmount: string }
-    expect(vm.totalMonthlySpentAmount).toContain('250')
+    expect(createWrapper().find('[data-test="amount"]').text()).toContain('250')
   })
 
   it('hides the delta when there is no previous-month baseline', () => {
     apolloState.current.value = { transactions: [usdc(100)] }
     apolloState.previous.value = { transactions: [] }
-    const vm = createWrapper().vm as unknown as { spendingDelta: unknown }
-    expect(vm.spendingDelta).toBeNull()
+    expect(delta(createWrapper()).exists()).toBe(false)
   })
 
-  it('computes an upward delta when spending increased', () => {
+  it('shows an upward delta when spending increased', () => {
     apolloState.current.value = { transactions: [usdc(200)] }
     apolloState.previous.value = { transactions: [usdc(100)] }
-    const vm = createWrapper().vm as unknown as {
-      spendingDelta: { percent: string; direction: string }
-    }
-    expect(vm.spendingDelta).toEqual({ percent: '100.0', direction: 'up' })
+    expect(delta(createWrapper()).text()).toContain('+ 100.0%')
   })
 
-  it('computes a downward delta when spending decreased', () => {
+  it('shows a downward delta when spending decreased', () => {
     apolloState.current.value = { transactions: [usdc(60)] }
     apolloState.previous.value = { transactions: [usdc(120)] }
-    const vm = createWrapper().vm as unknown as {
-      spendingDelta: { percent: string; direction: string }
-    }
-    expect(vm.spendingDelta).toEqual({ percent: '50.0', direction: 'down' })
-  })
-
-  it('renders the delta direction in the slot', () => {
-    apolloState.current.value = { transactions: [usdc(200)] }
-    apolloState.previous.value = { transactions: [usdc(100)] }
-    const wrapper = createWrapper()
-    expect(wrapper.find('[data-test="percentage-change"]').text()).toContain('+ 100.0%')
+    expect(delta(createWrapper()).text()).toContain('- 50.0%')
   })
 })

--- a/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseMonthSpent.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseMonthSpent.spec.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { USDC_ADDRESS } from '@/constant'
+import ExpenseMonthSpent from '../ExpenseMonthSpent.vue'
+
+type Transactions = { transactions: { amount: bigint; tokenAddress: string }[] }
+
+// Holds the result returned to the two useQuery calls (current month, then previous month).
+const apolloState = vi.hoisted(() => ({
+  current: null as unknown as { value: Transactions | undefined },
+  previous: null as unknown as { value: Transactions | undefined },
+  error: null as unknown as { value: Error | null },
+  callIndex: 0
+}))
+
+vi.mock('@vue/apollo-composable', async () => {
+  const { ref } = await import('vue')
+  apolloState.current = ref<Transactions | undefined>(undefined)
+  apolloState.previous = ref<Transactions | undefined>(undefined)
+  apolloState.error = ref<Error | null>(null)
+  const useQuery = vi.fn(() => {
+    // The component calls useQuery for the current month first, then the previous month.
+    const isCurrent = apolloState.callIndex++ % 2 === 0
+    return {
+      result: isCurrent ? apolloState.current : apolloState.previous,
+      loading: ref(false),
+      error: apolloState.error
+    }
+  })
+  return { useQuery }
+})
+
+const usdc = (whole: number) => ({
+  amount: BigInt(whole) * 1_000_000n,
+  tokenAddress: USDC_ADDRESS
+})
+
+const createWrapper = (): VueWrapper =>
+  mount(ExpenseMonthSpent, {
+    global: {
+      stubs: { OverviewCard: { template: '<div><slot /></div>' } }
+    }
+  })
+
+describe('ExpenseMonthSpent', () => {
+  beforeEach(() => {
+    apolloState.callIndex = 0
+    apolloState.current.value = { transactions: [] }
+    apolloState.previous.value = { transactions: [] }
+    apolloState.error.value = null
+  })
+
+  it('formats the current month spent total', () => {
+    apolloState.current.value = { transactions: [usdc(250)] }
+    const vm = createWrapper().vm as unknown as { totalMonthlySpentAmount: string }
+    expect(vm.totalMonthlySpentAmount).toContain('250')
+  })
+
+  it('hides the delta when there is no previous-month baseline', () => {
+    apolloState.current.value = { transactions: [usdc(100)] }
+    apolloState.previous.value = { transactions: [] }
+    const vm = createWrapper().vm as unknown as { spendingDelta: unknown }
+    expect(vm.spendingDelta).toBeNull()
+  })
+
+  it('computes an upward delta when spending increased', () => {
+    apolloState.current.value = { transactions: [usdc(200)] }
+    apolloState.previous.value = { transactions: [usdc(100)] }
+    const vm = createWrapper().vm as unknown as {
+      spendingDelta: { percent: string; direction: string }
+    }
+    expect(vm.spendingDelta).toEqual({ percent: '100.0', direction: 'up' })
+  })
+
+  it('computes a downward delta when spending decreased', () => {
+    apolloState.current.value = { transactions: [usdc(60)] }
+    apolloState.previous.value = { transactions: [usdc(120)] }
+    const vm = createWrapper().vm as unknown as {
+      spendingDelta: { percent: string; direction: string }
+    }
+    expect(vm.spendingDelta).toEqual({ percent: '50.0', direction: 'down' })
+  })
+
+  it('renders the delta direction in the slot', () => {
+    apolloState.current.value = { transactions: [usdc(200)] }
+    apolloState.previous.value = { transactions: [usdc(100)] }
+    const wrapper = createWrapper()
+    expect(wrapper.find('[data-test="percentage-change"]').text()).toContain('+ 100.0%')
+  })
+})

--- a/app/src/components/sections/ExpenseAccountView/__tests__/MyApprovedExpenseSection.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/MyApprovedExpenseSection.spec.ts
@@ -4,13 +4,15 @@ import { createMockQueryResponse } from '@/tests/mocks'
 import { useGetExpensesQuery } from '@/queries/expense.queries'
 
 // UTable is auto-imported by @nuxt/ui/vite, so config.global.stubs cannot catch
-// it — the module itself must be mocked. Renders only the empty slot so data
-// rows never reach the cell templates.
+// it — the module itself must be mocked. The stub exposes the row count and the
+// empty slot so the section can be asserted without reaching component internals.
 vi.mock('@nuxt/ui/components/Table.vue', () => ({
   default: {
     name: 'UTable',
     props: { data: { type: Array, required: false } },
-    template: '<div><slot name="empty" v-if="!data || data.length === 0" /></div>'
+    template:
+      '<div><span data-test="row-count">{{ data ? data.length : 0 }}</span>' +
+      '<slot name="empty" v-if="!data || data.length === 0" /></div>'
   }
 }))
 
@@ -36,12 +38,10 @@ describe('MyApprovedExpenseSection', () => {
         { data: { approvedAddress: '0x00000000000000000000000000000000000000ff' } }
       ])
     )
-    const vm = createWrapper().vm as unknown as { myExpenses: unknown[] }
-    expect(vm.myExpenses).toHaveLength(1)
+    expect(createWrapper().find('[data-test="row-count"]').text()).toBe('1')
   })
 
   it('shows an empty state when the user has no approvals', () => {
-    const wrapper = createWrapper()
-    expect(wrapper.find('[data-test="my-expenses-empty"]').exists()).toBe(true)
+    expect(createWrapper().find('[data-test="my-expenses-empty"]').exists()).toBe(true)
   })
 })

--- a/app/src/components/sections/ExpenseAccountView/__tests__/MyApprovedExpenseSection.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/MyApprovedExpenseSection.spec.ts
@@ -1,0 +1,47 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { createMockQueryResponse } from '@/tests/mocks'
+import { useGetExpensesQuery } from '@/queries/expense.queries'
+
+// UTable is auto-imported by @nuxt/ui/vite, so config.global.stubs cannot catch
+// it — the module itself must be mocked. Renders only the empty slot so data
+// rows never reach the cell templates.
+vi.mock('@nuxt/ui/components/Table.vue', () => ({
+  default: {
+    name: 'UTable',
+    props: { data: { type: Array, required: false } },
+    template: '<div><slot name="empty" v-if="!data || data.length === 0" /></div>'
+  }
+}))
+
+import MyApprovedExpenseSection from '../MyApprovedExpenseSection.vue'
+
+// mockUserStore.address — the address treated as the current user.
+const CURRENT_USER = '0x0000000000000000000000000000000000000001'
+
+const createWrapper = () =>
+  mount(MyApprovedExpenseSection, {
+    global: { stubs: { TransferAction: true } }
+  })
+
+describe('MyApprovedExpenseSection', () => {
+  beforeEach(() => {
+    vi.mocked(useGetExpensesQuery).mockReturnValue(createMockQueryResponse([]))
+  })
+
+  it('keeps only the current user approvals', () => {
+    vi.mocked(useGetExpensesQuery).mockReturnValue(
+      createMockQueryResponse([
+        { data: { approvedAddress: CURRENT_USER } },
+        { data: { approvedAddress: '0x00000000000000000000000000000000000000ff' } }
+      ])
+    )
+    const vm = createWrapper().vm as unknown as { myExpenses: unknown[] }
+    expect(vm.myExpenses).toHaveLength(1)
+  })
+
+  it('shows an empty state when the user has no approvals', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.find('[data-test="my-expenses-empty"]').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the 4 critical UI issues found while auditing the Expense Account page (`ExpenseAccountView.vue`).

## Changes

### 1. Hardcoded / fake stat-card values
- `ExpenseAccountTotalApproved` — replaced the hardcoded `10` and the `+12.3% TODO` delta with the real count of distinct approved members from `useGetExpensesQuery`.
- `ExpenseMonthSpent` — replaced the fake `+26.3% than last week` with a real month-over-month delta computed from a previous-month transactions query. The delta is hidden when there is no previous-month baseline rather than faked.
- `ExpenseAccountBalance` — removed the fake `+41.3% than last week` delta (no historical balance source exists).

### 2. Empty states
`MyApprovedExpenseSection`, `ExpenseAccountTable` and `ExpenseTransactions` now show a contextual empty message instead of a blank table, and distinguish loading from empty.

### 3. Error states
`ExpenseAccountTable` and `ExpenseTransactions` show an inline error message when their fetch fails, so a failure is no longer indistinguishable from "no data". Mutation errors keep using `UAlert` as before.

### 4. Accessibility
- Status badges carry an icon so status is not conveyed by colour alone.
- The decorative `OverviewCard` icon is marked `aria-hidden` with an empty `alt`.

## Testing

- `npm run type-check` — passes.
- `npx vitest run` — 207 files / 1738 tests pass, plus new specs for `ExpenseAccountTotalApproved`, `ExpenseMonthSpent` and `MyApprovedExpenseSection`.
- `eslint` + `prettier` — clean on changed files.

## Out of scope (separate tickets)

- Ponder query invalidation after a transfer (`ExpenseTransactions` / `ExpenseMonthSpent` not actively refreshed).
- Responsive / i18n issues.

Closes #1965
