### PR TITLE
fix: 🐛 rename OverviewCard prop variant to color

### DIFF
--- a/app/src/components/OverviewCard.vue
+++ b/app/src/components/OverviewCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full rounded-2xl py-6" :class="[bgColor, textColor]" :data-variant="variant">
+  <div class="w-full rounded-2xl py-6" :class="[bgColor, textColor]" :data-color="color">
     <div class="flex flex-col items-center gap-4">
       <img :src="cardIcon" alt="" aria-hidden="true" class="h-16 w-16" data-test="card-icon" />
       <span v-if="!loading" class="text-4xl font-bold" data-test="amount">{{ title }}</span>
@@ -21,7 +21,7 @@ const props = defineProps({
     type: String,
     required: true
   },
-  variant: {
+  color: {
     type: String,
     default: 'primary'
   },
@@ -36,7 +36,7 @@ const props = defineProps({
 })
 
 const bgColor = computed(() => {
-  switch (props.variant) {
+  switch (props.color) {
     case 'info':
       return 'bg-[#D9F1F6]'
     case 'success':
@@ -49,7 +49,7 @@ const bgColor = computed(() => {
 })
 
 const textColor = computed(() => {
-  switch (props.variant) {
+  switch (props.color) {
     case 'info':
       return 'text-[#0C315A]'
     case 'success':

--- a/app/src/components/__tests__/OverviewCard.spec.ts
+++ b/app/src/components/__tests__/OverviewCard.spec.ts
@@ -19,18 +19,18 @@ describe('OverviewCard', () => {
   })
 
   it.each(['info', 'success', 'warning', 'unknown'] as const)(
-    'exposes the %s variant via data-variant',
-    (variant) => {
+    'exposes the %s color via data-color',
+    (color) => {
       const wrapper = mount(OverviewCard, {
         props: {
           title: 'Test Title',
           subtitle: 'Test Subtitle',
-          variant,
+          color,
           cardIcon: 'test-icon.png'
         }
       })
 
-      expect(wrapper.attributes('data-variant')).toBe(variant)
+      expect(wrapper.attributes('data-color')).toBe(color)
     }
   )
 


### PR DESCRIPTION
## What

`OverviewCard.vue` declared its color prop as `variant`, but all 7 call sites pass `color`. The mismatch meant the `color` attribute was ignored and `variant` fell back to its `'primary'` default — so every stat card rendered with the default white background (`bg-white`) instead of its intended green/amber/blue.

This renames the prop (and the `:data-variant` test attribute) to `color`, matching every existing caller. No caller changes were needed.

## Why

The three Expense stat cards (`ExpenseAccountBalance`, `ExpenseMonthSpent`, `ExpenseAccountTotalApproved`) — plus the CashRemuneration and SherToken cards — all visually rendered white instead of their color-coded backgrounds.

## Changes

- `app/src/components/OverviewCard.vue`: `variant` prop → `color`; `props.variant` → `props.color` in both `bgColor`/`textColor` computeds; `:data-variant` → `:data-color`.
- `app/src/components/__tests__/OverviewCard.spec.ts`: updated the variant-exposure test to pass `color` and assert `data-color`.

## Testing

- OverviewCard spec: 7/7 passing.
- `npm run type-check`: no OverviewCard/`color`-related errors. (Pre-existing `useToast` auto-import errors are unrelated — the auto-import type declarations aren't generated in a fresh worktree.)

Closes #1972