### PR TITLE
fix: 🐛 rename OverviewCard callers' color prop to variant

### DIFF
--- a/app/src/components/sections/CashRemunerationView/CashRemunerationMonthlyClaim.vue
+++ b/app/src/components/sections/CashRemunerationView/CashRemunerationMonthlyClaim.vue
@@ -2,7 +2,7 @@
   <OverviewCard
     :title="totalMonthlyClaim"
     subtitle="Month Claimed"
-    color="warning"
+    variant="warning"
     :card-icon="cartIcon"
     :loading="isFetching"
   >

--- a/app/src/components/sections/CashRemunerationView/CashRemunerationPendingClaim.vue
+++ b/app/src/components/sections/CashRemunerationView/CashRemunerationPendingClaim.vue
@@ -2,7 +2,7 @@
   <OverviewCard
     :title="totalPendingAmount"
     subtitle="Pending Claim"
-    color="info"
+    variant="info"
     :card-icon="personIcon"
     :loading="isFetching"
   >

--- a/app/src/components/sections/CashRemunerationView/CashRemunerationTotalBalance.vue
+++ b/app/src/components/sections/CashRemunerationView/CashRemunerationTotalBalance.vue
@@ -1,7 +1,7 @@
 <template>
   <OverviewCard
     :title="total[currency.code]?.formated ?? 0"
-    color="success"
+    variant="success"
     subtitle="Total Balance"
     :card-icon="bagIcon"
     :loading="isLoadingBalance"

--- a/app/src/components/sections/ExpenseAccountView/ExpenseAccountBalance.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseAccountBalance.vue
@@ -3,7 +3,7 @@
     data-test="expense-account-balance"
     :title="total[currencyStore.localCurrency.code]?.formated ?? 0"
     subtitle="Total Balance"
-    color="success"
+    variant="success"
     :card-icon="bagIcon"
     :loading="isLoading"
   />

--- a/app/src/components/sections/ExpenseAccountView/ExpenseAccountTotalApproved.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseAccountTotalApproved.vue
@@ -2,7 +2,7 @@
   <OverviewCard
     :title="totalApproved"
     subtitle="Total Approved"
-    color="info"
+    variant="info"
     :card-icon="personIcon"
     :loading="isLoading"
   />

--- a/app/src/components/sections/ExpenseAccountView/ExpenseMonthSpent.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseMonthSpent.vue
@@ -2,7 +2,7 @@
   <OverviewCard
     :title="totalMonthlySpentAmount"
     subtitle="Month Spent"
-    color="warning"
+    variant="warning"
     :card-icon="cartIcon"
     :loading="loading"
   >

--- a/app/src/components/sections/SherTokenView/InvestorsHeader.vue
+++ b/app/src/components/sections/SherTokenView/InvestorsHeader.vue
@@ -3,7 +3,7 @@
     <OverviewCard
       :title="`${shareholdersCount} Investors`"
       subtitle="Investors"
-      color="info"
+      variant="info"
       :card-icon="personIcon"
       :loading="!teamStore.currentTeam"
     >
@@ -15,7 +15,7 @@
           : '...'
       "
       subtitle="Your Balance"
-      color="success"
+      variant="success"
       :card-icon="bagIcon"
       :loading="!teamStore.currentTeam"
     >
@@ -27,7 +27,7 @@
           : '...'
       "
       subtitle="Total Supply"
-      color="warning"
+      variant="warning"
       :card-icon="cartIcon"
       :loading="!teamStore.currentTeam"
     >


### PR DESCRIPTION
## What

Renames the `OverviewCard` caller attribute from `color` to `variant` at all 9 call sites (across 7 files). The `OverviewCard` component itself is unchanged — `variant` is the correct, intended API.

## Why

`OverviewCard` declares a `variant` prop that drives `bgColor`/`textColor`, but every caller was passing `color`. Vue silently ignored the unknown attribute, so `variant` stayed at its default `'primary'` and all stat cards rendered with `bg-white` instead of their intended green/amber/blue.

## Changes

| File | Before | After |
| --- | --- | --- |
| `ExpenseAccountBalance.vue` | `color="success"` | `variant="success"` |
| `ExpenseMonthSpent.vue` | `color="warning"` | `variant="warning"` |
| `ExpenseAccountTotalApproved.vue` | `color="info"` | `variant="info"` |
| `CashRemunerationPendingClaim.vue` | `color="info"` | `variant="info"` |
| `CashRemunerationTotalBalance.vue` | `color="success"` | `variant="success"` |
| `CashRemunerationMonthlyClaim.vue` | `color="warning"` | `variant="warning"` |
| `InvestorsHeader.vue` (×3) | `color="info" / "success" / "warning"` | `variant="…"` |

## Tests

`npx vitest run` on `OverviewCard.spec.ts` plus the 6 caller specs (Cash Remuneration ×3, Expense ×3 incl. ExpenseAccountTable, InvestorsHeader): **68 / 68 passing**.

Closes #1972
