### PR TITLE
feat: ✨ "Cash out all" action on team dashboard

### DIFF
--- a/app/src/components/sections/DashboardView/CashOutAllAction.vue
+++ b/app/src/components/sections/DashboardView/CashOutAllAction.vue
@@ -1,0 +1,251 @@
+<template>
+  <div v-if="isOwner" class="flex justify-end">
+    <TeamArchivedTooltip v-slot="{ disabled: archivedDisabled }">
+      <UButton
+        color="warning"
+        icon="i-heroicons-banknotes"
+        :disabled="!hasAnyBalance || cashOut.isRunning.value || archivedDisabled"
+        data-test="cash-out-all-button"
+        label="Cash out all"
+        @click="openModal"
+      />
+    </TeamArchivedTooltip>
+
+    <UModal
+      v-if="modal.mount"
+      v-model:open="modal.show"
+      title="Cash out all accounts"
+      :description="
+        phase === 'review'
+          ? 'Review what will be withdrawn before signing.'
+          : 'Each account is a separate transaction to confirm in your wallet.'
+      "
+      :close="phase === 'progress' && cashOut.isRunning.value ? false : { onClick: closeModal }"
+    >
+      <template #body>
+        <!-- Review phase -->
+        <div v-if="phase === 'review'" class="space-y-4" data-test="cash-out-review">
+          <UAlert
+            color="warning"
+            variant="soft"
+            icon="i-heroicons-exclamation-triangle"
+            title="This empties your treasury to your wallet."
+            description="Cash Remuneration and Expense funds are first moved into the Bank, then the whole Bank balance is sent to your connected wallet. You will sign one transaction per account (the Bank may need one signature per token)."
+          />
+
+          <div
+            class="divide-y divide-gray-100 rounded-lg border border-gray-200 dark:divide-gray-800 dark:border-gray-800"
+          >
+            <div
+              v-for="row in reviewRows"
+              :key="row.label"
+              class="flex items-center justify-between px-3 py-2 text-sm"
+              :data-test="`cash-out-review-${row.key}`"
+            >
+              <span class="text-gray-500 dark:text-gray-400">{{ row.label }}</span>
+              <span class="font-medium">{{ row.value }}</span>
+            </div>
+            <div
+              class="flex items-center justify-between px-3 py-2 text-sm"
+              data-test="cash-out-review-bank"
+            >
+              <span class="font-medium">Bank → your wallet</span>
+              <span class="font-semibold">~{{ projectedBankFormatted }}</span>
+            </div>
+          </div>
+
+          <p class="text-xs text-gray-500 dark:text-gray-400">
+            The Bank charges a small transfer fee, so the received amount is slightly lower.
+          </p>
+
+          <div class="flex justify-end gap-2">
+            <UButton
+              color="neutral"
+              variant="outline"
+              data-test="cash-out-all-cancel"
+              @click="closeModal"
+            >
+              Cancel
+            </UButton>
+            <UButton
+              color="warning"
+              :disabled="!hasAnyBalance"
+              data-test="cash-out-all-confirm"
+              label="Cash out all"
+              @click="confirm"
+            />
+          </div>
+        </div>
+
+        <!-- Progress phase -->
+        <div v-else class="space-y-4" data-test="cash-out-progress">
+          <ul class="space-y-2">
+            <li
+              v-for="step in cashOut.steps.value"
+              :key="step.key"
+              class="flex items-start gap-3 rounded-lg border border-gray-200 px-3 py-2 dark:border-gray-800"
+              :data-test="`cash-out-step-${step.key}`"
+            >
+              <UIcon
+                :name="stepIcon(step.status)"
+                :class="['mt-0.5 size-5 shrink-0', stepIconClass(step.status)]"
+              />
+              <div class="min-w-0 flex-1">
+                <p class="font-medium">{{ step.label }}</p>
+                <p v-if="step.status === 'active' && step.detail" class="text-xs text-gray-500">
+                  {{ step.detail }}
+                </p>
+                <p
+                  v-if="step.status === 'failed' && step.error"
+                  class="text-error text-xs"
+                  :data-test="`cash-out-error-${step.key}`"
+                >
+                  {{ step.error }}
+                </p>
+              </div>
+            </li>
+          </ul>
+
+          <UAlert
+            v-if="cashOut.isComplete.value"
+            color="success"
+            variant="soft"
+            icon="i-heroicons-check-circle"
+            title="Cash out complete"
+            description="All available funds were sent to your wallet."
+            data-test="cash-out-complete"
+          />
+
+          <div class="flex justify-end gap-2">
+            <UButton
+              v-if="cashOut.hasFailed.value"
+              color="warning"
+              :loading="cashOut.isRunning.value"
+              data-test="cash-out-all-retry"
+              label="Retry"
+              @click="retry"
+            />
+            <UButton
+              color="neutral"
+              variant="outline"
+              :disabled="cashOut.isRunning.value"
+              data-test="cash-out-all-done"
+              :label="cashOut.isComplete.value ? 'Done' : 'Close'"
+              @click="closeModal"
+            />
+          </div>
+        </div>
+      </template>
+    </UModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { Address } from 'viem'
+import { useContractBalance } from '@/composables'
+import { useBankOwner } from '@/composables/bank/reads'
+import { buildCashOutPlan, useCashOutAll } from '@/composables/cashOut'
+import type { CashOutStepStatus } from '@/composables/cashOut'
+import { useCurrencyStore, useTeamStore, useUserDataStore } from '@/stores'
+import { formatCurrencyShort } from '@/utils/currencyUtil'
+import TeamArchivedTooltip from '@/components/TeamArchivedTooltip.vue'
+
+const teamStore = useTeamStore()
+const userStore = useUserDataStore()
+const currencyStore = useCurrencyStore()
+const toast = useToast()
+
+const bankAddress = computed(() => teamStore.getContractAddressByType('Bank'))
+const cashRemAddress = computed(() => teamStore.getContractAddressByType('CashRemunerationEIP712'))
+const expenseAddress = computed(() => teamStore.getContractAddressByType('ExpenseAccountEIP712'))
+
+const bankBalance = useContractBalance(bankAddress as unknown as Address)
+const cashRemBalance = useContractBalance(cashRemAddress as unknown as Address)
+const expenseBalance = useContractBalance(expenseAddress as unknown as Address)
+
+const { data: bankOwner } = useBankOwner()
+
+const currencyCode = computed(() => currencyStore.localCurrency.code)
+const fiat = (balance: ReturnType<typeof useContractBalance>) =>
+  balance.total.value[currencyCode.value]?.value ?? 0
+const fiatFormatted = (balance: ReturnType<typeof useContractBalance>) =>
+  balance.total.value[currencyCode.value]?.formated ?? '—'
+
+const isOwner = computed(() => {
+  if (!bankOwner.value || !userStore.address) return false
+  return String(bankOwner.value).toLowerCase() === userStore.address.toLowerCase()
+})
+
+const balancesFiat = computed(() => ({
+  cashRemuneration: fiat(cashRemBalance),
+  expense: fiat(expenseBalance),
+  bank: fiat(bankBalance)
+}))
+
+const plan = computed(() => buildCashOutPlan(balancesFiat.value))
+const hasAnyBalance = computed(() => plan.value.length > 0)
+
+const projectedBankFormatted = computed(() =>
+  formatCurrencyShort(
+    balancesFiat.value.cashRemuneration + balancesFiat.value.expense + balancesFiat.value.bank,
+    currencyCode.value
+  )
+)
+
+const reviewRows = computed(() => {
+  const rows: { key: string; label: string; value: string }[] = []
+  if (balancesFiat.value.cashRemuneration > 0)
+    rows.push({
+      key: 'cashRemuneration',
+      label: 'Cash Remuneration',
+      value: fiatFormatted(cashRemBalance)
+    })
+  if (balancesFiat.value.expense > 0)
+    rows.push({ key: 'expense', label: 'Expense Account', value: fiatFormatted(expenseBalance) })
+  return rows
+})
+
+const cashOut = useCashOutAll()
+
+const modal = ref({ mount: false, show: false })
+const phase = ref<'review' | 'progress'>('review')
+
+const openModal = () => {
+  cashOut.reset()
+  phase.value = 'review'
+  modal.value = { mount: true, show: true }
+}
+
+const closeModal = () => {
+  modal.value = { mount: false, show: false }
+  phase.value = 'review'
+  cashOut.reset()
+}
+
+const confirm = async () => {
+  phase.value = 'progress'
+  await cashOut.start(plan.value)
+  if (cashOut.isComplete.value) {
+    toast.add({ title: 'Cash out complete', color: 'success' })
+  }
+}
+
+const retry = () => cashOut.retry()
+
+const stepIcon = (status: CashOutStepStatus) =>
+  ({
+    pending: 'i-heroicons-clock',
+    active: 'i-heroicons-arrow-path',
+    success: 'i-heroicons-check-circle',
+    failed: 'i-heroicons-x-circle'
+  })[status]
+
+const stepIconClass = (status: CashOutStepStatus) =>
+  ({
+    pending: 'text-gray-400',
+    active: 'animate-spin text-warning',
+    success: 'text-success',
+    failed: 'text-error'
+  })[status]
+</script>

