### PR TITLE
fix: 🐛 Polymarket accounting tables — layout, column picker, trade ordering

### DIFF
--- a/dashboard/app/components/accounting/AccountingColumnVisibility.vue
+++ b/dashboard/app/components/accounting/AccountingColumnVisibility.vue
@@ -6,13 +6,27 @@
       size="sm"
       icon="i-lucide-columns-3"
       trailing-icon="i-lucide-chevron-down"
-      :ui="{ trailingIcon: open ? 'rotate-180 transition-transform' : 'transition-transform' }"
+      class="w-44 justify-start"
+      :ui="{ trailingIcon: open ? 'ms-auto rotate-180 transition-transform' : 'ms-auto transition-transform' }"
     >
-      Columns<span v-if="hiddenCount > 0" class="text-muted">· {{ hiddenCount }} hidden</span>
+      <span class="truncate">{{ summary }}</span>
     </UButton>
 
     <template #content>
       <div class="p-1 min-w-44 max-h-80 overflow-y-auto">
+        <button
+          type="button"
+          class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-elevated"
+          @click="toggleAll"
+        >
+          <UIcon
+            :name="allSelected ? 'i-lucide-check' : 'i-lucide-minus'"
+            class="w-4 h-4 shrink-0"
+            :class="allSelected ? 'text-primary' : 'text-transparent'"
+          />
+          All columns
+        </button>
+        <USeparator class="my-1" />
         <button
           v-for="item in items"
           :key="item.value"
