### PR TITLE
feat: ✨ load-balance Polygon RPC across pooled endpoints with failover (#2040)

### DIFF
--- a/ponder/.env.local.example
+++ b/ponder/.env.local.example
@@ -3,7 +3,14 @@
 # NETWORK=hardhat
 
 # ─── Polygon ─────────────────────────────────────────────────────────────────
-PONDER_RPC_URL_137=https://polygon-mainnet.g.alchemy.com/v2/<your-key>
+# Primary RPC pool: comma-separated URLs, load-balanced round-robin.
+PONDER_RPC_URLS_137=https://polygon-mainnet.g.alchemy.com/v2/<key-a>,https://polygon-mainnet.g.alchemy.com/v2/<key-b>
+# Optional backup pool: used only when the whole primary pool fails.
+# PONDER_RPC_URLS_137_BACKUP=https://polygon-rpc.com,https://rpc.ankr.com/polygon
+# Max requests/second applied to EACH endpoint (default 25).
+# PONDER_RPC_MAX_RPS=25
+# Legacy single-URL var — still honored as a fallback if PONDER_RPC_URLS_137 is unset.
+# PONDER_RPC_URL_137=https://polygon-mainnet.g.alchemy.com/v2/<your-key>
 # Required for all networks
 # OfficerFactoryBeacon address for the selected NETWORK
 # FACTORY_ADDRESS=0x...

--- a/ponder/.env.local.example
+++ b/ponder/.env.local.example
@@ -3,17 +3,27 @@
 # NETWORK=hardhat
 
 # ─── Polygon ─────────────────────────────────────────────────────────────────
-# Primary RPC pool: comma-separated URLs, load-balanced round-robin.
-PONDER_RPC_URLS_137=https://polygon-mainnet.g.alchemy.com/v2/<key-a>,https://polygon-mainnet.g.alchemy.com/v2/<key-b>
-# Optional backup pool: used only when the whole primary pool fails.
-# PONDER_RPC_URLS_137_BACKUP=https://polygon-rpc.com,https://rpc.ankr.com/polygon
-# Max requests/second applied to EACH endpoint (default 25).
-# PONDER_RPC_MAX_RPS=25
-# Optional WebSocket endpoint for real-time block subscriptions (newHeads).
-# Lowers realtime RPC usage vs polling; falls back to polling if it drops.
-# PONDER_WS_URL_137=wss://polygon-mainnet.g.alchemy.com/v2/<your-key>
-# Legacy single-URL var — still honored as a fallback if PONDER_RPC_URLS_137 is unset.
+# Primary RPC pool: comma-separated URLs, load-balanced round-robin, each URL
+# independently rate-limited (PONDER_RPC_MAX_RPS). Public-first to spare the
+# Alchemy quota — BUT most public Polygon RPCs fail an indexer's needs (as of
+# 2026-06: polygon-rpc.com is gated, publicnode prunes getLogs even at the tip,
+# nodies caps ranges at 500 blocks). drpc is the one that keeps history AND
+# serves eth_getLogs, so use it alone — don't pool endpoints with mismatched
+# range caps (loadBalance round-robins blindly and would thrash on retries).
+PONDER_RPC_URLS_137=https://polygon.drpc.org
+# Lower than the 25 default — public free tiers 429 sooner.
+PONDER_RPC_MAX_RPS=10
+# Backup pool: used ONLY when the whole primary pool fails. Keep Alchemy here so
+# the heavy one-time historical backfill can lean on it, while steady-state
+# realtime (the recurring cost) stays on the public primary.
+PONDER_RPC_URLS_137_BACKUP=https://polygon-mainnet.g.alchemy.com/v2/<your-key>
+# Optional WebSocket for realtime newHeads; cuts realtime RPC vs polling and
+# reverts to polling if it drops. Ponder uses ONE socket, so this is "list
+# several, use the first" (reorder to swap) — not runtime WS failover.
+PONDER_WS_URLS_137=wss://polygon-bor-rpc.publicnode.com,wss://polygon.drpc.org
+# Legacy single-URL vars — still honored as fallbacks if the *_URLS_137 vars are unset.
 # PONDER_RPC_URL_137=https://polygon-mainnet.g.alchemy.com/v2/<your-key>
+# PONDER_WS_URL_137=wss://polygon-mainnet.g.alchemy.com/v2/<your-key>
 # Required for all networks
 # OfficerFactoryBeacon address for the selected NETWORK
 # FACTORY_ADDRESS=0x...

--- a/ponder/.env.local.example
+++ b/ponder/.env.local.example
@@ -9,6 +9,9 @@ PONDER_RPC_URLS_137=https://polygon-mainnet.g.alchemy.com/v2/<key-a>,https://pol
 # PONDER_RPC_URLS_137_BACKUP=https://polygon-rpc.com,https://rpc.ankr.com/polygon
 # Max requests/second applied to EACH endpoint (default 25).
 # PONDER_RPC_MAX_RPS=25
+# Optional WebSocket endpoint for real-time block subscriptions (newHeads).
+# Lowers realtime RPC usage vs polling; falls back to polling if it drops.
+# PONDER_WS_URL_137=wss://polygon-mainnet.g.alchemy.com/v2/<your-key>
 # Legacy single-URL var — still honored as a fallback if PONDER_RPC_URLS_137 is unset.
 # PONDER_RPC_URL_137=https://polygon-mainnet.g.alchemy.com/v2/<your-key>
 # Required for all networks

--- a/ponder/ponder.config.ts
+++ b/ponder/ponder.config.ts
@@ -86,7 +86,12 @@ const polygonRpc =
 
 // Optional WebSocket endpoint for real-time block subscriptions (newHeads).
 // Cuts realtime RPC usage vs polling; Ponder reverts to polling if it drops.
-const polygonWs = process.env.PONDER_WS_URL_137 || undefined;
+// Ponder's `ws` field takes a single URL, so we accept a comma-separated list
+// and use the first entry; the rest are documented alternates (reorder to swap).
+const wsUrls = parseRpcUrls(
+  process.env.PONDER_WS_URLS_137 ?? process.env.PONDER_WS_URL_137,
+);
+const polygonWs = wsUrls[0] || undefined;
 
 // ─── Shared factory helper ────────────────────────────────────────────────────
 const subContractFactory = factory({

--- a/ponder/ponder.config.ts
+++ b/ponder/ponder.config.ts
@@ -1,5 +1,5 @@
-import { createConfig, factory } from "ponder";
-import { parseAbiItem } from "viem";
+import { createConfig, factory, loadBalance, rateLimit } from "ponder";
+import { http, fallback, parseAbiItem } from "viem";
 import { FACTORY_BEACON_ABI } from "./abis/factory-beacon";
 import { OFFICER_ABI } from "./abis/officer";
 import { BANK_ABI } from "./abis/bank";
@@ -44,6 +44,46 @@ const feeCollectorAddress = process.env.FEE_COLLECTOR_ADDRESS as `0x${string}`;
 // On Hardhat start from block 0; on Polygon skip pre-deployment blocks.
 const startBlock = isHardhat ? 0 : Number(process.env.START_BLOCK);
 
+// ─── Polygon RPC transport ──────────────────────────────────────────────────
+// Two pools of comma-separated URLs: a primary pool that is load-balanced
+// (round-robin), and an optional backup pool used only when the whole primary
+// pool fails. Each endpoint is independently rate-limited to stay under the
+// provider's per-key limit and avoid 429s.
+const POLYGON_RPS = Number(process.env.PONDER_RPC_MAX_RPS ?? 25);
+
+const parseRpcUrls = (value: string | undefined): string[] =>
+  (value ?? "")
+    .split(",")
+    .map((url) => url.trim())
+    .filter(Boolean);
+
+// Falls back to the legacy single-URL var so existing deployments keep working.
+const primaryRpcUrls = parseRpcUrls(
+  process.env.PONDER_RPC_URLS_137 ?? process.env.PONDER_RPC_URL_137,
+);
+const backupRpcUrls = parseRpcUrls(process.env.PONDER_RPC_URLS_137_BACKUP);
+
+if (!isHardhat && primaryRpcUrls.length === 0) {
+  throw new Error(
+    "Set PONDER_RPC_URLS_137 (comma-separated) or PONDER_RPC_URL_137 for Polygon.",
+  );
+}
+
+const rateLimitedPool = (urls: string[]) =>
+  loadBalance(
+    urls.map((url) => rateLimit(http(url), { requestsPerSecond: POLYGON_RPS })),
+  );
+
+const polygonRpc =
+  primaryRpcUrls.length === 0
+    ? undefined
+    : backupRpcUrls.length > 0
+      ? fallback([
+          rateLimitedPool(primaryRpcUrls),
+          rateLimitedPool(backupRpcUrls),
+        ])
+      : rateLimitedPool(primaryRpcUrls);
+
 // ─── Shared factory helper ────────────────────────────────────────────────────
 const subContractFactory = factory({
   event: CONTRACT_DEPLOYED_EVENT,
@@ -53,7 +93,7 @@ export default createConfig({
   chains: {
     polygon: {
       id: 137,
-      rpc: process.env.PONDER_RPC_URL_137,
+      rpc: polygonRpc,
     },
     ...(isHardhat
       ? {

--- a/ponder/ponder.config.ts
+++ b/ponder/ponder.config.ts
@@ -84,6 +84,10 @@ const polygonRpc =
         ])
       : rateLimitedPool(primaryRpcUrls);
 
+// Optional WebSocket endpoint for real-time block subscriptions (newHeads).
+// Cuts realtime RPC usage vs polling; Ponder reverts to polling if it drops.
+const polygonWs = process.env.PONDER_WS_URL_137 || undefined;
+
 // ─── Shared factory helper ────────────────────────────────────────────────────
 const subContractFactory = factory({
   event: CONTRACT_DEPLOYED_EVENT,
@@ -94,6 +98,7 @@ export default createConfig({
     polygon: {
       id: 137,
       rpc: polygonRpc,
+      ws: polygonWs,
     },
     ...(isHardhat
       ? {


### PR DESCRIPTION
# Description

## Initial Issue Description

Fixes #2040

The Ponder indexer drove all Polygon traffic through a single RPC endpoint (`PONDER_RPC_URL_137`). With many factory-discovered contracts plus continuous block polling, that single key absorbed the full request volume — prone to provider rate limiting (429s) — and any provider hiccup stalled indexing entirely.

## PR Summary Or Solution description

Replaces the single Polygon endpoint with two comma-separated pools wired as a viem `fallback` of `loadBalance` pools, each endpoint independently `rateLimit`-ed, and adds an optional WebSocket endpoint for realtime indexing:

- **Primary pool** — `PONDER_RPC_URLS_137` (CSV), load-balanced round-robin so no single key is hammered.
- **Backup pool** — `PONDER_RPC_URLS_137_BACKUP` (CSV, optional), used only when the entire primary pool fails.
- **Per-endpoint rate limit** — `PONDER_RPC_MAX_RPS` (default 25) applied to each URL to stay under provider limits and avoid 429s.
- **WebSocket** — `PONDER_WS_URL_137` (optional). When set, Ponder subscribes to new blocks over WebSocket instead of polling, cutting realtime RPC usage; it reverts to polling automatically if the socket drops.
- **Backward compatible** — legacy `PONDER_RPC_URL_137` is still honored when the new list is unset; the Hardhat path is unchanged.

This spreads/cushions RPC load, adds failover, and lowers realtime polling; it does not reduce the historical-sync call count (governed by start block + DB persistence, already addressed).

### Reviewer notes

- New env vars must be set on the deployment (documented in `ponder/.env.local.example`): `PONDER_RPC_URLS_137`, `PONDER_RPC_URLS_137_BACKUP`, `PONDER_RPC_MAX_RPS`, `PONDER_WS_URL_137`.
- `loadBalance` / `rateLimit` are re-exported by `ponder@0.16`; `fallback` / `http` come from `viem`. `ws` is a chain-level field.
- Not type-checked locally (worktree has no `node_modules`); run `npm ci && ponder codegen` to validate.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (config-only change; no unit test surface)
- [x] Docs have been added / updated (`ponder/.env.local.example`)