### PR TITLE
chore: 🔧 remove dead test mocks (0 consumers)

### DIFF
--- a/app/src/tests/mocks/contract.mock.ts
+++ b/app/src/tests/mocks/contract.mock.ts
@@ -60,17 +60,6 @@ export const mockBODReads = {
   memberCount: createContractReadMock(0n)
 }
 
-export const mockBODWrites = {
-  addMember: createContractWriteV3Mock(),
-  removeMember: createContractWriteV3Mock(),
-  updateMember: createContractWriteV3Mock(),
-  pause: createContractWriteV3Mock(),
-  unpause: createContractWriteV3Mock(),
-  setBoard: createContractWriteV3Mock(),
-  addAction: createContractWriteV3Mock(),
-  approve: createContractWriteV3Mock()
-}
-
 /**
  * BOD Composable-level mocks (higher-level interfaces returned by BOD composables)
  */
@@ -171,7 +160,6 @@ export const resetContractMocks = () => {
 
   const allWriteV3Mocks = [
     mockBankWrites,
-    mockBODWrites,
     mockCashRemunerationWrites,
     mockExpenseAccountWrites,
     mockElectionsWrites,

--- a/app/src/tests/mocks/wagmi.vue.mock.ts
+++ b/app/src/tests/mocks/wagmi.vue.mock.ts
@@ -43,17 +43,6 @@ export const mockWagmiCore = {
   getPublicClient: vi.fn()
 }
 
-// Mock useWaitForTransactionReceipt composable
-export const mockUseWaitForTransactionReceipt = {
-  data: ref(null),
-  error: ref(null),
-  isLoading: ref(false),
-  isSuccess: ref(false),
-  isError: ref(false),
-  isPending: ref(false),
-  status: ref('idle' as const)
-}
-
 // Mock useConnection composable
 export const mockUseConnection = {
   address: ref('0x1234567890123456789012345678901234567890'),
@@ -97,14 +86,6 @@ export const mockUseBalance = {
   isLoading: ref(false),
   error: ref(null),
   refetch: vi.fn()
-}
-
-// Mock useSendTransaction composable
-export const mockUseSendTransaction = {
-  isPending: ref(false),
-  error: ref(null),
-  data: ref<string>(''),
-  sendTransaction: vi.fn()
 }
 
 // Mock wagmi config and transport functions


### PR DESCRIPTION
## Summary
Pure dead-code removal of shared test mocks with zero spec consumers:
- `mockUseSendTransaction` (app/src/tests/mocks/wagmi.vue.mock.ts)
- `mockUseWaitForTransactionReceipt` (app/src/tests/mocks/wagmi.vue.mock.ts)
- `mockBODWrites` (app/src/tests/mocks/contract.mock.ts), including its entry in `resetContractMocks`' `allWriteV3Mocks` array

Each was confirmed to have no remaining references in `app/src` (the only other `mockUseWaitForTransactionReceipt` is a separate local definition in `MyApprovedExpenseSection.mock.ts`).

Part of #1844

## Test plan
- [x] `CI=1 npm run test:unit -- --run` — 1747 passed (214 files)
- [x] `npm run type-check` — clean