### PR TITLE
chore: 🔧 Sentry config cleanup — orphaned dep, missing env var, hardcoded org

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -13,5 +13,6 @@ SENTRY_ORG=
 SENTRY_PROJECT=cnc-portal-app
 # Optional: tag Sentry releases with a git SHA or semver (exposed to browser)
 VITE_APP_RELEASE=
+VITE_APP_SUBGRAPH_ENDPOINT=
 VITE_APP_TREASURY_SIGNER=
 VITE_APP_BOD_SIGNER=

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -17,7 +17,6 @@
         "@safe-global/api-kit": "^4.0.1",
         "@safe-global/protocol-kit": "^6.1.2",
         "@safe-global/safe-core-sdk-types": "^5.1.0",
-        "@sentry/cli": "^2.53.0",
         "@sentry/vite-plugin": "^4.3.0",
         "@sentry/vue": "^10.11.0",
         "@tailwindcss/vite": "^4.1.18",
@@ -4720,16 +4719,6 @@
         }
       }
     },
-    "node_modules/@synthetixio/ethereum-wallet-mock/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@synthetixio/synpress": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@synthetixio/synpress/-/synpress-4.1.2.tgz",
@@ -8499,16 +8488,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dayjs": {

--- a/app/package.json
+++ b/app/package.json
@@ -40,7 +40,6 @@
     "@safe-global/api-kit": "^4.0.1",
     "@safe-global/protocol-kit": "^6.1.2",
     "@safe-global/safe-core-sdk-types": "^5.1.0",
-    "@sentry/cli": "^2.53.0",
     "@sentry/vite-plugin": "^4.3.0",
     "@sentry/vue": "^10.11.0",
     "@tailwindcss/vite": "^4.1.18",

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,6 +16,8 @@ CHAIN_ID=11155111 # Sepolia Testnet
 SENTRY_DSN=
 # Sentry source map upload (build-time only, never exposed to clients)
 SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=cnc-portal-api
 # Full DSN of the frontend Sentry project — used by the tunnel route to
 # compute the ingest URL server-side (prevents SSRF).
 SENTRY_FRONTEND_DSN=

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "build": "tsc && npm run sentry:sourcemaps",
+    "build": "tsc && ([ -z \"$SENTRY_AUTH_TOKEN\" ] || npm run sentry:sourcemaps)",
     "prod": "node  dist/index.js",
     "copy:docs": "npx shx cp src/utils/backend_specs.html dist/utils/backend_specs.html",
     "db:wake": "ts-node scripts/wake-db.ts",

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,7 +33,7 @@
     "seed:test": "NODE_ENV=test ts-node prisma/seed.ts",
     "seed:staging": "NODE_ENV=staging ts-node prisma/seed.ts",
     "seed:reset": "npx prisma migrate reset --force && npm run seed",
-    "sentry:sourcemaps": "sentry-cli sourcemaps inject --org global-citizen-g6 --project cnc-portal-api ./dist && sentry-cli sourcemaps upload --org global-citizen-g6 --project cnc-portal-api ./dist"
+    "sentry:sourcemaps": "sentry-cli sourcemaps inject --org $SENTRY_ORG --project $SENTRY_PROJECT ./dist && sentry-cli sourcemaps upload --org $SENTRY_ORG --project $SENTRY_PROJECT ./dist"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Closes #2006

## Changes

### `app/package.json`
- Remove `@sentry/cli` — orphaned after `sentry:releases` script deletion; `sentryVitePlugin` bundles its own CLI

### `app/.env.example`
- Add `VITE_APP_SUBGRAPH_ENDPOINT` — used by `apollo-client` and `tracePropagationTargets`, was missing

### `backend/package.json`
- `sentry:sourcemaps`: replace hardcoded `--org global-citizen-g6 --project cnc-portal-api` with `$SENTRY_ORG` / `$SENTRY_PROJECT`

### `backend/.env.example`
- Add `SENTRY_ORG` and `SENTRY_PROJECT` to document the new vars