@@ -36,9 +50,11 @@
 import { computed, ref } from 'vue'
 
 /**
- * Column-visibility picker for the General Ledger. Uses a single `UPopover`
- * trigger (no nested select/button chrome) and toggles visible keys via
- * `v-model`.
+ * Column-visibility picker for the General Ledger. Mirrors
+ * `AccountingCategoryFilter`: a single `UButton` trigger summarising the
+ * selection plus toggleable entries. "All columns" selects the whole set, or
+ * clears it so the user can pick a fresh subset. An empty selection is allowed
+ * (the table then shows no columns).
  */
 
 export interface ColumnOption<K2 extends string> {
@@ -57,19 +73,34 @@ const emit = defineEmits<{
 
 const open = ref(false)
 
-const hiddenCount = computed(() => props.items.length - props.modelValue.length)
+const allSelected = computed(() => props.modelValue.length === props.items.length)
+
+const summary = computed(() => {
+  if (allSelected.value) {
+    return 'All columns'
+  }
+  if (props.modelValue.length === 0) {
+    return 'No columns'
+  }
+  if (props.modelValue.length === 1) {
+    return props.items.find(item => item.value === props.modelValue[0])?.label ?? '1 column'
+  }
+  return `${props.modelValue.length} columns`
+})
 
 function isSelected(value: K): boolean {
   return props.modelValue.includes(value)
+}
+
+function toggleAll(): void {
+  // Already all selected → clear, so the user can pick a fresh subset.
+  emit('update:modelValue', allSelected.value ? [] : props.items.map(item => item.value))
 }
 
 function toggle(value: K): void {
   const next = [...props.modelValue]
   const idx = next.indexOf(value)
   if (idx >= 0) {
-    if (next.length <= 1) {
-      return
-    }
     next.splice(idx, 1)
   } else {
     next.push(value)

--- a/dashboard/app/components/accounting/AccountingIncomeStatement.vue
+++ b/dashboard/app/components/accounting/AccountingIncomeStatement.vue
@@ -123,14 +123,22 @@
     </UPageCard>
 
     <UPageCard v-if="hasAddress" variant="subtle">
-      <h3 class="font-semibold text-black dark:text-white mb-1">
-        Trades by position · {{ totalPositions }} positions
-      </h3>
-      <p class="text-sm text-muted mb-4">
-        Each position groups its buys and sells. <strong>Net = returned − invested</strong> is your
-        profit on the position (cash basis — a still-open position doesn't yet credit the unsold shares).
-        Click a position to expand its trades.
-      </p>
+      <div class="flex flex-col sm:flex-row sm:items-start justify-between gap-3 mb-4">
+        <div>
+          <h3 class="font-semibold text-black dark:text-white mb-1">
+            Trades by position · {{ totalPositions }} positions
+          </h3>
+          <p class="text-sm text-muted">
+            Each position groups its buys and sells. <strong>Net = returned − invested</strong> is your
+            profit on the position (cash basis — a still-open position doesn't yet credit the unsold shares).
+            Click a position to expand its trades.
+          </p>
+        </div>
+        <AccountingTableSearch
+          v-model="tradesSearchQuery"
+          placeholder="Search position, outcome…"
+        />
+      </div>
 
       <UTable
         :data="pagedTrades"
@@ -237,7 +245,9 @@ import type { PolymarketActivity, PolymarketPosition } from '~/types/polymarket'
 import { useAccountingPeriod } from '~/composables/useAccountingPeriod'
 import { formatSignedUsd, formatUsd, type LedgerCategoryColor, signClass } from '~/utils/accounting'
 import { buildIncomeStatement } from '~/utils/incomeStatement'
+import { matchesAccountingSearch, normalizeAccountingSearchQuery } from '~/utils/accountingSearch'
 import AccountingPagination from './AccountingPagination.vue'
+import AccountingTableSearch from './AccountingTableSearch.vue'
 
 const props = defineProps<{
   activities: PolymarketActivity[]
@@ -249,6 +259,7 @@ const props = defineProps<{
 
 const pageSize = ref(20)
 const currentPage = ref(1)
+const tradesSearchQuery = ref('')
 
 const {
   todayStr,
@@ -259,7 +270,7 @@ const {
   presetOptions: periodPresetOptions
 } = useAccountingPeriod()
 
-watch([() => props.walletAddress, accountingPeriod], () => {
+watch([() => props.walletAddress, accountingPeriod, tradesSearchQuery], () => {
   currentPage.value = 1
 })
 
@@ -276,6 +287,14 @@ const statement = computed(() =>
 const isReconciled = computed(() => Math.abs(statement.value.reconciliationGap) < 1)
 
 type PositionAction = 'BUY' | 'SELL' | 'SPLIT' | 'MERGE' | 'REDEEM'
+
+const ACTION_META: Record<PositionAction, { label: string, color: LedgerCategoryColor }> = {
+  BUY: { label: 'Buy', color: 'info' },
+  SELL: { label: 'Sell', color: 'warning' },
+  SPLIT: { label: 'Split', color: 'neutral' },
+  MERGE: { label: 'Merge', color: 'neutral' },
+  REDEEM: { label: 'Redeem', color: 'primary' }
+}
 
 interface PositionTrade {
   /** Market grouping key — conditionId when present, robust across buys & redeems. */
@@ -361,13 +380,40 @@ const positionGroups = computed<PositionTrade[][]>(() => {
   return [...byMarket.values()].sort((a, b) => lastTs(b) - lastTs(a))
 })
 
-const totalPositions = computed(() => positionGroups.value.length)
+function positionGroupMatchesSearch(group: PositionTrade[], query: string): boolean {
+  const sample = group[0]
+  if (!sample) {
+    return false
+  }
+  if (matchesAccountingSearch(query, sample.market, sample.outcome)) {
+    return true
+  }
+  return group.some(trade =>
+    matchesAccountingSearch(
+      query,
+      trade.market,
+      trade.outcome,
+      ACTION_META[trade.action].label
+    )
+  )
+}
+
+const filteredPositionGroups = computed(() => {
+  if (!normalizeAccountingSearchQuery(tradesSearchQuery.value)) {
+    return positionGroups.value
+  }
+  return positionGroups.value.filter(group =>
+    positionGroupMatchesSearch(group, tradesSearchQuery.value)
+  )
+})
+
+const totalPositions = computed(() => filteredPositionGroups.value.length)
 
 // Paginate by position, then hand the table a flat list of that page's trades —
 // UTable regroups them via the `position` grouping column. Each trade carries
 // its block's zebra parity so the whole position (header + leaves) shares a shade.
 const pagedTrades = computed<PositionTrade[]>(() =>
-  positionGroups.value
+  filteredPositionGroups.value
     .slice((currentPage.value - 1) * pageSize.value, currentPage.value * pageSize.value)
     .flatMap((group, index) => group.map(trade => ({ ...trade, groupEven: index % 2 === 0 })))
 )
@@ -399,14 +445,6 @@ const tableMeta = {
       return row.getIsGrouped() ? `${zebra} font-semibold` : zebra
     }
   }
-}
-
-const ACTION_META: Record<PositionAction, { label: string, color: LedgerCategoryColor }> = {
-  BUY: { label: 'Buy', color: 'info' },
-  SELL: { label: 'Sell', color: 'warning' },
-  SPLIT: { label: 'Split', color: 'neutral' },
-  MERGE: { label: 'Merge', color: 'neutral' },
-  REDEEM: { label: 'Redeem', color: 'primary' }
 }
 
 /** Market title for a group header row (read off its first child trade). */

--- a/dashboard/app/components/accounting/AccountingIncomeStatement.vue
+++ b/dashboard/app/components/accounting/AccountingIncomeStatement.vue
@@ -356,7 +356,7 @@ const positionGroups = computed<PositionTrade[][]>(() => {
   }
   const lastTs = (trades: PositionTrade[]): number => Math.max(...trades.map(t => t.timestamp))
   for (const trades of byMarket.values()) {
-    trades.sort((a, b) => a.timestamp - b.timestamp) // chronological: buys before sells
+    trades.sort((a, b) => b.timestamp - a.timestamp) // most recent first when expanded
   }
   return [...byMarket.values()].sort((a, b) => lastTs(b) - lastTs(a))
 })

--- a/dashboard/app/components/accounting/AccountingIncomeStatement.vue
+++ b/dashboard/app/components/accounting/AccountingIncomeStatement.vue
@@ -140,7 +140,7 @@
         :meta="tableMeta"
         :loading="isLoading"
         :ui="{
-          base: 'table-fixed border-separate border-spacing-0',
+          base: 'table-auto border-separate border-spacing-0',
           thead: '[&>tr]:bg-elevated/50 [&>tr]:after:content-none',
           tbody: '[&>tr]:last:[&>td]:border-b-0',
           th: 'py-2 first:rounded-l-lg last:rounded-r-lg border-y border-default first:border-l last:border-r',
@@ -160,15 +160,15 @@
           <div v-if="row.getIsGrouped()" class="space-y-0.5">
             <button
               type="button"
-              class="flex items-center gap-2 text-left font-medium cursor-pointer"
+              class="flex items-start gap-2 text-left font-medium cursor-pointer"
               @click="row.toggleExpanded()"
             >
               <UIcon
                 :name="row.getIsExpanded() ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'"
-                class="w-4 h-4 shrink-0 text-muted"
+                class="w-4 h-4 shrink-0 text-muted mt-0.5"
               />
-              <span class="truncate max-w-xs">{{ groupLabel(row) }}</span>
-              <span class="text-muted text-xs">({{ row.getLeafRows().length }})</span>
+              <span class="wrap-break-word min-w-48">{{ groupLabel(row) }}</span>
+              <span class="text-muted text-xs shrink-0">({{ row.getLeafRows().length }})</span>
             </button>
             <p class="pl-6 text-xs text-muted">
               Invested {{ formatUsd(groupInvested(row)) }} · Returned {{ formatUsd(groupReturned(row)) }}
@@ -446,7 +446,7 @@ function groupSoldShares(row: Row<PositionTrade>): number {
 }
 
 function formatDate(ts: number): string {
-  return ts ? format(new Date(ts * 1000), 'MMM d, yyyy') : '—'
+  return ts ? format(new Date(ts * 1000), 'MMM d, yyyy HH:mm') : '—'
 }
 
 function formatShares(value: number | undefined): string {

--- a/dashboard/app/components/accounting/AccountingLedger.vue
+++ b/dashboard/app/components/accounting/AccountingLedger.vue
@@ -11,6 +11,10 @@
           </p>
         </div>
         <div class="flex items-center gap-2 flex-wrap">
+          <AccountingTableSearch
+            v-model="searchQuery"
+            placeholder="Search market, account, tx…"
+          />
           <USelect
             v-model="periodPreset"
             :items="periodPresetOptions"
@@ -212,9 +216,11 @@ import {
   type MergedColumnKey,
   type MergedLedgerRow
 } from '~/utils/mergedLedger'
+import { matchesAccountingSearch, normalizeAccountingSearchQuery } from '~/utils/accountingSearch'
 import AccountingCategoryFilter, {
   type CategoryOption
 } from './AccountingCategoryFilter.vue'
+import AccountingTableSearch from './AccountingTableSearch.vue'
 import AccountingColumnVisibility, {
   type ColumnOption
 } from './AccountingColumnVisibility.vue'
@@ -249,6 +255,7 @@ const generalLedger = computed(() =>
 
 const pageSize = ref(20)
 const currentPage = ref(1)
+const searchQuery = ref('')
 
 const categoryOptions: CategoryOption<LedgerCategory>[] = Object.entries(CATEGORY_META).map(
   ([value, meta]) => ({
@@ -261,7 +268,7 @@ const allCategoryValues = categoryOptions.map(option => option.value)
 // Multi-select: every category selected == "All categories".
 const selectedCategories = ref<LedgerCategory[]>([...allCategoryValues])
 
-watch([() => props.walletAddress, selectedCategories, accountingPeriod], () => {
+watch([() => props.walletAddress, selectedCategories, accountingPeriod, searchQuery], () => {
   currentPage.value = 1
 })
 
@@ -280,12 +287,35 @@ function inSelectedPeriod(timestamp: number): boolean {
 
 const selectedCategorySet = computed(() => new Set(selectedCategories.value))
 
+function ledgerRowMatchesSearch(row: MergedLedgerRow, query: string): boolean {
+  const meta = CATEGORY_META[row.entry.category]
+  return matchesAccountingSearch(
+    query,
+    row.entry.description,
+    row.entry.outcome,
+    meta.label,
+    row.entry.txHash,
+    row.entry.counterparty,
+    row.entry.marketSlug,
+    row.account
+  )
+}
+
 const filteredRows = computed(() => {
-  const rows = allRows.value.filter(row => inSelectedPeriod(row.entry.timestamp))
-  if (selectedCategories.value.length === allCategoryValues.length) {
+  let rows = allRows.value.filter(row => inSelectedPeriod(row.entry.timestamp))
+  if (selectedCategories.value.length !== allCategoryValues.length) {
+    rows = rows.filter(row => selectedCategorySet.value.has(row.entry.category))
+  }
+  if (!normalizeAccountingSearchQuery(searchQuery.value)) {
     return rows
   }
-  return rows.filter(row => selectedCategorySet.value.has(row.entry.category))
+  const matchingEntryIds = new Set<string>()
+  for (const row of rows) {
+    if (ledgerRowMatchesSearch(row, searchQuery.value)) {
+      matchingEntryIds.add(row.entry.id)
+    }
+  }
+  return rows.filter(row => matchingEntryIds.has(row.entry.id))
 })
 
 // Pagination counts ACTIVITIES (isFirst rows), not journal lines — a page of

--- a/dashboard/app/components/accounting/AccountingLedger.vue
+++ b/dashboard/app/components/accounting/AccountingLedger.vue
@@ -50,7 +50,7 @@
         :columns="columns"
         :loading="isLoading"
         :ui="{
-          base: 'table-fixed border-separate border-spacing-0',
+          base: 'table-auto border-separate border-spacing-0',
           thead: '[&>tr]:bg-elevated/50 [&>tr]:after:content-none',
           tbody: '[&>tr]:last:[&>td]:border-b-0',
           th: 'py-2 first:rounded-l-lg last:rounded-r-lg border-y border-default first:border-l last:border-r',
@@ -83,7 +83,7 @@
         </template>
 
         <template #market-cell="{ row }">
-          <div v-if="row.original.isFirst" class="flex items-center gap-2 max-w-xs">
+          <div v-if="row.original.isFirst" class="flex items-start gap-2 min-w-48">
             <img
               v-if="row.original.entry.icon"
               :src="row.original.entry.icon"
@@ -95,11 +95,11 @@
               :href="marketUrl(row.original.entry)!"
               target="_blank"
               rel="noopener noreferrer"
-              class="truncate hover:underline text-black dark:text-white"
+              class="wrap-break-word hover:underline text-black dark:text-white"
             >
               {{ row.original.entry.description }}
             </a>
-            <span v-else class="truncate">{{ row.original.entry.description }}</span>
+            <span v-else class="wrap-break-word">{{ row.original.entry.description }}</span>
           </div>
         </template>
 

--- a/dashboard/app/components/accounting/AccountingPositions.vue
+++ b/dashboard/app/components/accounting/AccountingPositions.vue
@@ -1,15 +1,21 @@
 <template>
   <UPageCard variant="subtle">
-    <h3 class="font-semibold text-black dark:text-white mb-4">
-      Positions · {{ positions.length }}
-    </h3>
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
+      <h3 class="font-semibold text-black dark:text-white">
+        Positions · {{ filteredPositions.length }}
+      </h3>
+      <AccountingTableSearch
+        v-model="searchQuery"
+        placeholder="Search market, outcome…"
+      />
+    </div>
 
     <UTable
       :data="pagedPositions"
       :columns="columns"
       :loading="isLoading"
       :ui="{
-        base: 'table-fixed border-separate border-spacing-0',
+        base: 'table-auto border-separate border-spacing-0',
         thead: '[&>tr]:bg-elevated/50 [&>tr]:after:content-none',
         tbody: '[&>tr]:last:[&>td]:border-b-0',
         th: 'py-2 first:rounded-l-lg last:rounded-r-lg border-y border-default first:border-l last:border-r',
@@ -30,7 +36,7 @@
       </template>
 
       <template #market-cell="{ row }">
-        <div class="flex items-center gap-2 max-w-xs">
+        <div class="flex items-start gap-2 min-w-48">
           <img
             v-if="row.original.icon"
             :src="row.original.icon"
@@ -42,11 +48,11 @@
             :href="marketUrl(row.original)!"
             target="_blank"
             rel="noopener noreferrer"
-            class="truncate hover:underline text-black dark:text-white"
+            class="wrap-break-word hover:underline text-black dark:text-white"
           >
             {{ row.original.title ?? "—" }}
           </a>
-          <span v-else class="truncate">{{ row.original.title ?? "—" }}</span>
+          <span v-else class="wrap-break-word">{{ row.original.title ?? "—" }}</span>
         </div>
       </template>
 
@@ -92,7 +98,7 @@
     <AccountingPagination
       v-model:page="currentPage"
       v-model:page-size="pageSize"
-      :total="sortedPositions.length"
+      :total="filteredPositions.length"
       noun="positions"
     />
   </UPageCard>
@@ -102,7 +108,9 @@
 import { computed, ref, watch } from 'vue'
 import type { PolymarketPosition } from '~/types/polymarket'
 import { formatSignedUsd, formatUsd, signClass } from '~/utils/accounting'
+import { matchesAccountingSearch, normalizeAccountingSearchQuery } from '~/utils/accountingSearch'
 import AccountingPagination from './AccountingPagination.vue'
+import AccountingTableSearch from './AccountingTableSearch.vue'
 
 const props = defineProps<{
   positions: PolymarketPosition[]
@@ -112,18 +120,40 @@ const props = defineProps<{
 
 const pageSize = ref(20)
 const currentPage = ref(1)
+const searchQuery = ref('')
 
 /** Open positions first (size > 0), then by current value. */
 const sortedPositions = computed(() =>
   [...props.positions].sort((a, b) => (b.currentValue ?? 0) - (a.currentValue ?? 0))
 )
 
-const pagedPositions = computed(() => {
-  const start = (currentPage.value - 1) * pageSize.value
-  return sortedPositions.value.slice(start, start + pageSize.value)
+function positionMatchesSearch(position: PolymarketPosition, query: string): boolean {
+  return matchesAccountingSearch(
+    query,
+    position.title,
+    position.outcome,
+    position.slug,
+    position.eventSlug,
+    position.conditionId,
+    position.asset
+  )
+}
+
+const filteredPositions = computed(() => {
+  if (!normalizeAccountingSearchQuery(searchQuery.value)) {
+    return sortedPositions.value
+  }
+  return sortedPositions.value.filter(position =>
+    positionMatchesSearch(position, searchQuery.value)
+  )
 })
 
-watch(() => props.positions, () => {
+const pagedPositions = computed(() => {
+  const start = (currentPage.value - 1) * pageSize.value
+  return filteredPositions.value.slice(start, start + pageSize.value)
+})
+
+watch([() => props.positions, searchQuery], () => {
   currentPage.value = 1
 })
 

--- a/dashboard/app/components/accounting/AccountingTableSearch.vue
+++ b/dashboard/app/components/accounting/AccountingTableSearch.vue
@@ -1,0 +1,44 @@
+<template>
+  <UInput
+    v-model="model"
+    icon="i-lucide-search"
+    :placeholder="placeholder"
+    :disabled="disabled"
+    size="sm"
+    :class="inputClass"
+    :ui="{ trailing: 'pe-1' }"
+    autocomplete="off"
+  >
+    <template v-if="model?.length" #trailing>
+      <UButton
+        color="neutral"
+        variant="link"
+        size="sm"
+        icon="i-lucide-circle-x"
+        aria-label="Clear search"
+        @click="model = ''"
+      />
+    </template>
+  </UInput>
+</template>
+
+<script setup lang="ts">
+/**
+ * Local search field for accounting tables. Each parent keeps its own
+ * `ref` / `defineModel` — instances do not share state.
+ */
+const model = defineModel<string>({ default: '' })
+
+withDefaults(
+  defineProps<{
+    placeholder?: string
+    disabled?: boolean
+    inputClass?: string
+  }>(),
+  {
+    placeholder: 'Search…',
+    disabled: false,
+    inputClass: 'w-full sm:w-64'
+  }
+)
+</script>

--- a/dashboard/app/utils/accountingSearch.ts
+++ b/dashboard/app/utils/accountingSearch.ts
@@ -1,0 +1,23 @@
+/**
+ * Case-insensitive substring match for accounting table search boxes.
+ * Empty or whitespace-only query matches every row.
+ */
+export function normalizeAccountingSearchQuery(query: string): string {
+  return query.trim().toLowerCase()
+}
+
+export function matchesAccountingSearch(
+  query: string,
+  ...fields: (string | number | undefined | null)[]
+): boolean {
+  const normalized = normalizeAccountingSearchQuery(query)
+  if (!normalized) {
+    return true
+  }
+  return fields.some((field) => {
+    if (field == null) {
+      return false
+    }
+    return String(field).toLowerCase().includes(normalized)
+  })
+}


### PR DESCRIPTION

## Summary

Improves Polymarket accounting table UX on the dashboard **General Ledger** and **Income Statement** tabs:

Fixes #2053 

- **Layout** — Switch tables from `table-fixed` to `table-auto` and replace `truncate` / `max-w-xs` with `wrap-break-word` and sensible min widths so long market titles remain readable.
- **Column picker** — Align `AccountingColumnVisibility` with `AccountingCategoryFilter`: **All columns** toggles the full set or clears it for a fresh subset; trigger shows a selection summary; individual columns can all be turned off.
- **Income Statement trades** — Sort expanded position trades most-recent-first; show `HH:mm` on leaf date cells.

## Changes

| File | What |
|------|------|
| `AccountingLedger.vue` | `table-auto`, wrapping market column  & search mode |
| `AccountingIncomeStatement.vue` | `table-auto`, wrapping position header, trade sort, datetime format  & search mode |
| `AccountingColumnVisibility.vue` | **All columns**, summary label, remove last-column lock |
| `AccountingPositions.vue` | ** add search mode |