--- a/app/src/components/sections/DashboardView/CompanyOverview.vue
+++ b/app/src/components/sections/DashboardView/CompanyOverview.vue
@@ -2,7 +2,10 @@
   <div class="flex flex-col gap-6">
     <!-- Treasury Overview -->
     <div class="flex flex-col gap-4">
-      <h3 class="text-lg font-semibold">Treasury Overview</h3>
+      <div class="flex items-center justify-between gap-2">
+        <h3 class="text-lg font-semibold">Treasury Overview</h3>
+        <CashOutAllAction />
+      </div>
 
       <!-- Total Balance Card -->
       <UCard>
@@ -124,6 +127,7 @@ import { useTeamStore } from '@/stores/teamStore'
 import { useCurrencyStore } from '@/stores'
 import { computed } from 'vue'
 import { useContractBalance } from '@/composables/useContractBalance'
+import CashOutAllAction from '@/components/sections/DashboardView/CashOutAllAction.vue'
 import type { Address } from 'viem'
 
 const teamStore = useTeamStore()

--- a/app/src/components/sections/DashboardView/__tests__/CashOutAllAction.spec.ts
+++ b/app/src/components/sections/DashboardView/__tests__/CashOutAllAction.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import type { CashOutRunStep } from '@/composables/cashOut'
+import { mockBankReads, mockUseContractBalance, mockUserStore } from '@/tests/mocks'
+import { useCurrencyStore } from '@/stores'
+
+const OWNER_ADDRESS = '0x742d35cc6bf8c55c6c2e013e5492d2b6637e0886'
+const NON_OWNER = '0x00000000000000000000000000000000000000bb'
+
+// Controllable orchestrator stub — the real sequence logic is covered by
+// useCashOutAll.spec.ts; here we only drive the component UI from its state.
+const mockCashOut = {
+  steps: ref<CashOutRunStep[]>([]),
+  currentIndex: ref(0),
+  isRunning: ref(false),
+  isComplete: ref(false),
+  hasFailed: ref(false),
+  failedStep: ref<CashOutRunStep | null>(null),
+  start: vi.fn(),
+  retry: vi.fn(),
+  reset: vi.fn()
+}
+
+vi.mock('@/composables/cashOut', async (importOriginal) => {
+  const actual: object = await importOriginal()
+  return { ...actual, useCashOutAll: vi.fn(() => mockCashOut) }
+})
+
+import CashOutAllAction from '../CashOutAllAction.vue'
+
+const BUTTON = '[data-test="cash-out-all-button"]'
+const CONFIRM = '[data-test="cash-out-all-confirm"]'
+
+const createWrapper = () => mount(CashOutAllAction, { global: { stubs: { teleport: true } } })
+
+const step = (over: Partial<CashOutRunStep>): CashOutRunStep => ({
+  key: 'bank',
+  label: 'Bank',
+  status: 'pending',
+  detail: '',
+  error: '',
+  ...over
+})
+
+describe('CashOutAllAction', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    // Pinia auto-unwraps the store's `localCurrency` ref in production; the
+    // shared mock does not, so return a plain object for `.code` lookups.
+    vi.mocked(useCurrencyStore).mockReturnValue({
+      localCurrency: { code: 'USD', name: 'US Dollar', symbol: '$' }
+    } as unknown as ReturnType<typeof useCurrencyStore>)
+    mockBankReads.owner.data.value = OWNER_ADDRESS
+    mockUserStore.address = OWNER_ADDRESS
+    mockCashOut.steps.value = []
+    mockCashOut.isRunning.value = false
+    mockCashOut.isComplete.value = false
+    mockCashOut.hasFailed.value = false
+  })
+
+  it('hides the button when the connected user is not the Bank owner', () => {
+    mockUserStore.address = NON_OWNER
+    expect(createWrapper().find(BUTTON).exists()).toBe(false)
+  })
+
+  it('shows an enabled button for the owner when an account holds funds', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.get(BUTTON).attributes('disabled')).toBeUndefined()
+  })
+
+  it('disables the button when every account is empty', () => {
+    mockUseContractBalance.total.value = {}
+    expect(createWrapper().get(BUTTON).attributes('disabled')).toBeDefined()
+  })
+
+  it('opens a review listing the source accounts and the projected Bank payout', async () => {
+    const wrapper = createWrapper()
+    await wrapper.get(BUTTON).trigger('click')
+
+    expect(wrapper.find('[data-test="cash-out-review"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="cash-out-review-cashRemuneration"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="cash-out-review-expense"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="cash-out-review-bank"]').text()).toContain(
+      'Bank → your wallet'
+    )
+  })
+
+  it('starts the sequence with the built plan and moves to the progress phase', async () => {
+    const wrapper = createWrapper()
+    await wrapper.get(BUTTON).trigger('click')
+    await wrapper.get(CONFIRM).trigger('click')
+    await flushPromises()
+
+    expect(mockCashOut.start).toHaveBeenCalledTimes(1)
+    const plan = mockCashOut.start.mock.calls[0][0] as { key: string }[]
+    expect(plan.map((s) => s.key)).toEqual(['cashRemuneration', 'expense', 'bank'])
+    expect(wrapper.find('[data-test="cash-out-progress"]').exists()).toBe(true)
+  })
+
+  it('renders each step and exposes a retry when a step fails', async () => {
+    const wrapper = createWrapper()
+    await wrapper.get(BUTTON).trigger('click')
+    await wrapper.get(CONFIRM).trigger('click')
+
+    mockCashOut.steps.value = [
+      step({ key: 'cashRemuneration', label: 'Cash Remuneration', status: 'success' }),
+      step({
+        key: 'expense',
+        label: 'Expense Account',
+        status: 'failed',
+        error: 'RPC node unavailable'
+      }),
+      step({ key: 'bank', label: 'Bank', status: 'pending' })
+    ]
+    mockCashOut.hasFailed.value = true
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="cash-out-step-expense"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="cash-out-error-expense"]').text()).toContain(
+      'RPC node unavailable'
+    )
+
+    await wrapper.get('[data-test="cash-out-all-retry"]').trigger('click')
+    expect(mockCashOut.retry).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a completion notice when the sequence finishes', async () => {
+    const wrapper = createWrapper()
+    await wrapper.get(BUTTON).trigger('click')
+    await wrapper.get(CONFIRM).trigger('click')
+
+    mockCashOut.steps.value = [step({ key: 'bank', label: 'Bank', status: 'success' })]
+    mockCashOut.isComplete.value = true
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="cash-out-complete"]').exists()).toBe(true)
+  })
+})

