### PR TITLE
test: ✅ raise patch coverage for expense page UI

### DIFF
--- a/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseAccountTable.actions.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseAccountTable.actions.spec.ts
@@ -219,4 +219,35 @@ describe('ExpenseAccountTable - Actions and Loading', () => {
       expect(logErrorSpy).toHaveBeenCalled()
     })
   })
+
+  describe('Empty and error states', () => {
+    it('shows an empty message when there are no approvals', () => {
+      vi.mocked(useGetExpensesQuery).mockReturnValue(
+        createMockQueryResponse([]) as ReturnType<typeof useGetExpensesQuery>
+      )
+      const wrapper = createComponent()
+      expect(wrapper.find('[data-test="approvals-empty"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="approvals-error"]').exists()).toBe(false)
+    })
+
+    it('shows an error message when the approvals fetch fails', () => {
+      vi.mocked(useGetExpensesQuery).mockReturnValue(
+        createMockQueryResponse([], false, new Error('boom')) as ReturnType<
+          typeof useGetExpensesQuery
+        >
+      )
+      const wrapper = createComponent()
+      expect(wrapper.find('[data-test="approvals-error"]').exists()).toBe(true)
+    })
+
+    it('renders an icon-bearing badge for an expired approval', () => {
+      vi.mocked(useGetExpensesQuery).mockReturnValue(
+        createMockQueryResponse([{ ...mockApprovals[0], status: 'expired' }]) as ReturnType<
+          typeof useGetExpensesQuery
+        >
+      )
+      const wrapper = createComponent()
+      expect(wrapper.text()).toContain('expired')
+    })
+  })
 })

--- a/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseTransactions.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseTransactions.spec.ts
@@ -215,4 +215,20 @@ describe('ExpenseTransactions', () => {
     await nextTick()
     expect(logErrorSpy).toHaveBeenCalledTimes(2)
   })
+
+  it('shows an empty state when there are no transactions', () => {
+    apolloState.expenseQueryResult.value = undefined
+    apolloState.incomingTransfersQueryResult.value = undefined
+    wrapper = createWrapper()
+    expect(wrapper.find('[data-test="expense-transactions-empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="expense-transactions-error"]').exists()).toBe(false)
+  })
+
+  it('shows an error state when a transactions query fails', () => {
+    apolloState.expenseQueryResult.value = undefined
+    apolloState.incomingTransfersQueryResult.value = undefined
+    apolloState.expenseQueryError.value = new Error('expense query failed')
+    wrapper = createWrapper()
+    expect(wrapper.find('[data-test="expense-transactions-error"]').exists()).toBe(true)
+  })
 })

--- a/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseTransactions.test-utils.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseTransactions.test-utils.ts
@@ -13,7 +13,8 @@ export const UTableStub = defineComponent({
     columns: { type: Array, required: false },
     loading: { type: Boolean, required: false }
   },
-  template: '<div data-test="expense-table"></div>'
+  template:
+    '<div data-test="expense-table"><slot name="empty" v-if="!data || data.length === 0" /></div>'
 })
 
 export const USelectStub = defineComponent({

--- a/app/src/components/sections/ExpenseAccountView/__tests__/MyApprovedExpenseSection.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/MyApprovedExpenseSection.spec.ts
@@ -1,29 +1,44 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { zeroAddress } from 'viem'
 import { createMockQueryResponse } from '@/tests/mocks'
 import { useGetExpensesQuery } from '@/queries/expense.queries'
-
-// UTable is auto-imported by @nuxt/ui/vite, so config.global.stubs cannot catch
-// it — the module itself must be mocked. The stub exposes the row count and the
-// empty slot so the section can be asserted without reaching component internals.
-vi.mock('@nuxt/ui/components/Table.vue', () => ({
-  default: {
-    name: 'UTable',
-    props: { data: { type: Array, required: false } },
-    template:
-      '<div><span data-test="row-count">{{ data ? data.length : 0 }}</span>' +
-      '<slot name="empty" v-if="!data || data.length === 0" /></div>'
-  }
-}))
-
 import MyApprovedExpenseSection from '../MyApprovedExpenseSection.vue'
 
 // mockUserStore.address — the address treated as the current user.
 const CURRENT_USER = '0x0000000000000000000000000000000000000001'
 
+const expense = (over: Record<string, unknown> = {}, data: Record<string, unknown> = {}) => ({
+  id: 1,
+  teamId: 1,
+  userAddress: CURRENT_USER,
+  signature: '0xsignature',
+  status: 'enabled',
+  balances: { 0: '0', 1: '5' },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  data: {
+    approvedAddress: CURRENT_USER,
+    amount: 100,
+    frequencyType: 0,
+    customFrequency: 0,
+    startDate: 1_700_000_000,
+    endDate: 1_800_000_000,
+    tokenAddress: zeroAddress,
+    ...data
+  },
+  ...over
+})
+
+const TransferActionStub = {
+  name: 'TransferAction',
+  props: ['row'],
+  template: '<div data-test="transfer-action" />'
+}
+
 const createWrapper = () =>
   mount(MyApprovedExpenseSection, {
-    global: { stubs: { TransferAction: true } }
+    global: { stubs: { TransferAction: TransferActionStub } }
   })
 
 describe('MyApprovedExpenseSection', () => {
@@ -31,14 +46,17 @@ describe('MyApprovedExpenseSection', () => {
     vi.mocked(useGetExpensesQuery).mockReturnValue(createMockQueryResponse([]))
   })
 
-  it('keeps only the current user approvals', () => {
+  it('renders a row only for the current user approvals', () => {
     vi.mocked(useGetExpensesQuery).mockReturnValue(
       createMockQueryResponse([
-        { data: { approvedAddress: CURRENT_USER } },
-        { data: { approvedAddress: '0x00000000000000000000000000000000000000ff' } }
+        expense({ signature: '0xa' }, { frequencyType: 0 }),
+        expense({ signature: '0xb' }, { frequencyType: 4, customFrequency: 7 }),
+        expense({ signature: '0xc', userAddress: '0xother' }, { approvedAddress: '0xother' })
       ])
     )
-    expect(createWrapper().find('[data-test="row-count"]').text()).toBe('1')
+    const wrapper = createWrapper()
+    expect(wrapper.findAll('[data-test="transfer-action"]')).toHaveLength(2)
+    expect(wrapper.find('[data-test="my-expenses-empty"]').exists()).toBe(false)
   })
 
   it('shows an empty state when the user has no approvals', () => {


### PR DESCRIPTION
## Summary

Test-only follow-up to #1966, which was merged with `codecov/patch` at 76.67%. This lands the missing coverage for the expense page UI changes — no application code is modified.

## Changes

- `MyApprovedExpenseSection.spec.ts` — mount the real `UTable` with full rows so the cell templates (date, frequency, amount, action) and the empty state are exercised.
- `ExpenseAccountTable.actions.spec.ts` — add tests for the empty state, the fetch-error state and the expired-status badge.
- `ExpenseTransactions.spec.ts` / `ExpenseTransactions.test-utils.ts` — add tests for the empty and error states; the table stub now renders the `#empty` slot.

## Testing

- `npm run type-check` — passes.
- `npx vitest run src/components/sections/ExpenseAccountView/__tests__/` — 6 files / 36 tests pass.
- `eslint` + `prettier` — clean.

Closes #1967
