### PR TITLE
fix: 🐛 remove hardhat/console.sol imports from production contracts

### DIFF
--- a/.github/workflows/contract-code-quality.yml
+++ b/.github/workflows/contract-code-quality.yml
@@ -34,6 +34,19 @@ jobs:
         run: npm run format-check
         working-directory: ./contract
 
+      - name: 🚫 Guard against hardhat/console.sol in production contracts
+        run: |
+          matches=$(grep -rn "hardhat/console.sol" contracts \
+            --include="*.sol" \
+            --exclude-dir=mocks \
+            --exclude-dir=test || true)
+          if [ -n "$matches" ]; then
+            echo "::error::hardhat/console.sol must not be imported outside contracts/mocks and contracts/test"
+            echo "$matches"
+            exit 1
+          fi
+        working-directory: ./contract
+
       - name: </> Run Solidity Linter
         run: npm run lint:sol
         working-directory: ./contract

--- a/contract/contracts/CashRemunerationEIP712.sol
+++ b/contract/contracts/CashRemunerationEIP712.sol
@@ -13,7 +13,6 @@ import './base/TokenSupport.sol';
 import {IMintableERC20} from './interfaces/IMintableERC20.sol';
 import {IInvestorV1} from './interfaces/IInvestorV1.sol';
 import {IOfficer} from './interfaces/IOfficer.sol';
-import 'hardhat/console.sol';
 
 /**
  * @title CashRemunerationEIP712

--- a/contract/contracts/Voting/Voting.sol
+++ b/contract/contracts/Voting/Voting.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.24;
 
 import './Types.sol';
-import 'hardhat/console.sol';
 
 import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol';


### PR DESCRIPTION
## Summary
- Remove the dev-only `hardhat/console.sol` import from `CashRemunerationEIP712.sol` and `Voting.sol` — it was shipped to production, bloating bytecode and leaking dev intent.
- Add a CI guard in `contract-code-quality.yml` that fails any import of `hardhat/console.sol` under `contracts/`, excluding `contracts/mocks/` and `contracts/test/`.

## Why
`hardhat/console.sol` is a development helper that should never reach production contracts. The guard prevents regressions.

## Notes for reviewer
- There were **no `console.log` call sites** — only the imports. As a result the deployed runtime bytecode is effectively unchanged (the import alone adds no opcodes without a `console.log` call), so the issue's "bytecode decreases" sanity check doesn't apply here. The real wins are removing the dev footgun and the CI guard.
- Verified locally: `npm run compile` (84 files), `npm run lint:sol`, and `npm run format-check:sol` all pass; the guard greps clean.
- Note: PR #2002 also targets this issue — one should be closed to avoid duplication.

Closes #1992