--- a/app/src/composables/cashOut/__tests__/plan.spec.ts
+++ b/app/src/composables/cashOut/__tests__/plan.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { buildCashOutPlan } from '../plan'
+
+const keys = (balances: Parameters<typeof buildCashOutPlan>[0]) =>
+  buildCashOutPlan(balances).map((s) => s.key)
+
+describe('buildCashOutPlan', () => {
+  it('returns no steps when every account is empty', () => {
+    expect(buildCashOutPlan({ cashRemuneration: 0, expense: 0, bank: 0 })).toEqual([])
+  })
+
+  it('keeps source accounts before the Bank and Bank always last', () => {
+    expect(keys({ cashRemuneration: 5, expense: 5, bank: 5 })).toEqual([
+      'cashRemuneration',
+      'expense',
+      'bank'
+    ])
+  })
+
+  it('includes the Bank step even when only a source account has funds (consolidation)', () => {
+    expect(keys({ cashRemuneration: 5, expense: 0, bank: 0 })).toEqual(['cashRemuneration', 'bank'])
+    expect(keys({ cashRemuneration: 0, expense: 5, bank: 0 })).toEqual(['expense', 'bank'])
+  })
+
+  it('skips empty source accounts', () => {
+    expect(keys({ cashRemuneration: 0, expense: 3, bank: 7 })).toEqual(['expense', 'bank'])
+  })
+
+  it('returns only the Bank step when just the Bank holds funds', () => {
+    expect(keys({ cashRemuneration: 0, expense: 0, bank: 7 })).toEqual(['bank'])
+  })
+
+  it('labels each step with its human-readable name', () => {
+    const plan = buildCashOutPlan({ cashRemuneration: 1, expense: 1, bank: 1 })
+    expect(plan.map((s) => s.label)).toEqual(['Cash Remuneration', 'Expense Account', 'Bank'])
+  })
+
+  it('treats negative balances as empty', () => {
+    expect(buildCashOutPlan({ cashRemuneration: -1, expense: -1, bank: -1 })).toEqual([])
+  })
+})

