### PR TITLE
ci: 👷 run app-e2e in the official Playwright container

### DIFF
--- a/.github/workflows/app-e2e.yml
+++ b/.github/workflows/app-e2e.yml
@@ -57,10 +57,16 @@ jobs:
 
       - name: ✅ Upload coverage to Codecov
         if: always()
-        continue-on-error: true # codecov-action@v4 occasionally EPIPEs on GPG verify
-        uses: codecov/codecov-action@v4.0.1
+        # Coverage upload must never gate the e2e job, but it must still work.
+        # v4.0.1 (a Node 20 action) sends `service: None` from inside the
+        # Playwright container and the upload silently fails; v5 fixes container
+        # detection and runs on Node 24. `slug` is passed explicitly so it never
+        # falls back to fragile git introspection inside the container.
+        continue-on-error: true
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ${{ github.repository }}
           files: ./app/coverage/e2e/lcov.info
           flags: app-e2e-tests
 

--- a/.github/workflows/app-e2e.yml
+++ b/.github/workflows/app-e2e.yml
@@ -18,7 +18,15 @@ jobs:
   app-e2e-test:
     if: github.event.action != 'labeled' || github.event.label.name == 'run'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Run inside the official Playwright image: Chromium and its system deps are
+    # preinstalled, so there is no browser download in the critical path.
+    # `playwright install` pulls Chromium from the azureedge.net CDN, which
+    # stalled for >20 min and timed the job out. Caching could not rescue it:
+    # actions/cache only writes in a post-step that is skipped when the job is
+    # cancelled, so a timed-out run never seeds the cache for the next one.
+    # Keep this tag in sync with @playwright/test in app/package.json.
+    container: mcr.microsoft.com/playwright:v1.48.2-noble
+    timeout-minutes: 15
 
     steps:
       - name: 🛫 Checkout
@@ -33,17 +41,6 @@ jobs:
 
       - name: 📦 Install dependencies
         run: npm ci
-        working-directory: ./app
-
-      - name: 🎭 Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('app/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-playwright-
-
-      - name: 🎭 Install Playwright browsers
-        run: npx playwright install chromium --with-deps
         working-directory: ./app
 
       - name: 🧪 Run E2E tests with coverage instrumentation

--- a/.github/workflows/app-e2e.yml
+++ b/.github/workflows/app-e2e.yml
@@ -18,7 +18,7 @@ jobs:
   app-e2e-test:
     if: github.event.action != 'labeled' || github.event.label.name == 'run'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - name: 🛫 Checkout
@@ -34,6 +34,13 @@ jobs:
       - name: 📦 Install dependencies
         run: npm ci
         working-directory: ./app
+
+      - name: 🎭 Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('app/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-playwright-
 
       - name: 🎭 Install Playwright browsers
         run: npx playwright install chromium --with-deps


### PR DESCRIPTION
## Problem

`app-e2e-test` (`.github/workflows/app-e2e.yml`) intermittently fails by hitting `timeout-minutes`. On the failing runs the job stalls inside **🎭 Install Playwright browsers** while downloading Chromium from `https://playwright.azureedge.net` — that single download ran **>24 min** and was cancelled at the cap, so the actual E2E test step never executed.

## Why caching (the original plan from #2070) does not fix it

`actions/cache` only **writes** its entry in a post-job step, and that post-step is **skipped when the job is cancelled** (timeout). So a timed-out run never seeds the cache → the next run is still a cache miss → it downloads from the same stalling CDN → it times out again. Chicken-and-egg: the cache can never be populated as long as a single download can't complete. Raising the timeout alone doesn't help either, since the download by itself already exceeds the budget.

## Fix

Run the job inside the **official Playwright image** `mcr.microsoft.com/playwright:v1.48.2-noble` (Alternative #1 in the issue). Chromium and its system dependencies are baked into the image — pulled from Microsoft's container registry on the Azure backbone, not the failing Edgio CDN — so there is **no browser download in the critical path**. This also removes the `apt-get --with-deps` work.

Concretely:
- Add `container: mcr.microsoft.com/playwright:v1.48.2-noble` (tag tracks `@playwright/test` in `app/package.json`).
- Drop the now-useless `🎭 Cache Playwright browsers` and `🎭 Install Playwright browsers` steps.
- Revert `timeout-minutes` to `15` (the >20 min download is gone).

## Follow-on: fix e2e coverage upload inside the container

Making the job actually reach the Codecov step (in a container) surfaced a pre-existing silent failure that `continue-on-error: true` had been masking: `codecov-action@v4.0.1` (a Node 20 action) sends `service: None` to the Codecov API from inside the container, so commit/report creation and the upload all fail — even though `nyc` generates the lcov report correctly (~34% line coverage). Upgraded `codecov-action` v4.0.1 → v5 (fixed container detection, runs on Node 24) and pass `slug` explicitly. Coverage now uploads (`git_service: github`, "Upload queued for processing complete").

## Result (measured)

| | Before | After |
|---|---|---|
| Job total | cancelled at **25 min** | **~1m30s** |
| E2E test step | **never ran** | **runs (~15s)** ✅ |
| Codecov upload | n/a (job cancelled) | **succeeds** ✅ |

## Acceptance

- The job no longer downloads a browser; the E2E test step actually runs.
- The job completes well within the timeout.
- e2e coverage is uploaded to Codecov.

Closes #2070