### PR TITLE
test: ✅ add renderWithProviders as the default spec mount helper

### DIFF
--- a/app/src/components/forms/__tests__/EditUserForm.spec.ts
+++ b/app/src/components/forms/__tests__/EditUserForm.spec.ts
@@ -1,9 +1,8 @@
 import { flushPromises } from '@vue/test-utils'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import EditUserForm from '@/components/forms/EditUserForm.vue'
-import { createTestingPinia } from '@pinia/testing'
 import { ref } from 'vue'
-import { mockUserData, mockUserStore, mockUseClipboard, mountWithProviders } from '@/tests/mocks'
+import { mockUserData, mockUserStore, mockUseClipboard, renderWithProviders } from '@/tests/mocks'
 import { useUpdateUserMutation } from '@/queries/user.queries'
 
 // Type for the mutation mock
@@ -28,9 +27,9 @@ const createMockMutation = (): Partial<MockMutation> & {
 global.window.open = vi.fn()
 
 const createWrapper = () =>
-  mountWithProviders(EditUserForm, {
+  renderWithProviders(EditUserForm, {
+    tooltipProvider: true,
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn })],
       stubs: {
         ProfileImageUpload: {
           name: 'ProfileImageUpload',

--- a/app/src/components/sections/ClaimHistoryView/__tests__/ClaimHistoryMemberHeader.spec.ts
+++ b/app/src/components/sections/ClaimHistoryView/__tests__/ClaimHistoryMemberHeader.spec.ts
@@ -1,19 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
-import { createTestingPinia } from '@pinia/testing'
 import ClaimHistoryMemberHeader from '@/components/sections/ClaimHistoryView/ClaimHistoryMemberHeader.vue'
-import { mockTeamData, mockTeamStore } from '@/tests/mocks'
+import { mockTeamData, mockTeamStore, renderWithProviders } from '@/tests/mocks'
 
 describe('ClaimHistoryMemberHeader', () => {
   const baseMembers = [...mockTeamData.members]
 
   const createWrapper = (memberAddress: string) =>
-    mount(ClaimHistoryMemberHeader, {
+    renderWithProviders(ClaimHistoryMemberHeader, {
       props: {
         memberAddress: memberAddress as `0x${string}`
-      },
-      global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn })]
       }
     })
 
@@ -91,12 +86,9 @@ describe('ClaimHistoryMemberHeader', () => {
   })
 
   it('handles undefined memberAddress safely', () => {
-    const wrapper = mount(ClaimHistoryMemberHeader, {
+    const wrapper = renderWithProviders(ClaimHistoryMemberHeader, {
       props: {
         memberAddress: undefined as unknown as `0x${string}`
-      },
-      global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn })]
       }
     })
 

--- a/app/src/components/sections/ContractManagementView/__tests__/AdvertiseContractSection.spec.ts
+++ b/app/src/components/sections/ContractManagementView/__tests__/AdvertiseContractSection.spec.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
-import { createTestingPinia } from '@pinia/testing'
 import AdvertiseContractSection from '@/components/sections/ContractManagementView/AdvertiseContractSection.vue'
 import { useTeamStore } from '@/stores'
-import { mockTeamStore } from '@/tests/mocks'
+import { mockTeamStore, renderWithProviders } from '@/tests/mocks'
 
 vi.mock('@/components/sections/ContractManagementView/TeamContracts.vue', () => ({
   default: { template: '<div data-test="team-contracts-stub" />' }
@@ -13,10 +11,7 @@ vi.mock('@/components/sections/ContractManagementView/forms/CreateAddCampaign.vu
   default: { template: '<div data-test="create-add-campaign-stub" />' }
 }))
 
-const mountSection = () =>
-  mount(AdvertiseContractSection, {
-    global: { plugins: [createTestingPinia({ createSpy: vi.fn })] }
-  })
+const mountSection = () => renderWithProviders(AdvertiseContractSection)
 
 describe('AdvertiseContractSection.vue', () => {
   beforeEach(() => {

--- a/app/src/components/sections/ContractManagementView/__tests__/BodApprovalModal.spec.ts
+++ b/app/src/components/sections/ContractManagementView/__tests__/BodApprovalModal.spec.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount, flushPromises } from '@vue/test-utils'
-import { createTestingPinia } from '@pinia/testing'
+import { flushPromises } from '@vue/test-utils'
 import { ref } from 'vue'
 import type { TableRow } from '@/types/table'
 import BodApprovalModal from '@/components/sections/ContractManagementView/BodApprovalModal.vue'
-import { useReadContractFn, mockTeamStore, mockUserStore, mockWagmiCore } from '@/tests/mocks'
+import {
+  useReadContractFn,
+  mockTeamStore,
+  mockUserStore,
+  mockWagmiCore,
+  renderWithProviders
+} from '@/tests/mocks'
 import { useTeamStore, useUserDataStore } from '@/stores'
 
 const CURRENT_ADDR = '0x0000000000000000000000000000000000000001'
@@ -31,12 +36,11 @@ function mountComponent(overrides?: { alreadyApproved?: boolean }) {
   }
   const row = baseRow as unknown as TableRow
 
-  return mount(BodApprovalModal, {
+  return renderWithProviders(BodApprovalModal, {
     props: {
       loading: false,
       row
-    },
-    global: { plugins: [createTestingPinia({ createSpy: vi.fn })] }
+    }
   })
 }
 

--- a/app/src/components/sections/ContractManagementView/__tests__/RedeployOfficerModal.spec.ts
+++ b/app/src/components/sections/ContractManagementView/__tests__/RedeployOfficerModal.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount, flushPromises } from '@vue/test-utils'
-import { createTestingPinia } from '@pinia/testing'
+import { flushPromises } from '@vue/test-utils'
 import { ref } from 'vue'
 import RedeployOfficerModal from '@/components/sections/ContractManagementView/RedeployOfficerModal.vue'
+import { renderWithProviders } from '@/tests/mocks'
 
 // ---------------------------------------------------------------------------
 // Mocks for the composables used by RedeployOfficerModal. The investor reads
@@ -63,15 +63,12 @@ const stubs = {
 }
 
 function mountModal(props: { open?: boolean } = {}) {
-  return mount(RedeployOfficerModal, {
+  return renderWithProviders(RedeployOfficerModal, {
     props: {
       open: true,
       ...props
     },
-    global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn })],
-      stubs
-    }
+    global: { stubs }
   })
 }
 

--- a/app/src/components/sections/SherTokenView/InvestorActions/__tests__/SetCompensationMultiplierAction.spec.ts
+++ b/app/src/components/sections/SherTokenView/InvestorActions/__tests__/SetCompensationMultiplierAction.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { flushPromises, mount } from '@vue/test-utils'
-import { createTestingPinia } from '@pinia/testing'
+import { flushPromises } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import SetCompensationMultiplierAction from '../SetCompensationMultiplierAction.vue'
 import {
@@ -8,14 +7,14 @@ import {
   mockSafeDepositRouterAddress,
   mockSafeDepositRouterReads,
   mockSafeDepositRouterWrites,
-  mockUseConnection
+  mockUseConnection,
+  renderWithProviders
 } from '@/tests/mocks'
 
 describe('SetCompensationMultiplierAction.vue', () => {
   const createWrapper = () =>
-    mount(SetCompensationMultiplierAction, {
+    renderWithProviders(SetCompensationMultiplierAction, {
       global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn })],
         stubs: { teleport: true }
       }
     })

--- a/app/src/components/sections/SherTokenView/InvestorActions/__tests__/ToggleSherCompensationAction.spec.ts
+++ b/app/src/components/sections/SherTokenView/InvestorActions/__tests__/ToggleSherCompensationAction.spec.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
-import { createTestingPinia } from '@pinia/testing'
 import ToggleSherCompensationAction from '../ToggleSherCompensationAction.vue'
 import {
   mockParseError,
@@ -9,16 +7,12 @@ import {
   mockSafeDepositRouterReads,
   mockSafeDepositRouterWrites,
   mockTeamStore,
-  mockUseConnection
+  mockUseConnection,
+  renderWithProviders
 } from '@/tests/mocks'
 
 describe('ToggleSherCompensationAction.vue', () => {
-  const createWrapper = () =>
-    mount(ToggleSherCompensationAction, {
-      global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn })]
-      }
-    })
+  const createWrapper = () => renderWithProviders(ToggleSherCompensationAction)
 
   beforeEach(() => {
     vi.useRealTimers()

--- a/app/src/components/sections/SherTokenView/__tests__/InvestorsHeader.spec.ts
+++ b/app/src/components/sections/SherTokenView/__tests__/InvestorsHeader.spec.ts
@@ -1,12 +1,10 @@
-import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { createTestingPinia } from '@pinia/testing'
 import InvestorsHeader from '../InvestorsHeader.vue'
 import { parseUnits } from 'viem'
-import { mockInvestorReads, mockTeamStore, mockUserStore } from '@/tests/mocks'
+import { mockInvestorReads, mockTeamStore, mockUserStore, renderWithProviders } from '@/tests/mocks'
 
 describe('InvestorsHeader', () => {
-  let wrapper: ReturnType<typeof mount>
+  let wrapper: ReturnType<typeof createComponent>
 
   // Test data constants
   const mockTokenData = {
@@ -46,9 +44,8 @@ describe('InvestorsHeader', () => {
   })
 
   const createComponent = () => {
-    return mount(InvestorsHeader, {
+    return renderWithProviders(InvestorsHeader, {
       global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn })],
         stubs: {
           OverviewCard: {
             template: `

--- a/app/src/components/sections/SherTokenView/__tests__/ShareholderMigrationBanner.spec.ts
+++ b/app/src/components/sections/SherTokenView/__tests__/ShareholderMigrationBanner.spec.ts
@@ -1,13 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount, flushPromises } from '@vue/test-utils'
-import { createTestingPinia } from '@pinia/testing'
+import { flushPromises } from '@vue/test-utils'
 import { computed, ref } from 'vue'
 import type { Address } from 'viem'
 import ShareholderMigrationBanner from '@/components/sections/SherTokenView/ShareholderMigrationBanner.vue'
 import { useInvestorAddress, useInvestorTotalSupply } from '@/composables/investor/reads'
 import { InconsistentSupplyError } from '@/composables/investor/useShareholderMigration'
 import { useTeamStore } from '@/stores'
-import { mockInvestorReads, mockTeamStore } from '@/tests/mocks'
+import { mockInvestorReads, mockTeamStore, renderWithProviders } from '@/tests/mocks'
 
 // ---------------------------------------------------------------------------
 // Mock the migration composable. Investor reads + team store come from the
@@ -94,11 +93,8 @@ function setupMocks(
 }
 
 function mountBanner() {
-  return mount(ShareholderMigrationBanner, {
-    global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn })],
-      stubs
-    }
+  return renderWithProviders(ShareholderMigrationBanner, {
+    global: { stubs }
   })
 }
 

--- a/app/src/components/sections/SherTokenView/forms/__tests__/MintRecapCard.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/MintRecapCard.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
-import { createTestingPinia } from '@pinia/testing'
 import { ref } from 'vue'
 import MintRecapCard from '../MintRecapCard.vue'
+import { renderWithProviders } from '@/tests/mocks'
 
 const VALID_ADDRESS = '0x1234567890123456789012345678901234567890'
 
@@ -17,15 +16,12 @@ vi.mock('@/composables/investor/reads', () => ({
 }))
 
 const mountRecap = (props: Record<string, unknown> = {}) =>
-  mount(MintRecapCard, {
+  renderWithProviders(MintRecapCard, {
     props: {
       recipientAddress: VALID_ADDRESS,
       issuedAmount: 10,
       hasValidationError: false,
       ...props
-    },
-    global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn })]
     }
   })
 

--- a/app/src/components/sections/VestingView/__tests__/VestingStats.spec.ts
+++ b/app/src/components/sections/VestingView/__tests__/VestingStats.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount, type VueWrapper } from '@vue/test-utils'
-import { createTestingPinia } from '@pinia/testing'
+import { type VueWrapper } from '@vue/test-utils'
+import { renderWithProviders } from '@/tests/mocks'
 
 // Auto-imported @nuxt/ui components bypass `config.global.stubs` because the
 // Nuxt UI Vite plugin resolves them through their file path. Mock the module
@@ -92,12 +92,9 @@ describe('VestingStats.vue', () => {
   let wrapper: VueWrapper
 
   const mountComponent = () => {
-    return mount(VestingStats, {
+    return renderWithProviders(VestingStats, {
       props: {
         reloadKey: mockReloadKey.value
-      },
-      global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn })]
       }
     })
   }

--- a/app/src/tests/README.md
+++ b/app/src/tests/README.md
@@ -23,6 +23,58 @@ ESLint enforces this via `no-restricted-syntax`: any `vi.mock('<globally-mocked-
 
 If you need to mock a module that **isn't** yet globally mocked but you're reaching for it across several specs, add it to `src/tests/setup/` and re-export the override hook from `src/tests/mocks/index.ts` rather than re-mocking it in each spec.
 
+## Mounting components: `renderWithProviders`
+
+`renderWithProviders` (from [`@/tests/mocks`](./mocks)) is the **default mounting path** for component specs. It is a drop-in for `mount` that installs the providers nearly every spec needs — `createTestingPinia` and the route stub — so you stop copy-pasting `global.plugins` into every file.
+
+```typescript
+// ❌ Before — every spec hand-rolls the same plugins block
+import { mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+
+const wrapper = mount(MyComponent, {
+  props: { loading: false },
+  global: {
+    plugins: [createTestingPinia({ createSpy: vi.fn })]
+  }
+})
+
+// ✅ After — providers are installed for you
+import { renderWithProviders } from '@/tests/mocks'
+
+const wrapper = renderWithProviders(MyComponent, {
+  props: { loading: false }
+})
+```
+
+The returned wrapper targets the component itself, so `props`, `emitted()`, `setProps`, `find`, `findComponent`, etc. all behave exactly as with `mount`. Any `mount` option you pass through (`props`, `attrs`, `slots`, `global.stubs`, …) is forwarded — the helper only **adds** to `global.plugins`, it never clobbers your `global` block:
+
+```typescript
+// Compose with local stubs — the helper merges them with the global ones
+renderWithProviders(RedeployOfficerModal, {
+  props: { open: true },
+  global: { stubs: { UForm, UFormField, UInput } }
+})
+```
+
+### Options
+
+All [`mount` options](https://test-utils.vuejs.org/api/#mount) are accepted, plus:
+
+| Option            | Default                              | Purpose                                                                                                                                                           |
+| ----------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pinia`           | `createTestingPinia({ createSpy })`  | `false` to install no Pinia (rely on the global `vi.mock('@/stores/*')`); a `TestingOptions` object to tweak it; a `TestingPinia` instance to read `pinia.state`. |
+| `route`           | `{ params: { id: '1' } }`            | Override the globally-mocked `useRoute()`. Reset before every test, so it never leaks.                                                                            |
+| `queryClient`     | _none_ (TanStack is mocked globally) | `true` for a fresh `QueryClient` (retries off) or pass your own. Only matters in specs that `vi.unmock('@tanstack/vue-query')`.                                   |
+| `tooltipProvider` | `false`                              | Wrap in reka-ui's `<TooltipProvider>` for components that render tooltip primitives directly (see below). `UTooltip` is stubbed, so rarely needed.                |
+
+```typescript
+// Opt out of Pinia and point the route at a different team
+renderWithProviders(MyView, { pinia: false, route: { params: { id: '42' } } })
+```
+
+> **Pinia note:** `createTestingPinia` is installed by default, but the global `vi.mock('@/stores/*')` still wins for the stores it mocks (see [`docs/testing/MOCK_SYSTEM.md`](../../../docs/testing/MOCK_SYSTEM.md)). Pass `pinia: false` when a spec relies entirely on the mocked stores and you want to make that explicit.
+
 ## Testing Components that Use Nuxt UI
 
 ### TL;DR
@@ -282,17 +334,15 @@ Both steps are required: `vi.unmock()` restores the real module, and `stubs: { X
 
 ## Provider Contexts (TooltipProvider)
 
-Some reka-ui primitives require a `TooltipProvider` ancestor. `UTooltip` is already globally mocked, so you normally don't need this. But if you test a component that uses reka-ui primitives directly, use `mountWithProviders`:
+Some reka-ui primitives require a `TooltipProvider` ancestor. `UTooltip` is already globally mocked, so you normally don't need this. But if you test a component that uses reka-ui primitives directly, pass `tooltipProvider: true` to `renderWithProviders`:
 
 ```typescript
-import { mountWithProviders } from '@/tests/setup/nuxt-ui.setup'
+import { renderWithProviders } from '@/tests/mocks'
 
-const wrapper = mountWithProviders(MyComponent, {
-  global: {
-    plugins: [createTestingPinia({ createSpy: vi.fn })]
-  }
-})
+const wrapper = renderWithProviders(MyComponent, { tooltipProvider: true })
 ```
+
+When `tooltipProvider` is enabled the returned wrapper targets the inner component, so `setProps` is unavailable — drive props through the DOM or the initial `props` option instead.
 
 ## Adding a New Global Stub
 

--- a/app/src/tests/helpers/renderWithProviders.ts
+++ b/app/src/tests/helpers/renderWithProviders.ts
@@ -1,0 +1,111 @@
+import { mount, type ComponentMountingOptions, type VueWrapper } from '@vue/test-utils'
+import { h, type Component, type ComponentPublicInstance } from 'vue'
+import { TooltipProvider } from 'reka-ui'
+import { vi } from 'vitest'
+import { createTestingPinia, type TestingOptions, type TestingPinia } from '@pinia/testing'
+import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query'
+import { setMockRoute, type MockRoute } from '@/tests/mocks/router.mock'
+
+type Plugins = NonNullable<NonNullable<ComponentMountingOptions<Component>['global']>['plugins']>
+
+/**
+ * Pinia behavior for {@link renderWithProviders}.
+ * - default / `TestingOptions` → installs `createTestingPinia({ createSpy: vi.fn, ...options })`
+ * - `TestingPinia` instance → installed as-is (lets a spec read `pinia.state`)
+ * - `false` → installs no Pinia (rely solely on the global `vi.mock('@/stores/*')`)
+ */
+export type PiniaOption = TestingPinia | TestingOptions | false
+
+export interface RenderOptions<C extends Component> extends ComponentMountingOptions<C> {
+  /** See {@link PiniaOption}. Defaults to `createTestingPinia({ createSpy: vi.fn })`. */
+  pinia?: PiniaOption
+  /**
+   * Overrides the globally-mocked route (default `{ params: { id: '1' } }`).
+   * Reset before every test by the global `beforeEach`, so it never leaks.
+   */
+  route?: Partial<MockRoute>
+  /**
+   * Installs `VueQueryPlugin` with a real `QueryClient` (opt-in).
+   * - `true` → fresh client with retries disabled
+   * - a `QueryClient` instance → installed as-is
+   *
+   * NOTE: TanStack Query hooks are mocked globally, so this only changes behavior
+   * in specs that `vi.unmock('@tanstack/vue-query')` to exercise the real client.
+   */
+  queryClient?: QueryClient | boolean
+  /**
+   * Wraps the component in reka-ui's `<TooltipProvider>` ancestor. Off by default
+   * because `UTooltip` is stubbed globally; enable only when the component renders
+   * reka-ui tooltip primitives directly. When enabled, the returned wrapper targets
+   * the inner component (so `setProps` is unavailable — drive props via the DOM).
+   */
+  tooltipProvider?: boolean
+}
+
+const isTestingPinia = (value: TestingPinia | TestingOptions): value is TestingPinia =>
+  'state' in value && 'install' in value
+
+const resolvePinia = (option: PiniaOption | undefined): TestingPinia | null => {
+  if (option === false) return null
+  if (option && isTestingPinia(option)) return option
+  return createTestingPinia({ createSpy: vi.fn, ...option })
+}
+
+const resolveQueryClient = (option: QueryClient | boolean | undefined): QueryClient | null => {
+  if (!option) return null
+  if (option instanceof QueryClient) return option
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+/**
+ * The default mounting path for component specs. Installs the providers nearly every
+ * spec needs — `createTestingPinia` and the route stub — and centralizes the
+ * `global.plugins` boilerplate that ~115 specs duplicate today.
+ *
+ * It is a drop-in for `mount`: the returned wrapper targets the component itself, so
+ * `props`, `emitted()`, `setProps`, `findComponent`, etc. all behave as usual.
+ *
+ * @example
+ * const wrapper = renderWithProviders(BodApprovalModal, { props: { loading: false, row } })
+ *
+ * @example // opt out of Pinia, point the route at a different team
+ * renderWithProviders(MyView, { pinia: false, route: { params: { id: '42' } } })
+ */
+export function renderWithProviders<C extends Component>(
+  component: C,
+  options: RenderOptions<C> = {}
+): VueWrapper<ComponentPublicInstance> {
+  const {
+    pinia,
+    route,
+    queryClient,
+    tooltipProvider,
+    global: globalOptions = {},
+    ...mountOptions
+  } = options
+
+  if (route) setMockRoute(route)
+
+  const plugins: Plugins = [...(globalOptions.plugins ?? [])]
+  const piniaInstance = resolvePinia(pinia)
+  if (piniaInstance) plugins.push(piniaInstance)
+  const client = resolveQueryClient(queryClient)
+  if (client) plugins.push([VueQueryPlugin, { queryClient: client }])
+
+  const mergedGlobal = { ...globalOptions, plugins }
+
+  if (tooltipProvider) {
+    const host = mount(TooltipProvider, {
+      global: mergedGlobal,
+      slots: { default: () => h(component, mountOptions.props ?? {}) }
+    })
+    return host.findComponent(
+      component as Component
+    ) as unknown as VueWrapper<ComponentPublicInstance>
+  }
+
+  return mount(component, {
+    ...mountOptions,
+    global: mergedGlobal
+  }) as unknown as VueWrapper<ComponentPublicInstance>
+}

--- a/app/src/tests/mocks/index.ts
+++ b/app/src/tests/mocks/index.ts
@@ -11,4 +11,5 @@ export * from './safeDepositRouter.mock'
 export * from './utils.mock'
 
 // Export test utilities
-export { mountWithProviders } from '../setup/nuxt-ui.setup'
+export { renderWithProviders } from '../helpers/renderWithProviders'
+export type { RenderOptions, PiniaOption } from '../helpers/renderWithProviders'

--- a/app/src/tests/mocks/router.mock.ts
+++ b/app/src/tests/mocks/router.mock.ts
@@ -13,3 +13,38 @@ export const mockRouter = {
   beforeEach: vi.fn(),
   afterEach: vi.fn()
 }
+
+export interface MockRoute {
+  params: Record<string, string>
+  query: Record<string, string>
+  path: string
+  fullPath: string
+  name: string | undefined
+  meta: Record<string, unknown>
+}
+
+const defaultRoute = (): MockRoute => ({
+  params: { id: '1' },
+  query: {},
+  path: '/teams/1',
+  fullPath: '/teams/1',
+  name: undefined,
+  meta: { name: 'Team View' }
+})
+
+// Shared, mutable route object returned by the globally-mocked `useRoute`.
+// Returning a stable reference (rather than a fresh object per call) means an
+// override applied before mount is reliably visible to the component under test.
+export const mockRoute: MockRoute = defaultRoute()
+
+// Override the route for a single test. Unspecified keys fall back to defaults,
+// so callers only declare what they care about (e.g. `{ params: { id: '42' } }`).
+export const setMockRoute = (route: Partial<MockRoute>): void => {
+  Object.assign(mockRoute, defaultRoute(), route)
+}
+
+// Restore the default route. Called from the global `beforeEach` so per-test
+// overrides never leak across tests.
+export const resetMockRoute = (): void => {
+  Object.assign(mockRoute, defaultRoute())
+}

--- a/app/src/tests/setup/composables.setup.ts
+++ b/app/src/tests/setup/composables.setup.ts
@@ -19,7 +19,7 @@ import {
 } from '@/tests/mocks/composables.mock'
 import { mockUploadFileApi } from '@/tests/mocks/api.mock'
 import { mockGetBalance, mockGetLogs } from '@/tests/mocks/viem.actions.mock'
-import { mockRouter } from '@/tests/mocks/router.mock'
+import { mockRouter, mockRoute, resetMockRoute } from '@/tests/mocks/router.mock'
 
 // Restore all shared composable mocks to their defaults before every test so
 // that in-place mutations (refs, spies) never leak across tests. Setup-file
@@ -28,6 +28,7 @@ beforeEach(() => {
   resetComposableMocks()
   resetDeployState()
   resetNotificationsMock()
+  resetMockRoute()
 })
 
 declare global {
@@ -75,11 +76,9 @@ vi.mock('vue-router', async (importOriginal) => {
     ...actual,
     useRouter: vi.fn(() => mockRouter),
     RouterView: { name: 'RouterView', template: '<div data-test="router-view">Router View</div>' },
-    useRoute: vi.fn(() => ({
-      params: { id: '1' },
-      path: '/teams/1',
-      meta: { name: 'Team View' }
-    }))
+    // Returns the shared, mutable `mockRoute`. Override per-test via
+    // `renderWithProviders(..., { route })` or `setMockRoute(...)`.
+    useRoute: vi.fn(() => mockRoute)
   }
 })
 

--- a/app/src/tests/setup/nuxt-ui.setup.ts
+++ b/app/src/tests/setup/nuxt-ui.setup.ts
@@ -1,4 +1,4 @@
-import { config, mount as originalMount, VueWrapper } from '@vue/test-utils'
+import { config } from '@vue/test-utils'
 import { defineComponent, h } from 'vue'
 import type { Component } from 'vue'
 import { TooltipProvider } from 'reka-ui'
@@ -131,23 +131,6 @@ const GlobalTestWrapper = defineComponent({
     return () => h(TooltipProvider, {}, () => h(props.component, {}, slots.default))
   }
 })
-
-/**
- * Custom mount helper that automatically wraps components with necessary providers
- */
-export function mountWithProviders<T extends Component>(
-  component: T,
-  options: Record<string, unknown> = {}
-): VueWrapper<T> {
-  return originalMount(
-    {
-      setup() {
-        return () => h(TooltipProvider, {}, () => h(component))
-      }
-    },
-    options
-  ) as VueWrapper<T>
-}
 
 export { GlobalTestWrapper }
 


### PR DESCRIPTION
## Summary

Closes #1843.

Component specs currently hand-roll the same mounting boilerplate — `mount(...)` plus `global.plugins: [createTestingPinia({ createSpy: vi.fn })]` — in ~115 files. This adds a single **`renderWithProviders`** helper that installs those providers by default, and proves it out by migrating eleven representative specs.

## What changed

- **`src/tests/helpers/renderWithProviders.ts`** — drop-in for `mount` that installs `createTestingPinia` + the route stub, and forwards every `mount` option (it only *adds* to `global.plugins`, never clobbers your `global` block). Parameterizable:
  - `pinia` — overridable `TestingOptions`, a `TestingPinia` instance, or `false` to install no Pinia (rely on the global `vi.mock('@/stores/*')`).
  - `route` — override the globally-mocked `useRoute()` (e.g. `{ params: { id: '42' } }`) instead of the hard-coded `{ id: '1' }`.
  - `queryClient` — opt-in real `QueryClient` for specs that `vi.unmock('@tanstack/vue-query')`.
  - `tooltipProvider` — wrap in reka-ui's `<TooltipProvider>`; this subsumes the old `mountWithProviders`, which is now removed.
- **Parameterizable route mock** — `mockRoute` + `setMockRoute`/`resetMockRoute`, reset in the global `beforeEach` so overrides never leak.
- **11 specs migrated**, net **−34 LOC** across them, identical assertions: InvestorsHeader, VestingStats, ShareholderMigrationBanner, MintRecapCard, RedeployOfficerModal, AdvertiseContractSection, BodApprovalModal, ClaimHistoryMemberHeader, ToggleSherCompensationAction, SetCompensationMultiplierAction, EditUserForm.
- **Docs** — new "Mounting components" section in `src/tests/README.md` with before/after + an options table, documenting the helper as the default mounting path.

## Test plan

- [x] `renderWithProviders` and migrated files pass type-check (no new errors)
- [x] ESLint clean on all changed files
- [x] Prettier-formatted (enforced by the pre-commit hook)
- [x] All 11 migrated specs green (94 tests)
- [ ] Reviewer: confirm the helper reads cleanly as the documented default for new specs