--- a/app/src/composables/cashOut/__tests__/useCashOutAll.spec.ts
+++ b/app/src/composables/cashOut/__tests__/useCashOutAll.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { BaseError, UserRejectedRequestError } from 'viem'
+import { useCashOutAll } from '../useCashOutAll'
+import {
+  mockBankWrites,
+  mockCashRemunerationWrites,
+  mockExpenseAccountWrites,
+  mockTeamStore,
+  mockUserStore,
+  mockWagmiCore,
+  useQueryClientFn
+} from '@/tests/mocks'
+import { buildCashOutPlan } from '../plan'
+
+const BANK_ADDRESS = '0x1111111111111111111111111111111111111111'
+const RECIPIENT = '0x00000000000000000000000000000000000000aa'
+
+const fullPlan = () => buildCashOutPlan({ cashRemuneration: 5, expense: 5, bank: 5 })
+
+const nativeBalance = (value: bigint) => ({
+  value,
+  decimals: 18,
+  formatted: '0',
+  symbol: 'ETH'
+})
+
+describe('useCashOutAll', () => {
+  const invalidateQueries = vi.fn().mockResolvedValue(undefined)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    invalidateQueries.mockClear()
+    useQueryClientFn.mockReturnValue({
+      invalidateQueries,
+      getQueryData: vi.fn(),
+      setQueryData: vi.fn(),
+      removeQueries: vi.fn()
+    })
+    mockUserStore.address = RECIPIENT
+    mockTeamStore.getContractAddressByType = vi.fn((type) =>
+      type === 'Bank' ? BANK_ADDRESS : '0x2222222222222222222222222222222222222222'
+    )
+    mockCashRemunerationWrites.ownerWithdrawAllToBank.mutateAsync.mockResolvedValue(undefined)
+    mockExpenseAccountWrites.ownerWithdrawAllToBank.mutateAsync.mockResolvedValue(undefined)
+    mockBankWrites.transfer.mutateAsync.mockResolvedValue(undefined)
+    mockBankWrites.transferToken.mutateAsync.mockResolvedValue(undefined)
+    mockWagmiCore.getBalance.mockResolvedValue(nativeBalance(5n))
+    mockWagmiCore.readContract.mockResolvedValue(1000n)
+  })
+
+  it('runs the three accounts in order and ends complete', async () => {
+    const flow = useCashOutAll()
+    await flow.start(fullPlan())
+
+    expect(flow.steps.value.map((s) => s.status)).toEqual(['success', 'success', 'success'])
+    expect(flow.isComplete.value).toBe(true)
+    expect(flow.hasFailed.value).toBe(false)
+    expect(mockCashRemunerationWrites.ownerWithdrawAllToBank.mutateAsync).toHaveBeenCalledWith({
+      args: []
+    })
+    expect(mockExpenseAccountWrites.ownerWithdrawAllToBank.mutateAsync).toHaveBeenCalledWith({
+      args: []
+    })
+    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards the Bank native balance then every held ERC-20 to the owner', async () => {
+    const flow = useCashOutAll()
+    await flow.start(fullPlan())
+
+    expect(mockBankWrites.transfer.mutateAsync).toHaveBeenCalledWith({ args: [RECIPIENT, 5n] })
+    // Two supported ERC-20 tokens (USDC, USDCe), each with a positive balance.
+    expect(mockBankWrites.transferToken.mutateAsync).toHaveBeenCalledTimes(2)
+    expect(mockBankWrites.transferToken.mutateAsync).toHaveBeenCalledWith({
+      args: [expect.any(String), RECIPIENT, 1000n]
+    })
+  })
+
+  it('skips Bank assets that have a zero balance', async () => {
+    mockWagmiCore.getBalance.mockResolvedValue(nativeBalance(0n))
+    mockWagmiCore.readContract.mockResolvedValue(0n)
+
+    const flow = useCashOutAll()
+    await flow.start(fullPlan())
+
+    expect(mockBankWrites.transfer.mutateAsync).not.toHaveBeenCalled()
+    expect(mockBankWrites.transferToken.mutateAsync).not.toHaveBeenCalled()
+    expect(flow.isComplete.value).toBe(true)
+  })
+
+  it('stops on a failing step, marks it failed and leaves the rest pending', async () => {
+    mockExpenseAccountWrites.ownerWithdrawAllToBank.mutateAsync.mockRejectedValueOnce(
+      new Error('RPC node unavailable')
+    )
+
+    const flow = useCashOutAll()
+    await flow.start(fullPlan())
+
+    expect(flow.steps.value.map((s) => s.status)).toEqual(['success', 'failed', 'pending'])
+    expect(flow.failedStep.value?.key).toBe('expense')
+    expect(flow.steps.value[1].error).toContain('RPC node unavailable')
+    expect(mockBankWrites.transfer.mutateAsync).not.toHaveBeenCalled()
+    expect(invalidateQueries).not.toHaveBeenCalled()
+  })
+
+  it('shows a friendly message when the wallet rejects the request', async () => {
+    mockCashRemunerationWrites.ownerWithdrawAllToBank.mutateAsync.mockRejectedValueOnce(
+      new BaseError('rejected', { cause: new UserRejectedRequestError(new Error('rejected')) })
+    )
+
+    const flow = useCashOutAll()
+    await flow.start(fullPlan())
+
+    expect(flow.steps.value[0].status).toBe('failed')
+    expect(flow.steps.value[0].error).toBe('You rejected the request.')
+  })
+
+  it('resumes from the failed step on retry and completes', async () => {
+    mockExpenseAccountWrites.ownerWithdrawAllToBank.mutateAsync
+      .mockRejectedValueOnce(new Error('RPC node unavailable'))
+      .mockResolvedValueOnce(undefined)
+
+    const flow = useCashOutAll()
+    await flow.start(fullPlan())
+    expect(flow.hasFailed.value).toBe(true)
+
+    await flow.retry()
+
+    expect(flow.steps.value.map((s) => s.status)).toEqual(['success', 'success', 'success'])
+    expect(flow.isComplete.value).toBe(true)
+    // Cash step is not re-run on retry — only expense (1 fail + 1 success) and bank.
+    expect(mockCashRemunerationWrites.ownerWithdrawAllToBank.mutateAsync).toHaveBeenCalledTimes(1)
+    expect(mockExpenseAccountWrites.ownerWithdrawAllToBank.mutateAsync).toHaveBeenCalledTimes(2)
+  })
+
+  it('does nothing for an empty plan', async () => {
+    const flow = useCashOutAll()
+    await flow.start([])
+
+    expect(flow.steps.value).toEqual([])
+    expect(flow.isComplete.value).toBe(false)
+    expect(invalidateQueries).not.toHaveBeenCalled()
+  })
+
+  it('reset clears the run state', async () => {
+    const flow = useCashOutAll()
+    await flow.start(fullPlan())
+    flow.reset()
+
+    expect(flow.steps.value).toEqual([])
+    expect(flow.currentIndex.value).toBe(0)
+    expect(flow.isRunning.value).toBe(false)
+  })
+})

