### PR TITLE
fix: 🔒 Disable public source maps in production

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -7,5 +7,11 @@ VITE_APP_CHAIN_ID=
 VITE_APP_CURRENCY_SYMBOL=
 VITE_APP_BLOCK_EXPLORER_URL=
 VITE_SENTRY_DSN=
+# Sentry source map upload (build-time only, never exposed to browser)
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=cnc-portal-app
+# Optional: tag Sentry releases with a git SHA or semver
+VITE_RELEASE=
 VITE_APP_TREASURY_SIGNER=
 VITE_APP_BOD_SIGNER=

--- a/app/.env.example
+++ b/app/.env.example
@@ -11,7 +11,7 @@ VITE_SENTRY_DSN=
 SENTRY_AUTH_TOKEN=
 SENTRY_ORG=
 SENTRY_PROJECT=cnc-portal-app
-# Optional: tag Sentry releases with a git SHA or semver
-VITE_RELEASE=
+# Optional: tag Sentry releases with a git SHA or semver (exposed to browser)
+VITE_APP_RELEASE=
 VITE_APP_TREASURY_SIGNER=
 VITE_APP_BOD_SIGNER=

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,7 +61,7 @@ export default defineConfig(({ mode }) => {
           deleteAfterUpload: true
         },
         release: {
-          name: process.env.VITE_RELEASE ?? undefined
+          name: process.env.VITE_APP_RELEASE ?? undefined
         }
       })
     )

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -6,6 +6,7 @@ import ui from '@nuxt/ui/vite'
 import vueDevTools from 'vite-plugin-vue-devtools'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import tailwindcss from '@tailwindcss/vite'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 
 export const ENV_LIST = ['VITE_APP_BACKEND_URL', 'VITE_APP_NETWORK_ALIAS']
 const SUPPORTED_NETWORKS = ['sepolia', 'hardhat', 'amoy', 'polygon']
@@ -42,6 +43,28 @@ export default defineConfig(({ mode }) => {
 
   if (!process.env.CI) {
     plugins.push(vueDevTools())
+  }
+
+  const isProd = mode === 'production'
+
+  // Upload source maps to Sentry in production and delete them from dist/
+  // so they are never served to end-users (hidden sourcemap).
+  if (isProd && process.env.SENTRY_AUTH_TOKEN) {
+    plugins.push(
+      sentryVitePlugin({
+        org: process.env.SENTRY_ORG,
+        project: process.env.SENTRY_PROJECT ?? 'cnc-portal-app',
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+        sourcemaps: {
+          // Remove .map files from the dist folder after upload so they
+          // are never accessible to end-users.
+          deleteAfterUpload: true
+        },
+        release: {
+          name: process.env.VITE_RELEASE ?? undefined
+        }
+      })
+    )
   }
 
   return {
@@ -92,7 +115,10 @@ export default defineConfig(({ mode }) => {
       port: 5173
     },
     build: {
-      sourcemap: true
+      // 'hidden' generates source maps but does NOT reference them in the
+      // output files, so browsers cannot load them. The Sentry plugin above
+      // uploads them to Sentry (prod only) and then deletes them from dist/.
+      sourcemap: isProd ? 'hidden' : true
     },
     css: {
       devSourcemap: true


### PR DESCRIPTION
Closes #1998

## What

- `sourcemap: true` → `sourcemap: 'hidden'` for production builds in `app/vite.config.ts`
- Wire up `@sentry/vite-plugin` (already installed, never used) with `deleteAfterUpload: true`
- Rename `VITE_RELEASE` → `VITE_APP_RELEASE` to follow the project `VITE_APP_*` convention
- Document new build-time env vars in `app/.env.example`

## Why

`sourcemap: true` embeds `.map` file references directly in the compiled JS bundles. Browsers load them automatically, exposing the full TypeScript source in DevTools to anyone.

`'hidden'` generates the same files but omits the reference — browsers never find them, while the Sentry plugin can still read and upload them before deleting them from `dist/`.

Side effect: Sentry stack traces will now be source-mapped (they were minified before because the plugin was never activated).

## How to test

```bash
cd app
npm run build
# Verify no .map files remain in dist/
find dist -name '*.map'   # should be empty
# Verify no sourceMappingURL comment in any JS bundle
grep -r 'sourceMappingURL' dist/assets/*.js   # should be empty
```

## Required env vars (CI / Railway)

| Variable | Used by | Purpose |
|---|---|---|
| `SENTRY_AUTH_TOKEN` | build (Node) | Upload maps to Sentry |
| `SENTRY_ORG` | build (Node) | Sentry org slug |
| `SENTRY_PROJECT` | build (Node) | Defaults to `cnc-portal-app` |
| `VITE_APP_RELEASE` | build + browser | Optional release tag (git SHA / semver) |