### PR TITLE
feat: ✨ add dark mode toggle to navbar

### DIFF
--- a/app/src/components/NavBar.vue
+++ b/app/src/components/NavBar.vue
@@ -12,6 +12,8 @@
           </span>
         </UButton>
 
+        <UColorModeButton data-test="color-mode-button" />
+
         <NotificationDropdown />
 
         <UDropdownMenu :items="profileItems" data-test="profile">


### PR DESCRIPTION
## What
Adds a `UColorModeButton` to the navbar so users can switch between light and dark themes.

## Why
`@nuxt/ui` v4 ships built-in color mode support, but the app had no UI control to toggle it.

## Changes
- `app/src/components/NavBar.vue`: add `<UColorModeButton data-test="color-mode-button" />` next to the notification dropdown.

Closes #2055