--- a/app/src/composables/cashOut/index.ts
+++ b/app/src/composables/cashOut/index.ts
@@ -1,0 +1,2 @@
+export * from './plan'
+export * from './useCashOutAll'

--- a/app/src/composables/cashOut/plan.ts
+++ b/app/src/composables/cashOut/plan.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure, framework-agnostic builder for the "Cash out all" plan.
+ *
+ * Kept free of Vue / wagmi so it can be unit-tested in isolation and reasoned
+ * about without a component harness. The orchestrator (`useCashOutAll`) and the
+ * UI consume the ordered step list this produces.
+ */
+
+export type CashOutStepKey = 'cashRemuneration' | 'expense' | 'bank'
+
+/**
+ * Display-time balance snapshot for the three accounts, expressed in the user's
+ * local fiat. Only the sign (`> 0`) matters for deciding which steps to keep;
+ * the magnitude is used by the UI for the review preview.
+ */
+export interface CashOutAccountBalances {
+  cashRemuneration: number
+  expense: number
+  bank: number
+}
+
+export interface CashOutPlanStep {
+  key: CashOutStepKey
+  /** Human label shown in the stepper, e.g. "Cash Remuneration". */
+  label: string
+}
+
+export const CASH_OUT_STEP_LABELS: Record<CashOutStepKey, string> = {
+  cashRemuneration: 'Cash Remuneration',
+  expense: 'Expense Account',
+  bank: 'Bank'
+}
+
+/**
+ * Builds the ordered cash-out plan from the three account balances.
+ *
+ * The order is fixed and intentional:
+ *  1. Cash Remuneration and 2. Expense Account come first — both sweep their
+ *     funds INTO the Bank (`ownerWithdrawAllToBank`).
+ *  3. The Bank runs LAST and forwards everything to the owner's wallet, so the
+ *     funds the source accounts just consolidated are not stranded.
+ *
+ * Empty source accounts are skipped. The Bank step is included whenever ANY
+ * account holds funds, because the source sweeps may fill an otherwise-empty
+ * Bank; if nothing actually remains at execution time the Bank step no-ops.
+ */
+export function buildCashOutPlan(balances: CashOutAccountBalances): CashOutPlanStep[] {
+  const hasCash = balances.cashRemuneration > 0
+  const hasExpense = balances.expense > 0
+  const hasBank = balances.bank > 0
+
+  const steps: CashOutPlanStep[] = []
+  if (hasCash) steps.push({ key: 'cashRemuneration', label: CASH_OUT_STEP_LABELS.cashRemuneration })
+  if (hasExpense) steps.push({ key: 'expense', label: CASH_OUT_STEP_LABELS.expense })
+  if (hasCash || hasExpense || hasBank)
+    steps.push({ key: 'bank', label: CASH_OUT_STEP_LABELS.bank })
+
+  return steps
+}

