### PR TITLE
test: ✅ isolate shared test mocks with factories + global auto-reset

### DIFF
--- a/app/src/components/forms/__tests__/CompensationAmount.advanced.spec.ts
+++ b/app/src/components/forms/__tests__/CompensationAmount.advanced.spec.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import CompensationAmount from '../CompensationAmount.vue'
 import { nextTick } from 'vue'
-import { mockInvestorReads, resetContractMocks } from '@/tests/mocks'
+import { mockInvestorReads } from '@/tests/mocks'
 
 // Test constants
 const SELECTORS = {
@@ -21,12 +21,7 @@ const MOCK_DATA = {
 describe('CompensationAmount - Advanced Features', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetContractMocks()
     mockInvestorReads.symbol.data.value = MOCK_DATA.tokenSymbol
-  })
-
-  afterEach(() => {
-    resetContractMocks()
   })
 
   const createWrapper = (props = {}) => {

--- a/app/src/components/forms/__tests__/CompensationAmout.spec.ts
+++ b/app/src/components/forms/__tests__/CompensationAmout.spec.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import CompensationAmount from '../CompensationAmount.vue'
 import { nextTick } from 'vue'
-import { mockInvestorReads, resetContractMocks } from '@/tests/mocks'
+import { mockInvestorReads } from '@/tests/mocks'
 
 // Test constants
 const SELECTORS = {
@@ -31,12 +31,7 @@ const MOCK_DATA = {
 describe('CompensationAmount', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetContractMocks()
     mockInvestorReads.symbol.data.value = MOCK_DATA.tokenSymbol
-  })
-
-  afterEach(() => {
-    resetContractMocks()
   })
 
   const createWrapper = (props = {}) => {

--- a/app/src/components/forms/__tests__/DepositBankForm.spec.ts
+++ b/app/src/components/forms/__tests__/DepositBankForm.spec.ts
@@ -10,8 +10,6 @@ import {
   mockERC20Reads,
   mockERC20Writes,
   mockBankWrites,
-  resetComposableMocks,
-  resetERC20Mocks,
   useQueryClientFn
 } from '@/tests/mocks'
 
@@ -65,8 +63,6 @@ const setTokenAmount = async (
 describe('DepositBankForm.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetComposableMocks()
-    resetERC20Mocks()
     createQueryClient()
     mockBankWrites.deposit.mutateAsync.mockResolvedValue(undefined)
   })

--- a/app/src/components/forms/__tests__/DepositSafeForm.spec.ts
+++ b/app/src/components/forms/__tests__/DepositSafeForm.spec.ts
@@ -9,8 +9,6 @@ import {
   mockUseSafeSendTransaction,
   mockERC20Reads,
   mockERC20Writes,
-  resetTransactionMocks,
-  resetERC20Mocks,
   useQueryClientFn
 } from '@/tests/mocks'
 
@@ -73,8 +71,6 @@ describe('DepositSafeForm.vue', () => {
   }
 
   beforeEach(() => {
-    resetTransactionMocks()
-    resetERC20Mocks()
     createQueryClient()
   })
 

--- a/app/src/components/forms/__tests__/SafeDepositRouterForm.spec.ts
+++ b/app/src/components/forms/__tests__/SafeDepositRouterForm.spec.ts
@@ -10,10 +10,7 @@ import {
   mockSafeDepositRouterReads,
   mockSafeDepositRouterWrites,
   mockInvestorReads,
-  mockParseError,
-  resetComposableMocks,
-  resetERC20Mocks,
-  resetSafeDepositRouterMocks
+  mockParseError
 } from '@/tests/mocks'
 
 type MutateOptions = {
@@ -76,9 +73,6 @@ const rejectOnError = (mutateAsync: ReturnType<typeof vi.fn>, err: Error) =>
 describe('SafeDepositRouterForm.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetComposableMocks()
-    resetERC20Mocks()
-    resetSafeDepositRouterMocks()
     mockInvestorReads.symbol.data.value = 'SHER'
     mockUseContractBalance.balances.value = [
       {

--- a/app/src/components/sections/AdministrationView/__tests__/PublishResult.spec.ts
+++ b/app/src/components/sections/AdministrationView/__tests__/PublishResult.spec.ts
@@ -2,12 +2,7 @@ import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { nextTick } from 'vue'
 import PublishResult from '../PublishResult.vue'
-import {
-  mockElectionsWrites,
-  resetContractMocks,
-  useQueryClientFn,
-  mockWagmiCore
-} from '@/tests/mocks'
+import { mockElectionsWrites, useQueryClientFn, mockWagmiCore } from '@/tests/mocks'
 import { useTeamStore } from '@/stores'
 
 vi.mock('@/constant', () => ({
@@ -37,7 +32,6 @@ describe('PublishResult.vue', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    resetContractMocks()
 
     vi.mocked(useTeamStore).mockImplementation(
       () =>

--- a/app/src/components/sections/CashRemunerationView/__tests__/SubmitClaims.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/__tests__/SubmitClaims.spec.ts
@@ -45,7 +45,6 @@ describe('SubmitClaims', () => {
     vi.clearAllMocks()
 
     mockTeamStore.currentTeamId = '1'
-    mockToast.add.mockClear()
   })
 
   afterEach(() => {

--- a/app/src/components/sections/ContractManagementView/forms/__tests__/CreateAddCampaign.spec.ts
+++ b/app/src/components/sections/ContractManagementView/forms/__tests__/CreateAddCampaign.spec.ts
@@ -1,7 +1,7 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import CreateAddCampaign from '@/components/sections/ContractManagementView/forms/CreateAddCampaign.vue'
-import { mockDeployState, resetDeployState } from '@/tests/mocks/composables.mock'
+import { mockDeployState } from '@/tests/mocks/composables.mock'
 import { useCreateContractMutation } from '@/queries/contract.queries'
 import { useTeamStore } from '@/stores'
 import { mockTeamStore } from '@/tests/mocks/store.mock'
@@ -12,7 +12,6 @@ const mountComponent = () => mount(CreateAddCampaign)
 describe('CreateAddCampaign.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetDeployState()
   })
 
   describe('rendering', () => {

--- a/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseAccountTable.actions.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/ExpenseAccountTable.actions.spec.ts
@@ -13,8 +13,7 @@ import {
   mockUseBalance,
   mockUseReadContract,
   mockUseSignTypedData,
-  mockUserStore,
-  resetContractMocks
+  mockUserStore
 } from '@/tests/mocks'
 import { useGetExpensesQuery } from '@/queries/expense.queries'
 
@@ -133,7 +132,6 @@ describe('ExpenseAccountTable - Actions and Loading', () => {
     mockUseBalance.data.value = null
     mockUseSignTypedData.data.value = '0xExpenseDataSignature'
     mockUseSignTypedData.error.value = null
-    resetContractMocks()
 
     vi.mocked(useGetExpensesQuery).mockReturnValue(
       createMockQueryResponse(mockApprovals) as ReturnType<typeof useGetExpensesQuery>

--- a/app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts
@@ -4,12 +4,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { ref } from 'vue'
 import { readContract, estimateGas } from '@wagmi/core'
 import TransferAction from '../TransferAction.vue'
-import {
-  mockExpenseAccountWrites,
-  mockERC20Writes,
-  resetContractMocks,
-  resetERC20Mocks
-} from '@/tests/mocks'
+import { mockExpenseAccountWrites, mockERC20Writes } from '@/tests/mocks'
 
 vi.mock('@/utils', () => ({
   log: { error: vi.fn() },
@@ -86,8 +81,6 @@ describe('TransferAction.vue', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
-    resetContractMocks()
-    resetERC20Mocks()
     vi.mocked(estimateGas).mockResolvedValue(21000n)
   })
 

--- a/app/src/components/sections/SafeView/__tests__/RemoveOwnerButton.spec.ts
+++ b/app/src/components/sections/SafeView/__tests__/RemoveOwnerButton.spec.ts
@@ -2,15 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import RemoveOwnerButton from '../RemoveOwnerButton.vue'
+import { mockUserStore } from '@/tests/mocks/store.mock'
 
-const { mockChainId, mockIsPending, mockLogError, mockUserStore, mockUpdateOwnersMutate } =
-  vi.hoisted(() => ({
-    mockChainId: { value: 137 },
-    mockIsPending: { value: false },
-    mockLogError: vi.fn(),
-    mockUserStore: { address: '0x1111111111111111111111111111111111111111' },
-    mockUpdateOwnersMutate: vi.fn()
-  }))
+const { mockChainId, mockIsPending, mockLogError, mockUpdateOwnersMutate } = vi.hoisted(() => ({
+  mockChainId: { value: 137 },
+  mockIsPending: { value: false },
+  mockLogError: vi.fn(),
+  mockUpdateOwnersMutate: vi.fn()
+}))
 
 vi.mock('@wagmi/vue', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@wagmi/vue')>()
@@ -25,10 +24,6 @@ vi.mock('@/queries/safe.mutations', () => ({
     mutate: mockUpdateOwnersMutate,
     isPending: mockIsPending
   })
-}))
-
-vi.mock('@/stores', () => ({
-  useUserDataStore: () => mockUserStore
 }))
 
 vi.mock('@/utils', () => ({

--- a/app/src/components/sections/SafeView/forms/__tests__/AddSignerModal.spec.ts
+++ b/app/src/components/sections/SafeView/forms/__tests__/AddSignerModal.spec.ts
@@ -81,7 +81,6 @@ describe('AddSignerModal', () => {
     vi.clearAllMocks()
     mockUpdateOwnersPending.value = false
     mockUpdateOwnersMutate.mockImplementation(() => undefined)
-    mockToast.add.mockReset()
   })
 
   afterEach(() => {

--- a/app/src/components/sections/SafeView/forms/__tests__/UpdateThresholdModal.spec.ts
+++ b/app/src/components/sections/SafeView/forms/__tests__/UpdateThresholdModal.spec.ts
@@ -3,7 +3,6 @@ import UpdateThresholdModal from '@/components/sections/SafeView/forms/UpdateThr
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, type ComponentPublicInstance } from 'vue'
 import { mount } from '@vue/test-utils'
-import { mockToast } from '@/tests/mocks/store.mock'
 
 interface UpdateThresholdModalVm extends ComponentPublicInstance {
   formState: {
@@ -107,7 +106,6 @@ describe('UpdateThresholdModal', () => {
     mockChainId.value = 137
     mockUpdateOwnersPending.value = false
     mockUpdateOwnersMutate.mockImplementation(() => undefined)
-    mockToast.add.mockReset()
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
   })
 

--- a/app/src/components/sections/SherTokenView/InvestorActions/__tests__/DistributeMintAction.spec.ts
+++ b/app/src/components/sections/SherTokenView/InvestorActions/__tests__/DistributeMintAction.spec.ts
@@ -4,7 +4,7 @@ import { createTestingPinia } from '@pinia/testing'
 import { nextTick } from 'vue'
 import type { Address } from 'viem'
 import DistributeMintAction from '@/components/sections/SherTokenView/InvestorActions/DistributeMintAction.vue'
-import { mockInvestorWrites, resetContractMocks, mockLog } from '@/tests/mocks'
+import { mockInvestorWrites, mockLog } from '@/tests/mocks'
 
 type DistributeOptions = {
   onSuccess?: () => void
@@ -36,7 +36,6 @@ describe('DistributeMintAction.vue', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    resetContractMocks()
   })
 
   it('renders with coming soon tooltip', () => {

--- a/app/src/components/sections/SherTokenView/InvestorActions/__tests__/PayDividendsAction.spec.ts
+++ b/app/src/components/sections/SherTokenView/InvestorActions/__tests__/PayDividendsAction.spec.ts
@@ -12,8 +12,7 @@ import {
   mockLog,
   mockTeamStore,
   mockToast,
-  mockUserStore,
-  resetContractMocks
+  mockUserStore
 } from '@/tests/mocks'
 
 describe('PayDividendsAction.vue', () => {
@@ -52,7 +51,6 @@ describe('PayDividendsAction.vue', () => {
     })
 
   beforeEach(() => {
-    resetContractMocks()
     vi.clearAllMocks()
     vi.stubGlobal('useToast', () => mockToast)
 

--- a/app/src/components/sections/SherTokenView/InvestorActions/__tests__/SetCompensationMultiplierAction.spec.ts
+++ b/app/src/components/sections/SherTokenView/InvestorActions/__tests__/SetCompensationMultiplierAction.spec.ts
@@ -8,8 +8,7 @@ import {
   mockSafeDepositRouterAddress,
   mockSafeDepositRouterReads,
   mockSafeDepositRouterWrites,
-  mockUseConnection,
-  resetSafeDepositRouterMocks
+  mockUseConnection
 } from '@/tests/mocks'
 
 describe('SetCompensationMultiplierAction.vue', () => {
@@ -23,7 +22,6 @@ describe('SetCompensationMultiplierAction.vue', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    resetSafeDepositRouterMocks()
     mockParseError.mockReturnValue('Parsed error message')
 
     mockSafeDepositRouterAddress.value = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'

--- a/app/src/components/sections/SherTokenView/InvestorActions/__tests__/ToggleSherCompensationAction.spec.ts
+++ b/app/src/components/sections/SherTokenView/InvestorActions/__tests__/ToggleSherCompensationAction.spec.ts
@@ -9,8 +9,7 @@ import {
   mockSafeDepositRouterReads,
   mockSafeDepositRouterWrites,
   mockTeamStore,
-  mockUseConnection,
-  resetSafeDepositRouterMocks
+  mockUseConnection
 } from '@/tests/mocks'
 
 describe('ToggleSherCompensationAction.vue', () => {
@@ -24,7 +23,6 @@ describe('ToggleSherCompensationAction.vue', () => {
   beforeEach(() => {
     vi.useRealTimers()
     vi.clearAllMocks()
-    resetSafeDepositRouterMocks()
     mockParseError.mockReturnValue('Parsed error message')
 
     mockSafeDepositRouterAddress.value = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'

--- a/app/src/components/sections/SherTokenView/__tests__/InvestorsActions.spec.ts
+++ b/app/src/components/sections/SherTokenView/__tests__/InvestorsActions.spec.ts
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
 import InvestorsActions from '@/components/sections/SherTokenView/InvestorsActions.vue'
 import type { Address } from 'viem'
-import { mockInvestorReads, mockTeamStore, resetContractMocks } from '@/tests/mocks'
+import { mockInvestorReads, mockTeamStore } from '@/tests/mocks'
 
 const DistributeMintActionStub = {
   props: ['tokenSymbol', 'investorsAddress'],
@@ -34,7 +34,6 @@ const SetCompensationMultiplierButtonStub = {
 
 describe('InvestorsActions.vue', () => {
   beforeEach(() => {
-    resetContractMocks()
     vi.clearAllMocks()
 
     mockTeamStore.getContractAddressByType = vi.fn((type: string) => {

--- a/app/src/components/sections/SherTokenView/__tests__/InvestorsHeader.spec.ts
+++ b/app/src/components/sections/SherTokenView/__tests__/InvestorsHeader.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { createTestingPinia } from '@pinia/testing'
 import InvestorsHeader from '../InvestorsHeader.vue'
 import { parseUnits } from 'viem'
-import { mockInvestorReads, mockTeamStore, mockUserStore, resetContractMocks } from '@/tests/mocks'
+import { mockInvestorReads, mockTeamStore, mockUserStore } from '@/tests/mocks'
 
 describe('InvestorsHeader', () => {
   let wrapper: ReturnType<typeof mount>
@@ -25,7 +25,6 @@ describe('InvestorsHeader', () => {
   } as const
 
   beforeEach(() => {
-    resetContractMocks()
     vi.clearAllMocks()
 
     // Initialize store state

--- a/app/src/components/sections/SherTokenView/__tests__/ShareholderList.spec.ts
+++ b/app/src/components/sections/SherTokenView/__tests__/ShareholderList.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import ShareholderList from '../../SherTokenView/ShareholderList.vue'
 import { parseEther, parseUnits, type Address } from 'viem'
 import { createTestingPinia } from '@pinia/testing'
-import { mockInvestorReads, mockTeamStore, mockUserStore, resetContractMocks } from '@/tests/mocks'
+import { mockInvestorReads, mockTeamStore, mockUserStore } from '@/tests/mocks'
 
 interface ComponentData {
   mintIndividualModal: { mount: boolean; show: boolean }
@@ -26,7 +26,6 @@ const MintFormStub = {
 
 describe('ShareholderList', () => {
   beforeEach(() => {
-    resetContractMocks()
     vi.clearAllMocks()
 
     mockTeamStore.currentTeam = {

--- a/app/src/components/sections/SherTokenView/forms/__tests__/MintForm.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/MintForm.spec.ts
@@ -4,13 +4,7 @@ import { createTestingPinia } from '@pinia/testing'
 import { ref } from 'vue'
 import { parseUnits } from 'viem'
 import MintForm from '../MintForm.vue'
-import {
-  mockToast,
-  mockTeamStore,
-  mockInvestorWrites,
-  resetContractMocks,
-  useReadContractFn
-} from '@/tests/mocks'
+import { mockToast, mockTeamStore, mockInvestorWrites, useReadContractFn } from '@/tests/mocks'
 
 const VALID_ADDRESS = '0x1234567890123456789012345678901234567890'
 
@@ -73,7 +67,6 @@ describe('MintForm.vue', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    resetContractMocks()
     vi.stubGlobal('useToast', () => mockToast)
 
     symbolRef.value = 'SHER'

--- a/app/src/components/sections/SherTokenView/forms/__tests__/PayDividendsForm.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/PayDividendsForm.spec.ts
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils'
 import PayDividendsForm from '../PayDividendsForm.vue'
 import { createTestingPinia } from '@pinia/testing'
 import type { Team } from '@/types'
-import { mockUseContractBalance, resetComposableMocks } from '@/tests/mocks'
+import { mockUseContractBalance } from '@/tests/mocks'
 
 type BalanceEntry = {
   amount: number
@@ -181,7 +181,6 @@ describe('PayDividendsForm.vue', () => {
     })
 
   afterEach(() => {
-    resetComposableMocks()
     vi.clearAllMocks()
     mockUseContractBalance.balances.value = []
   })

--- a/app/src/components/sections/__tests__/OwnerTreasuryWithdrawAction.spec.ts
+++ b/app/src/components/sections/__tests__/OwnerTreasuryWithdrawAction.spec.ts
@@ -14,8 +14,6 @@ import {
   mockUseChainId,
   mockUseContractBalance,
   mockUserStore,
-  resetComposableMocks,
-  resetContractMocks,
   useQueryClientFn
 } from '@/tests/mocks'
 
@@ -83,8 +81,6 @@ describe('OwnerTreasuryWithdrawAction', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
-    resetContractMocks()
-    resetComposableMocks()
     vi.mocked(useQueryClientFn).mockReturnValue({
       invalidateQueries,
       getQueryData: vi.fn(),

--- a/app/src/composables/bank/__tests__/bankWrites.spec.ts
+++ b/app/src/composables/bank/__tests__/bankWrites.spec.ts
@@ -4,12 +4,11 @@ import {
   useDistributeNativeDividends,
   useDistributeTokenDividends
 } from '../writes'
-import { mockBankWrites, resetContractMocks } from '@/tests/mocks'
+import { mockBankWrites } from '@/tests/mocks'
 
 describe('Bank Contract Writes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetContractMocks()
   })
 
   it('useDepositToken returns the deposit mutation', () => {

--- a/app/src/composables/bod/__tests__/reads.spec.ts
+++ b/app/src/composables/bod/__tests__/reads.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useBodOwner, useBodIsActionExecuted, useBodIsMember } from '../reads'
-import { mockBODReads, resetContractMocks } from '@/tests/mocks'
+import { mockBODReads } from '@/tests/mocks'
 import type { Address } from 'viem'
 
 const MOCK_DATA = {
@@ -12,7 +12,6 @@ const MOCK_DATA = {
 describe('BOD Contract Reads', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetContractMocks()
   })
 
   it('useBodOwner returns the owner mock', () => {

--- a/app/src/composables/bod/__tests__/writes.spec.ts
+++ b/app/src/composables/bod/__tests__/writes.spec.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useBodAddAction, useBodApproveAction } from '../writes'
-import { mockBodAddAction, mockBodApproveAction, resetContractMocks } from '@/tests/mocks'
+import { mockBodAddAction, mockBodApproveAction } from '@/tests/mocks'
 
 describe('BOD Contract Writes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetContractMocks()
   })
 
   describe('useBodAddAction', () => {

--- a/app/src/composables/elections/__tests__/reads.spec.ts
+++ b/app/src/composables/elections/__tests__/reads.spec.ts
@@ -24,7 +24,6 @@ const MOCK_DATA = {
 describe('Elections Contract Reads', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetContractMocks()
   })
 
   describe('useElectionsAddress', () => {

--- a/app/src/composables/erc20/__tests__/reads.spec.ts
+++ b/app/src/composables/erc20/__tests__/reads.spec.ts
@@ -12,7 +12,6 @@ const MOCK_DATA = {
 describe('ERC20 Contract Reads', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetERC20Mocks()
   })
 
   it('useErc20BalanceOf returns the balance mock', () => {

--- a/app/src/composables/erc20/__tests__/writes.spec.ts
+++ b/app/src/composables/erc20/__tests__/writes.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useERC20Approve } from '../writes'
-import { mockERC20Writes, resetERC20Mocks } from '@/tests/mocks'
+import { mockERC20Writes } from '@/tests/mocks'
 import type { Address } from 'viem'
 
 const MOCK_DATA = {
@@ -12,7 +12,6 @@ const MOCK_DATA = {
 describe('ERC20 Contract Writes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetERC20Mocks()
   })
 
   it('useERC20Approve returns the approve V3 mutation', () => {

--- a/app/src/composables/investor/__tests__/reads.spec.ts
+++ b/app/src/composables/investor/__tests__/reads.spec.ts
@@ -8,7 +8,7 @@ import {
   useInvestorBalanceOf,
   useInvestorShareholders
 } from '../reads'
-import { mockInvestorReads, resetContractMocks } from '@/tests/mocks'
+import { mockInvestorReads } from '@/tests/mocks'
 import type { Address } from 'viem'
 
 const MOCK_DATA = {
@@ -21,7 +21,6 @@ const MOCK_DATA = {
 describe('Investor Contract Reads', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetContractMocks()
   })
 
   it('useInvestorAddress returns a ref-like value', () => {

--- a/app/src/composables/vesting/__tests__/writes.spec.ts
+++ b/app/src/composables/vesting/__tests__/writes.spec.ts
@@ -4,12 +4,11 @@ import {
   useVestingStopVestingWrite,
   useVestingReleaseWrite
 } from '../writes'
-import { mockVestingWrites, resetContractMocks } from '@/tests/mocks'
+import { mockVestingWrites } from '@/tests/mocks'
 
 describe('Vesting Contract Writes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetContractMocks()
   })
 
   it('useVestingAddVestingWrite returns the addVesting V3 mutation', () => {

--- a/app/src/tests/mocks/composables.mock.ts
+++ b/app/src/tests/mocks/composables.mock.ts
@@ -2,79 +2,90 @@ import { vi } from 'vitest'
 import { ref } from 'vue'
 
 /**
+ * Default builders for the contract-balance mock state. Exposed as functions so
+ * that `resetComposableMocks()` can restore a FRESH copy on every test, even
+ * after a spec has mutated `balances.value` / `total.value` in place.
+ */
+const defaultContractBalances = () => [
+  {
+    amount: 0.5,
+    token: {
+      id: 'native',
+      name: 'SepoliaETH',
+      symbol: 'SepoliaETH',
+      code: 'SepoliaETH',
+      coingeckoId: 'ethereum',
+      decimals: 18,
+      address: '0x0000000000000000000000000000000000000000'
+    },
+    values: {
+      USD: {
+        value: 500,
+        formated: '$500',
+        id: 'usd',
+        code: 'USD',
+        symbol: '$',
+        price: 1000,
+        formatedPrice: '$1K'
+      }
+    }
+  },
+  {
+    amount: 50,
+    token: {
+      id: 'usdc',
+      name: 'USD Coin',
+      symbol: 'USDC',
+      code: 'USDC',
+      coingeckoId: 'usd-coin',
+      decimals: 6,
+      address: '0xA3492D046095AFFE351cFac15de9b86425E235dB'
+    },
+    values: {
+      USD: {
+        value: 50000,
+        formated: '$50K',
+        id: 'usd',
+        code: 'USD',
+        symbol: '$',
+        price: 1000,
+        formatedPrice: '$1K'
+      }
+    }
+  }
+]
+
+const defaultContractTotal = () => ({
+  USD: {
+    value: 50500,
+    formated: '$50.5K',
+    id: 'usd',
+    code: 'USD',
+    symbol: '$',
+    price: 1000,
+    formatedPrice: '$1K'
+  }
+})
+
+const defaultDividendsTotal = () => ({
+  USD: {
+    value: 100,
+    formated: '$100',
+    id: 'usd',
+    code: 'USD',
+    symbol: '$',
+    price: 1000,
+    formatedPrice: '$1K'
+  }
+})
+
+/**
  * Mock useContractBalance composable
  */
 export const mockUseContractBalance = {
-  balances: ref([
-    {
-      amount: 0.5,
-      token: {
-        id: 'native',
-        name: 'SepoliaETH',
-        symbol: 'SepoliaETH',
-        code: 'SepoliaETH',
-        coingeckoId: 'ethereum',
-        decimals: 18,
-        address: '0x0000000000000000000000000000000000000000'
-      },
-      values: {
-        USD: {
-          value: 500,
-          formated: '$500',
-          id: 'usd',
-          code: 'USD',
-          symbol: '$',
-          price: 1000,
-          formatedPrice: '$1K'
-        }
-      }
-    },
-    {
-      amount: 50,
-      token: {
-        id: 'usdc',
-        name: 'USD Coin',
-        symbol: 'USDC',
-        code: 'USDC',
-        coingeckoId: 'usd-coin',
-        decimals: 6,
-        address: '0xA3492D046095AFFE351cFac15de9b86425E235dB'
-      },
-      values: {
-        USD: {
-          value: 50000,
-          formated: '$50K',
-          id: 'usd',
-          code: 'USD',
-          symbol: '$',
-          price: 1000,
-          formatedPrice: '$1K'
-        }
-      }
-    }
-  ]),
-  total: ref({
-    USD: {
-      value: 50500,
-      formated: '$50.5K',
-      id: 'usd',
-      code: 'USD',
-      symbol: '$',
-      price: 1000,
-      formatedPrice: '$1K'
-    }
-  }),
-  dividendsTotal: ref({
-    USD: {
-      value: 100,
-      formated: '$100',
-      id: 'usd',
-      code: 'USD',
-      symbol: '$',
-      price: 1000,
-      formatedPrice: '$1K'
-    }
-  }),
+  balances: ref(defaultContractBalances()),
+  total: ref(defaultContractTotal()),
+  dividendsTotal: ref(defaultDividendsTotal()),
   dividends: ref([]),
   isLoading: ref(false),
   error: ref(null)
@@ -188,7 +199,10 @@ export const mockUseSubmitRestriction = {
  * Reset function for composable mocks
  */
 export const resetComposableMocks = () => {
-  // Reset contract balance loading state
+  // Reset contract balance state (fresh copies so in-place mutations don't leak)
+  mockUseContractBalance.balances.value = defaultContractBalances()
+  mockUseContractBalance.total.value = defaultContractTotal()
+  mockUseContractBalance.dividendsTotal.value = defaultDividendsTotal()
   mockUseContractBalance.isLoading.value = false
   mockUseContractBalance.error.value = null
   mockUseContractBalance.dividends.value = []
@@ -233,6 +247,7 @@ export const resetComposableMocks = () => {
   if (vi.isMockFunction(mockUseFetch.post.execute)) {
     mockUseFetch.post.execute.mockClear()
   }
+  mockUseFetch.get.url.value = ''
   mockUseFetch.get.data.value = null
   mockUseFetch.get.error.value = null
   if (vi.isMockFunction(mockUseFetch.get.execute)) {
@@ -241,6 +256,7 @@ export const resetComposableMocks = () => {
 
   // Reset clipboard mock
   mockUseClipboard.copied.value = false
+  mockUseClipboard.isSupported.value = true
   if (vi.isMockFunction(mockUseClipboard.copy)) {
     mockUseClipboard.copy.mockClear()
   }

--- a/app/src/tests/mocks/query.mock.ts
+++ b/app/src/tests/mocks/query.mock.ts
@@ -108,6 +108,16 @@ export const mockNotificationsRef = ref<Notification[]>([...mockNotificationData
 export const mockUpdateNotificationMutateAsync = vi.fn().mockResolvedValue(undefined)
 
 /**
+ * Restore the shared notifications query mock to its default. `mockNotificationsRef`
+ * is returned by the globally-mocked `useGetNotificationsQuery`, so specs that mutate
+ * `.value` would otherwise leak that list into the next test.
+ */
+export const resetNotificationsMock = () => {
+  mockNotificationsRef.value = [...mockNotificationData]
+  mockUpdateNotificationMutateAsync.mockClear()
+}
+
+/**
  * User Query Mocks
  */
 export const mockUserData: User = {

--- a/app/src/tests/mocks/store.mock.ts
+++ b/app/src/tests/mocks/store.mock.ts
@@ -40,15 +40,47 @@ export const mockToast = {
   add: vi.fn()
 }
 
-export const mockUserStore = {
+interface UserStoreData {
+  address: string
+  name: string
+  nonce: string
+  imageUrl: string
+  isAuth: boolean
+}
+
+const userStoreDataDefaults = (): UserStoreData => ({
   address: '0x0000000000000000000000000000000000000001',
   name: 'Test User',
   nonce: '',
   imageUrl: 'https://example.com/avatar.jpg',
-  isAuth: true,
+  isAuth: true
+})
+
+/**
+ * Build a fully independent user-store mock (fresh data + fresh spies).
+ * Use when a spec needs its own isolated store instance.
+ */
+export const makeUserStore = (overrides: Partial<UserStoreData> = {}) => ({
+  ...userStoreDataDefaults(),
+  ...overrides,
   setUserData: vi.fn(),
   clearUserData: vi.fn(),
   setAuthStatus: vi.fn()
+})
+
+/**
+ * Shared instance returned by the globally-mocked `useUserDataStore`.
+ * Specs set up state by mutating it directly (e.g. `mockUserStore.address = '0x…'`);
+ * `resetUserStoreMock()` (called in a global `beforeEach`) restores defaults so
+ * mutations never leak across tests.
+ */
+export const mockUserStore = makeUserStore()
+
+export const resetUserStoreMock = () => {
+  Object.assign(mockUserStore, userStoreDataDefaults())
+  mockUserStore.setUserData.mockClear()
+  mockUserStore.clearUserData.mockClear()
+  mockUserStore.setAuthStatus.mockClear()
 }
 
 export const mockUseCurrencyStore = () => ({

--- a/app/src/tests/mocks/store.mock.ts
+++ b/app/src/tests/mocks/store.mock.ts
@@ -2,38 +2,68 @@ import { mockTeamData } from '@/tests/mocks/index'
 import type { ContractType } from '@/types/teamContract'
 import { vi } from 'vitest'
 import { ref } from 'vue'
-export const mockTeamStore = {
+const teamStoreDataDefaults = () => ({
   currentTeam: mockTeamData,
   currentTeamId: mockTeamData.id,
   currentTeamMeta: {
     isPending: false,
     data: mockTeamData
-  },
-  teamsMeta: {
-    reloadTeams: vi.fn()
-  },
+  }
+})
 
-  setCurrentTeamId: vi.fn((id: string) => {
-    mockTeamStore.currentTeamId = id
-  }),
-  getContractAddressByType: vi.fn((type: ContractType) => {
-    const contractAddresses = {
-      Bank: '0x1111111111111111111111111111111111111111',
-      InvestorV1: '0x2222222222222222222222222222222222222222',
-      Voting: '0x3333333333333333333333333333333333333333',
-      BoardOfDirectors: '0x4444444444444444444444444444444444444444',
-      ExpenseAccountEIP712: '0x5555555555555555555555555555555555555555',
-      CashRemunerationEIP712: '0x6666666666666666666666666666666666666666',
-      Campaign: '0x7777777777777777777777777777777777777777',
-      Elections: '0x8888888888888888888888888888888888888888',
-      Proposals: '0x9999999999999999999999999999999999999999',
-      VestingV1: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-      SafeDepositRouter: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
-      Safe: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
-    }
-    return contractAddresses[type] || '0x1234567890123456789012345678901234567890'
-  }),
-  fetchTeam: vi.fn()
+const defaultGetContractAddressByType = (type: ContractType) => {
+  const contractAddresses = {
+    Bank: '0x1111111111111111111111111111111111111111',
+    InvestorV1: '0x2222222222222222222222222222222222222222',
+    Voting: '0x3333333333333333333333333333333333333333',
+    BoardOfDirectors: '0x4444444444444444444444444444444444444444',
+    ExpenseAccountEIP712: '0x5555555555555555555555555555555555555555',
+    CashRemunerationEIP712: '0x6666666666666666666666666666666666666666',
+    Campaign: '0x7777777777777777777777777777777777777777',
+    Elections: '0x8888888888888888888888888888888888888888',
+    Proposals: '0x9999999999999999999999999999999999999999',
+    VestingV1: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    SafeDepositRouter: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    Safe: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+  }
+  return contractAddresses[type] || '0x1234567890123456789012345678901234567890'
+}
+
+/**
+ * Build a fully independent team-store mock (fresh data + fresh spies).
+ * Use when a spec needs its own isolated store instance.
+ */
+export const makeTeamStore = (overrides: Record<string, unknown> = {}) => {
+  const store = {
+    ...teamStoreDataDefaults(),
+    teamsMeta: {
+      reloadTeams: vi.fn()
+    },
+    setCurrentTeamId: vi.fn((id: string) => {
+      store.currentTeamId = id
+    }),
+    getContractAddressByType: vi.fn(defaultGetContractAddressByType),
+    fetchTeam: vi.fn(),
+    ...overrides
+  }
+  return store
+}
+
+/**
+ * Shared instance returned by the globally-mocked `useTeamStore`.
+ * Specs set up state by mutating it directly (e.g. `mockTeamStore.currentTeamId = '1'`);
+ * `resetTeamStoreMock()` (called in a global `beforeEach`) restores defaults — including
+ * the default `getContractAddressByType`, which several specs replace with their own spy —
+ * so mutations never leak across tests.
+ */
+export const mockTeamStore = makeTeamStore()
+
+export const resetTeamStoreMock = () => {
+  Object.assign(mockTeamStore, teamStoreDataDefaults())
+  mockTeamStore.getContractAddressByType = vi.fn(defaultGetContractAddressByType)
+  mockTeamStore.setCurrentTeamId.mockClear()
+  mockTeamStore.fetchTeam.mockClear()
+  mockTeamStore.teamsMeta.reloadTeams.mockClear()
 }
 
 export const mockToast = {

--- a/app/src/tests/mocks/wagmi.vue.mock.ts
+++ b/app/src/tests/mocks/wagmi.vue.mock.ts
@@ -134,3 +134,28 @@ export const useChainIdFn = vi.fn(() => mockUseChainId)
 export const useReadContractFn = vi.fn(() => ({ ...mockUseReadContract }))
 export const useSignTypedDataFn = vi.fn(() => ({ ...mockUseSignTypedData }))
 export const useAccountFn = vi.fn(() => ({ ...mockUseAccount }))
+
+/**
+ * Reset the stateful wagmi mocks to their defaults. `transferHash` is a
+ * module-level ref shared via `mockUseWriteContract.data`, so without this it
+ * leaks a tx hash from one test into the next. Read-contract data and the
+ * @wagmi/core action spies are reset too.
+ */
+export const resetWagmiVueMocks = () => {
+  transferHash.value = undefined
+  mockUseWriteContract.isPending.value = false
+  mockUseWriteContract.error.value = null
+  mockUseWriteContract.isError.value = false
+  mockUseWriteContract.status.value = 'idle'
+  mockUseWriteContract.variables.value = undefined
+  mockUseWriteContract.mutate.mockClear()
+  mockUseWriteContract.mutateAsync.mockClear()
+  mockUseWriteContract.reset.mockClear()
+
+  mockUseReadContract.data.value = '0xData'
+  mockUseReadContract.error.value = null
+
+  Object.values(mockWagmiCore).forEach((fn) => {
+    if (vi.isMockFunction(fn)) fn.mockClear()
+  })
+}

--- a/app/src/tests/setup/composables.setup.ts
+++ b/app/src/tests/setup/composables.setup.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { beforeEach, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
 import { queryMocks } from '@/tests/mocks/query.mock'
 import {
@@ -13,11 +13,21 @@ import {
   useMutationFn,
   mockUseFetch,
   mockUseSubmitRestriction,
-  mockUseDeployContract
+  mockUseDeployContract,
+  resetComposableMocks,
+  resetDeployState
 } from '@/tests/mocks/composables.mock'
 import { mockUploadFileApi } from '@/tests/mocks/api.mock'
 import { mockGetBalance, mockGetLogs } from '@/tests/mocks/viem.actions.mock'
 import { mockRouter } from '@/tests/mocks/router.mock'
+
+// Restore all shared composable mocks to their defaults before every test so
+// that in-place mutations (refs, spies) never leak across tests. Setup-file
+// `beforeEach` hooks run BEFORE spec-level ones, so per-test setup still wins.
+beforeEach(() => {
+  resetComposableMocks()
+  resetDeployState()
+})
 
 declare global {
   var __mockFetch: ReturnType<typeof vi.fn> | undefined

--- a/app/src/tests/setup/composables.setup.ts
+++ b/app/src/tests/setup/composables.setup.ts
@@ -1,6 +1,6 @@
 import { beforeEach, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
-import { queryMocks } from '@/tests/mocks/query.mock'
+import { queryMocks, resetNotificationsMock } from '@/tests/mocks/query.mock'
 import {
   mockUseBackendWake,
   mockUseAuth,
@@ -27,6 +27,7 @@ import { mockRouter } from '@/tests/mocks/router.mock'
 beforeEach(() => {
   resetComposableMocks()
   resetDeployState()
+  resetNotificationsMock()
 })
 
 declare global {

--- a/app/src/tests/setup/erc20.setup.ts
+++ b/app/src/tests/setup/erc20.setup.ts
@@ -1,5 +1,10 @@
-import { vi } from 'vitest'
-import { mockERC20Reads, mockERC20Writes } from '../mocks/erc20.mock'
+import { beforeEach, vi } from 'vitest'
+import { mockERC20Reads, mockERC20Writes, resetERC20Mocks } from '../mocks/erc20.mock'
+
+// Restore ERC20 read/write mocks to defaults before every test.
+beforeEach(() => {
+  resetERC20Mocks()
+})
 
 /**
  * Mock ERC20 read composables that are actually consumed. Unused reads

--- a/app/src/tests/setup/safeDepositRouter.setup.ts
+++ b/app/src/tests/setup/safeDepositRouter.setup.ts
@@ -1,9 +1,15 @@
-import { vi } from 'vitest'
+import { beforeEach, vi } from 'vitest'
 import {
   mockSafeDepositRouterAddress,
   mockSafeDepositRouterReads,
-  mockSafeDepositRouterWrites
+  mockSafeDepositRouterWrites,
+  resetSafeDepositRouterMocks
 } from '../mocks/safeDepositRouter.mock'
+
+// Restore SafeDepositRouter read/write mocks to defaults before every test.
+beforeEach(() => {
+  resetSafeDepositRouterMocks()
+})
 
 /**
  * Mock SafeDepositRouter read composables that are actually consumed. Unused

--- a/app/src/tests/setup/store.setup.ts
+++ b/app/src/tests/setup/store.setup.ts
@@ -8,6 +8,7 @@ import * as mocks from '@/tests/mocks/store.mock'
 beforeEach(() => {
   mocks.resetUserStoreMock()
   mocks.resetTeamStoreMock()
+  mocks.mockToast.add.mockClear()
 })
 
 // Convention: mock individual store submodules, not the `@/stores` barrel.

--- a/app/src/tests/setup/store.setup.ts
+++ b/app/src/tests/setup/store.setup.ts
@@ -1,5 +1,13 @@
-import { vi } from 'vitest'
+import { beforeEach, vi } from 'vitest'
 import * as mocks from '@/tests/mocks/store.mock'
+
+// Restore the shared user-store mock to its defaults before every test so that
+// per-spec mutations (e.g. `mockUserStore.address = '0x…'`) never leak across
+// tests. The mock below returns the SAME object reference on every call, so a
+// mutation made before mounting is reliably visible to the component.
+beforeEach(() => {
+  mocks.resetUserStoreMock()
+})
 
 // Convention: mock individual store submodules, not the `@/stores` barrel.
 // `@/stores/index.ts` re-exports each submodule via `export *`, so a mock on
@@ -11,7 +19,7 @@ vi.mock('@/stores/user', async (importOriginal) => {
   const actual: object = await importOriginal()
   return {
     ...actual,
-    useUserDataStore: vi.fn(() => ({ ...mocks.mockUserStore }))
+    useUserDataStore: vi.fn(() => mocks.mockUserStore)
   }
 })
 

--- a/app/src/tests/setup/store.setup.ts
+++ b/app/src/tests/setup/store.setup.ts
@@ -7,6 +7,7 @@ import * as mocks from '@/tests/mocks/store.mock'
 // mutation made before mounting is reliably visible to the component.
 beforeEach(() => {
   mocks.resetUserStoreMock()
+  mocks.resetTeamStoreMock()
 })
 
 // Convention: mock individual store submodules, not the `@/stores` barrel.
@@ -27,7 +28,7 @@ vi.mock('@/stores/teamStore', async (importOriginal) => {
   const actual: object = await importOriginal()
   return {
     ...actual,
-    useTeamStore: vi.fn(() => ({ ...mocks.mockTeamStore }))
+    useTeamStore: vi.fn(() => mocks.mockTeamStore)
   }
 })
 

--- a/app/src/tests/setup/utils.setup.ts
+++ b/app/src/tests/setup/utils.setup.ts
@@ -1,5 +1,11 @@
-import { vi } from 'vitest'
-import { mockLog, mockParseError } from '../mocks/utils.mock'
+import { beforeEach, vi } from 'vitest'
+import { mockLog, mockParseError, resetUtilsMocks } from '../mocks/utils.mock'
+
+// Clear the shared log / parseError spies before every test (call history only;
+// implementations are preserved).
+beforeEach(() => {
+  resetUtilsMocks()
+})
 
 vi.mock('@/utils', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>

--- a/app/src/tests/setup/wagmi.vue.setup.ts
+++ b/app/src/tests/setup/wagmi.vue.setup.ts
@@ -1,5 +1,14 @@
-import { vi } from 'vitest'
+import { beforeEach, vi } from 'vitest'
 import * as mocks from '@/tests/mocks/wagmi.vue.mock'
+import { resetContractMocks } from '@/tests/mocks/contract.mock'
+
+// Global web3 reset: restore wagmi state (incl. the shared `transferHash` ref)
+// and all V3 contract read/write mocks to defaults before every test. Setup
+// `beforeEach` hooks run before spec-level ones, so per-test setup still wins.
+beforeEach(() => {
+  mocks.resetWagmiVueMocks()
+  resetContractMocks()
+})
 
 vi.mock('@wagmi/vue', async (importOriginal) => {
   const actual: object = await importOriginal()


### PR DESCRIPTION
## Summary

Prototype for #1844. Audit showed shared test mocks were never reset, so in-place mutations (object fields, `ref().value`, spy call history) leaked across tests, and several `useXStore: () => ({ ...mockX })` spreads (re-evaluated at call time) made mutation timing fragile.

Rather than rewriting specs to verbose `setX(makeX({...}))` calls (which would *increase* per-spec code), this fixes the root cause centrally and keeps the terse `mockX.field = …` ergonomics. **Zero spec churn** for setup; only redundant manual resets were removed.

### Store mocks (stable reference + factory + auto-reset)
| Mock | Target | Treatment |
|------|--------|-----------|
| `mockUserStore` | `useUserDataStore` | `makeUserStore` + `resetUserStoreMock`, stable ref |
| `mockTeamStore` | `useTeamStore` | `makeTeamStore` + `resetTeamStoreMock` (restores default `getContractAddressByType`), stable ref |
| `mockToast` | `useToast` | spy cleared globally |

`mockUseCurrencyStore` already returns a fresh object — left as is.

### Composable + web3 + infra mocks (global auto-reset of existing reset fns)
The repo already had `reset*Mocks()` helpers, but **none were wired** — they were called manually in ~30 specs, inconsistently. Wired them into global `beforeEach` hooks and closed their gaps:

- **composables**: `resetComposableMocks` + `resetDeployState` now global; filled gaps (`mockUseContractBalance` balances/total/dividendsTotal, `mockUseClipboard.isSupported`, `mockUseFetch.get.url`).
- **web3**: new `resetWagmiVueMocks` (clears the shared `transferHash` ref + write/read refs + `@wagmi/core` spies); wired `resetContractMocks`, `resetERC20Mocks`, `resetSafeDepositRouterMocks` globally.
- **utils**: `resetUtilsMocks` (was defined but never called) now global.
- **query**: new `resetNotificationsMock` for the shared `mockNotificationsRef`.

Also dropped `RemoveOwnerButton.spec.ts`'s local `vi.mock('@/stores')` and 3 redundant manual `mockToast` clears.

## Result

- Cross-test leakage removed across store, composable, web3, utils and notification mocks, all via central `beforeEach` hooks — no `mockX.field = …` call sites changed.
- The spread/identity footgun is fixed.

## Test plan

- [x] `npm run test:unit` — 213 files / 1748 tests pass
- [x] `npm run type-check` clean
- [x] `eslint` clean on changed files

Closes #1844
