### PR TITLE
fix: remove hardhat console imports from production contracts

### DIFF
--- a/.github/workflows/contract-code-quality.yml
+++ b/.github/workflows/contract-code-quality.yml
@@ -30,6 +30,14 @@ jobs:
         run: npm run compile
         working-directory: ./contract
 
+      - name: </> Reject hardhat console imports
+        run: |
+          if grep -R --line-number --include='*.sol' "hardhat/console\.sol" contracts --exclude-dir=test --exclude-dir=mocks; then
+            echo "::error::Remove hardhat/console.sol imports from production contracts"
+            exit 1
+          fi
+        working-directory: ./contract
+
       - name: </> Run Format Check
         run: npm run format-check
         working-directory: ./contract

--- a/contract/contracts/CashRemunerationEIP712.sol
+++ b/contract/contracts/CashRemunerationEIP712.sol
@@ -13,7 +13,6 @@ import './base/TokenSupport.sol';
 import {IMintableERC20} from './interfaces/IMintableERC20.sol';
 import {IInvestorV1} from './interfaces/IInvestorV1.sol';
 import {IOfficer} from './interfaces/IOfficer.sol';
-import 'hardhat/console.sol';
 
 /**
  * @title CashRemunerationEIP712

--- a/contract/contracts/Voting/Voting.sol
+++ b/contract/contracts/Voting/Voting.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.24;
 
 import './Types.sol';
-import 'hardhat/console.sol';
 
 import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol';


### PR DESCRIPTION
## Summary
- remove `hardhat/console.sol` imports from `CashRemunerationEIP712` and `Voting`
- add a CI grep guard that rejects future production imports under `contracts/`, excluding `contracts/test` and `contracts/mocks`

Fixes #1992

## Validation
- `npm run compile`
- `npm run lint:sol`
- local CI-equivalent grep guard: no production console imports
- `git diff --check`

`npm run format-check` currently fails on existing Prettier drift across 39 Solidity files in this branch, so this PR leaves repo-wide formatting out of scope.

## Bytecode sanity check
Compared `origin/develop` compiled in a clean worktree against this branch:

| Contract | Deployed bytes before | Deployed bytes after | Delta | Init bytes before | Init bytes after | Delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `CashRemunerationEIP712` | 11020 | 11020 | 0 | 11250 | 11250 | 0 |
| `Voting` | 13023 | 13023 | 0 | 13253 | 13253 | 0 |

Hardhat compile drops from 85 Solidity files to 84 because `hardhat/console.sol` is no longer compiled. The affected contract bytecode itself is unchanged because these imports were unused.