--- a/app/src/composables/cashOut/useCashOutAll.ts
+++ b/app/src/composables/cashOut/useCashOutAll.ts
@@ -1,0 +1,209 @@
+import { computed, ref } from 'vue'
+import { getBalance, readContract } from '@wagmi/core'
+import type { Address } from 'viem'
+import { useQueryClient } from '@tanstack/vue-query'
+import { config as wagmiConfig } from '@/wagmi.config'
+import { ERC20_ABI } from '@/artifacts/abi/erc20'
+import { SUPPORTED_TOKENS } from '@/constant'
+import { useTeamStore, useUserDataStore } from '@/stores'
+import { classifyError } from '@/utils'
+import type { ContractKey } from '@/composables/contracts/errorCatalogs.types'
+import { useOwnerWithdrawAllToBank as useCashOwnerWithdrawAll } from '@/composables/cashRemuneration/writes'
+import { useOwnerWithdrawAllToBank as useExpenseOwnerWithdrawAll } from '@/composables/expenseAccount/writes'
+import { useTransfer, useTransferToken } from '@/composables/bank/writes'
+import type { CashOutPlanStep, CashOutStepKey } from './plan'
+
+export type CashOutStepStatus = 'pending' | 'active' | 'success' | 'failed'
+
+/**
+ * Live, per-step state tracked while the sequence runs. One entry per planned
+ * account; the Bank entry may internally emit several transactions (one per
+ * held token), surfaced through `detail`.
+ */
+export interface CashOutRunStep {
+  key: CashOutStepKey
+  label: string
+  status: CashOutStepStatus
+  /** Sub-progress hint, e.g. the token currently being transferred. */
+  detail: string
+  /** User-facing message when `status === 'failed'`. */
+  error: string
+}
+
+const CONTRACT_KEY: Record<CashOutStepKey, ContractKey> = {
+  cashRemuneration: 'CashRemuneration',
+  expense: 'ExpenseAccount',
+  bank: 'Bank'
+}
+
+/**
+ * Orchestrates the "Cash out all" sequence.
+ *
+ * It is a state machine on top of the existing single-purpose contract
+ * composables — it coordinates them but never wraps a contract call itself, so
+ * each underlying composable stays single-purpose.
+ *
+ * Behaviour:
+ *  - Steps run in the planned order; on the first failure the sequence STOPS
+ *    with that step marked `failed`. `retry()` re-runs from the failed step.
+ *  - Every step is idempotent on retry: the source sweeps simply re-run, and
+ *    the Bank step re-reads live balances so already-emptied tokens are skipped.
+ *  - The Bank step reads RAW on-chain balances at execution time (after the
+ *    source accounts have consolidated into it) and forwards native + each held
+ *    ERC-20 to the connected owner via `transfer` / `transferToken`.
+ */
+export function useCashOutAll() {
+  const teamStore = useTeamStore()
+  const userStore = useUserDataStore()
+  const queryClient = useQueryClient()
+
+  const cashWithdraw = useCashOwnerWithdrawAll()
+  const expenseWithdraw = useExpenseOwnerWithdrawAll()
+  const bankTransfer = useTransfer()
+  const bankTransferToken = useTransferToken()
+
+  const steps = ref<CashOutRunStep[]>([])
+  const currentIndex = ref(0)
+  const isRunning = ref(false)
+
+  const isComplete = computed(
+    () => steps.value.length > 0 && steps.value.every((s) => s.status === 'success')
+  )
+  const failedStep = computed(() => steps.value.find((s) => s.status === 'failed') ?? null)
+  const hasFailed = computed(() => failedStep.value !== null)
+
+  /**
+   * Bank step: forward everything the Bank now holds to the connected owner.
+   * Reads happen here (not up front) so they include what the source accounts
+   * just consolidated.
+   */
+  async function executeBankStep(step: CashOutRunStep) {
+    const bank = teamStore.getContractAddressByType('Bank') as Address | undefined
+    const to = userStore.address as Address | undefined
+    if (!bank) throw new Error('Bank address is undefined')
+    if (!to) throw new Error('Recipient address is undefined')
+
+    // Native balance first.
+    const native = await getBalance(wagmiConfig, { address: bank })
+    if (native.value > 0n) {
+      step.detail = `Transferring ${native.symbol}…`
+      await bankTransfer.mutateAsync({ args: [to, native.value] })
+    }
+
+    // Then each supported ERC-20 the Bank holds.
+    const erc20s = SUPPORTED_TOKENS.filter((token) => token.id !== 'native')
+    for (const token of erc20s) {
+      const balance = (await readContract(wagmiConfig, {
+        address: token.address,
+        abi: ERC20_ABI,
+        functionName: 'balanceOf',
+        args: [bank]
+      })) as bigint
+      if (balance > 0n) {
+        step.detail = `Transferring ${token.symbol}…`
+        await bankTransferToken.mutateAsync({ args: [token.address, to, balance] })
+      }
+    }
+
+    step.detail = ''
+  }
+
+  async function executeStep(step: CashOutRunStep) {
+    switch (step.key) {
+      case 'cashRemuneration':
+        await cashWithdraw.mutateAsync({ args: [] })
+        break
+      case 'expense':
+        await expenseWithdraw.mutateAsync({ args: [] })
+        break
+      case 'bank':
+        await executeBankStep(step)
+        break
+    }
+  }
+
+  /**
+   * One-shot refresh of every contract balance touched by the flow. The
+   * per-write invalidation in `useContractWritesV3` only covers reads keyed by
+   * the called contract's address, which misses the Bank's ERC-20 `balanceOf`
+   * reads (keyed by the token address) — so we sweep both query families once
+   * the sequence completes.
+   */
+  async function refreshBalances() {
+    await queryClient.invalidateQueries({
+      predicate: (query) => {
+        const key = query.queryKey
+        return Array.isArray(key) && (key[0] === 'balance' || key[0] === 'readContract')
+      }
+    })
+  }
+
+  async function run() {
+    isRunning.value = true
+    try {
+      while (currentIndex.value < steps.value.length) {
+        const step = steps.value[currentIndex.value]
+        step.status = 'active'
+        step.error = ''
+        try {
+          await executeStep(step)
+          step.status = 'success'
+          currentIndex.value++
+        } catch (error: unknown) {
+          const classified = classifyError(error, { contract: CONTRACT_KEY[step.key] })
+          step.status = 'failed'
+          step.detail = ''
+          step.error =
+            classified.category === 'user_rejected'
+              ? 'You rejected the request.'
+              : classified.userMessage
+          return
+        }
+      }
+      await refreshBalances()
+    } finally {
+      isRunning.value = false
+    }
+  }
+
+  /** Initialise the sequence from a plan and run it to the first failure. */
+  async function start(plan: CashOutPlanStep[]) {
+    steps.value = plan.map((step) => ({
+      key: step.key,
+      label: step.label,
+      status: 'pending',
+      detail: '',
+      error: ''
+    }))
+    currentIndex.value = 0
+    if (steps.value.length === 0) return
+    await run()
+  }
+
+  /** Re-run from the currently failed step, then continue the sequence. */
+  async function retry() {
+    const step = steps.value[currentIndex.value]
+    if (!step || step.status !== 'failed') return
+    step.status = 'pending'
+    step.error = ''
+    await run()
+  }
+
+  function reset() {
+    steps.value = []
+    currentIndex.value = 0
+    isRunning.value = false
+  }
+
+  return {
+    steps,
+    currentIndex,
+    isRunning,
+    isComplete,
+    hasFailed,
+    failedStep,
+    start,
+    retry,
+    reset
+  }
+}

