### PR TITLE
refactor: ♻️ extract TanStack Query mock into opt-in setup (#1845)

### DIFF
--- a/app/src/tests/README.md
+++ b/app/src/tests/README.md
@@ -23,6 +23,27 @@ ESLint enforces this via `no-restricted-syntax`: any `vi.mock('<globally-mocked-
 
 If you need to mock a module that **isn't** yet globally mocked but you're reaching for it across several specs, add it to `src/tests/setup/` and re-export the override hook from `src/tests/mocks/index.ts` rather than re-mocking it in each spec.
 
+## Opt-in: exercising real TanStack Query flows
+
+The TanStack Vue Query mock lives in its own setup file, [`setup/tanstack.setup.ts`](./setup/tanstack.setup.ts). It globally replaces `useQuery`, `useMutation` and `useQueryClient` so most specs don't need a `QueryClient` in context.
+
+When a spec needs to test the **real** library (loading/error states, cache invalidation, refetch), opt out locally and provide a real client via [`@/tests/helpers/queryClient`](./helpers/queryClient.ts):
+
+```typescript
+import { mount } from '@vue/test-utils'
+import { withQueryClient } from '@/tests/helpers/queryClient'
+
+vi.unmock('@tanstack/vue-query')
+
+const wrapper = mount(MyComponent, {
+  global: { plugins: [...withQueryClient()] }
+})
+```
+
+`withQueryClient()` installs a fresh `QueryClient` per call with retries disabled, so failing queries surface immediately.
+
+> Migration note (#1845): the long-term goal is to remove the global mock entirely and make query mocking opt-in. ~23 spec files currently rely on the global `useQueryClient` mock and will need this helper (or `renderWithProviders`, #1843) before the global mock can be deleted.
+
 ## Testing Components that Use Nuxt UI
 
 ### TL;DR

--- a/app/src/tests/helpers/queryClient.ts
+++ b/app/src/tests/helpers/queryClient.ts
@@ -1,0 +1,45 @@
+import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query'
+
+/**
+ * Opt-in TanStack Vue Query test helpers (#1845).
+ *
+ * The global mock in `src/tests/setup/tanstack.setup.ts` replaces `useQuery`,
+ * `useMutation` and `useQueryClient` for every spec. To exercise the *real*
+ * library instead, a spec must:
+ *
+ * 1. Opt out of the global mock at the top of the file:
+ *
+ *    ```ts
+ *    vi.unmock('@tanstack/vue-query')
+ *    ```
+ *
+ * 2. Mount the component with a real `QueryClient` provided in context, using
+ *    the `global.plugins` returned by `withQueryClient()`:
+ *
+ *    ```ts
+ *    const wrapper = mount(MyComponent, {
+ *      global: { plugins: [...withQueryClient()] }
+ *    })
+ *    ```
+ *
+ * Retries are disabled by default so failing queries surface immediately
+ * instead of being retried under fake timers.
+ */
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+      mutations: { retry: false }
+    }
+  })
+}
+
+/**
+ * Returns Vue plugins that install a fresh real `QueryClient` for a test mount.
+ * Pass-through to `global.plugins` in `@vue/test-utils`.
+ */
+export function withQueryClient(
+  queryClient: QueryClient = createTestQueryClient()
+): [[typeof VueQueryPlugin, { queryClient: QueryClient }]] {
+  return [[VueQueryPlugin, { queryClient }]]
+}

--- a/app/src/tests/setup/composables.setup.ts
+++ b/app/src/tests/setup/composables.setup.ts
@@ -8,9 +8,6 @@ import {
   mockUseApolloQuery,
   mockUseSafeSendTransaction,
   mockUseClipboard,
-  useQueryClientFn,
-  useQueryFn,
-  useMutationFn,
   mockUseFetch,
   mockUseSubmitRestriction,
   mockUseDeployContract
@@ -28,19 +25,7 @@ if (!globalThis.__mockFetch) {
   globalThis.__mockFetch = vi.fn()
 }
 
-/**
- * Mock TanStack Vue Query
- * Provides a mock queryClient with mocked invalidateQueries method
- */
-vi.mock('@tanstack/vue-query', async () => {
-  const actual: object = await vi.importActual('@tanstack/vue-query')
-  return {
-    ...actual,
-    useQueryClient: useQueryClientFn,
-    useQuery: useQueryFn,
-    useMutation: useMutationFn
-  }
-})
+// The TanStack Vue Query mock now lives in `tanstack.setup.ts` (#1845).
 
 vi.mock('@vue/apollo-composable', async (importOriginal) => {
   const actual: object = await importOriginal()

--- a/app/src/tests/setup/tanstack.setup.ts
+++ b/app/src/tests/setup/tanstack.setup.ts
@@ -1,0 +1,24 @@
+import { vi } from 'vitest'
+import { useQueryClientFn, useQueryFn, useMutationFn } from '@/tests/mocks/composables.mock'
+
+/**
+ * Global TanStack Vue Query mock.
+ *
+ * Replaces `useQuery`, `useMutation` and `useQueryClient` with shared mocks so
+ * specs don't need a real `QueryClient` in context.
+ *
+ * NOTE (#1845): this global mock is the main blocker to exercising real TanStack
+ * flows. The target is to remove it and make query mocking opt-in per spec.
+ * Specs that want to drive the real library should mount with the opt-in helper
+ * `mountWithQueryClient` from `@/tests/helpers/queryClient` and locally
+ * `vi.unmock('@tanstack/vue-query')`. See `app/src/tests/README.md`.
+ */
+vi.mock('@tanstack/vue-query', async () => {
+  const actual: object = await vi.importActual('@tanstack/vue-query')
+  return {
+    ...actual,
+    useQueryClient: useQueryClientFn,
+    useQuery: useQueryFn,
+    useMutation: useMutationFn
+  }
+})

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -9,6 +9,7 @@ process.env.TZ = 'UTC'
 const mockFiles = [
   'axios',
   'store',
+  'tanstack',
   'composables',
   'wagmi.vue',
   'viem',


### PR DESCRIPTION
## Summary

First, non-breaking slice of #1845 (stop globally mocking TanStack Query / wagmi).

- Move the global `@tanstack/vue-query` mock out of the `composables.setup.ts` monolith into a dedicated `tanstack.setup.ts`, continuing the per-domain split of the test setup.
- Add an opt-in `withQueryClient` / `createTestQueryClient` helper (`app/src/tests/helpers/queryClient.ts`) so specs can mount with a real `QueryClient` and exercise real query/mutation flows.
- Document the opt-in path and the migration plan in `app/src/tests/README.md`.

Behaviour is unchanged — the mock is still global. This is the groundwork before the breaking step.

## Why scoped this way

Measured the blast radius of simply deleting the global mock: **23 spec files / 209 tests fail** with `No 'queryClient' found in Vue context` (components call `useQueryClient()` directly). Migrating those in one PR would be large and depends on `renderWithProviders` (#1843). So this PR ships the foundation green; the deletion + per-spec migration follows.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean on changed files
- [x] Full unit suite green (213 files / 1748 tests)

Relates to #1845