--- a/app/src/composables/cashOut/useCashOutAll.ts
+++ b/app/src/composables/cashOut/useCashOutAll.ts
@@ -143,6 +143,7 @@ export function useCashOutAll() {
     try {
       while (currentIndex.value < steps.value.length) {
         const step = steps.value[currentIndex.value]
+        if (!step) break
         step.status = 'active'
         step.error = ''
         try {

--- a/app/src/tests/mocks/wagmi.vue.mock.ts
+++ b/app/src/tests/mocks/wagmi.vue.mock.ts
@@ -38,6 +38,7 @@ export const mockWagmiCore = {
   waitForTransactionReceipt: vi.fn(),
   writeContract: vi.fn(),
   readContract: vi.fn(),
+  getBalance: vi.fn(),
   getWalletClient: vi.fn(),
   estimateGas: vi.fn(),
   getPublicClient: vi.fn()


### PR DESCRIPTION
## What

Adds a **"Cash out all"** action on the team dashboard. The owner empties the team treasury to their own wallet in one guided, multi-step flow.

Closes #1892

## How it works

A single button on the Treasury Overview opens a modal that:

1. **Review** — lists the non-empty accounts to be withdrawn and the projected Bank payout, then asks for confirmation.
2. **Progress** — runs the withdraws **in sequence**, one step per account, with live per-step status.

The sequence order is fixed and intentional:

1. **Cash Remuneration → Bank** (`ownerWithdrawAllToBank`, skipped if empty)
2. **Expense Account → Bank** (`ownerWithdrawAllToBank`, skipped if empty)
3. **Bank → owner wallet** — runs **last** and reads its balance **live** (so the funds the first two steps just consolidated are not stranded), then forwards native + each held ERC-20 to the connected owner via `transfer` / `transferToken`. Zero-balance assets are skipped.

Each account is a separate transaction the owner signs; the Bank step may emit one signature per token.

**On failure** (wallet reject or revert) the sequence **stops** on the failing step, surfaces the error inline, and offers **Retry**. Retry is idempotent — source sweeps simply re-run and the Bank step re-reads live balances, skipping already-emptied assets.

## Scope (v1)

- **No contract change** — all primitives already exist (`useTransfer` / `useTransferToken` / `useOwnerWithdrawAllToBank`).
- Button is shown only to the **Bank owner**, hidden for BOD-governed teams (owner ≠ user), disabled when archived or when every account is empty.

Out of scope (tracked for later): BOD-governed teams, the Safe account, a single-tx `Bank.ownerWithdrawAll()` to cut the number of signatures, and gas/fiat estimates.

## Architecture

- `composables/cashOut/plan.ts` — **pure** ordered-plan builder (skip/order logic), fully unit-tested.
- `composables/cashOut/useCashOutAll.ts` — **orchestrator** state machine that *coordinates* the existing single-purpose contract composables (it never wraps a contract call itself), with `start` / `retry` / per-step status and a one-shot balance refresh on completion.
- `components/sections/DashboardView/CashOutAllAction.vue` — gating + button + review/progress modal, wired into `CompanyOverview.vue`.

## Tests

- `plan.spec.ts` — order, skip rules, Bank-always-last, empty plan (7).
- `useCashOutAll.spec.ts` — order, Bank multi-token sweep, zero-balance skip, stop-on-failure, wallet-reject message, retry-and-resume, refresh (8).
- `CashOutAllAction.spec.ts` — owner gating, empty-balance disable, review preview, plan hand-off, progress + retry, completion notice (7).

22 new tests, all green. Lint clean. The pre-existing repo `type-check` debt in unrelated files (untyped Nuxt UI table `row`/`val` params) is untouched.

## Test infra

Adds `getBalance` to the shared `@wagmi/core` mock so the Bank step's native read is mockable.
