### PR TITLE
feat: ✨ add multi-endpoint RPC fallback to app, dashboard & backend

### DIFF
--- a/app/src/wagmi.config.ts
+++ b/app/src/wagmi.config.ts
@@ -1,6 +1,7 @@
 import { http, createConfig } from '@wagmi/vue'
 import { mainnet, sepolia, polygon, hardhat, polygonAmoy } from '@wagmi/vue/chains'
 import { injected } from '@wagmi/connectors'
+import { fallback } from 'viem'
 import { e2eMockConnector } from './e2e/mockConnector'
 
 /**
@@ -12,13 +13,31 @@ import { e2eMockConnector } from './e2e/mockConnector'
  */
 const isE2E = import.meta.env.VITE_E2E === 'true'
 
+/**
+ * Multi-endpoint failover. viem's `http()` only retries the *same* endpoint, so
+ * a dead, rate-limited, or gated provider takes reads down with it; `fallback()`
+ * rotates to the next endpoint instead. A configured RPC URL stays first (top
+ * priority) and the public endpoints (drpc, publicnode) are the safety net.
+ * These are current-state reads (`eth_call`/`getBalance`), so publicnode's log
+ * pruning is irrelevant here.
+ */
+const polygonRpcUrl = import.meta.env.VITE_APP_POLYGON_RPC_URL
+
 export const config = createConfig({
   chains: [mainnet, sepolia, polygon, hardhat, polygonAmoy],
   connectors: isE2E ? [e2eMockConnector()] : [injected()],
   transports: {
-    [mainnet.id]: http(),
+    [mainnet.id]: fallback([
+      http(),
+      http('https://eth.drpc.org'),
+      http('https://ethereum-rpc.publicnode.com')
+    ]),
     [sepolia.id]: http('https://sepolia.drpc.org'),
-    [polygon.id]: http(import.meta.env.VITE_APP_POLYGON_RPC_URL || 'https://polygon-rpc.com'),
+    [polygon.id]: fallback([
+      ...(polygonRpcUrl ? [http(polygonRpcUrl)] : []),
+      http('https://polygon.drpc.org'),
+      http('https://polygon-bor-rpc.publicnode.com')
+    ]),
     [polygonAmoy.id]: http(),
     [hardhat.id]: http()
   }

--- a/backend/src/utils/__tests__/viem.config.test.ts
+++ b/backend/src/utils/__tests__/viem.config.test.ts
@@ -1,14 +1,16 @@
 import { hardhat, mainnet, polygon, polygonAmoy, sepolia } from 'viem/chains';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock the createPublicClient and http functions
+// Mock the createPublicClient, http and fallback functions
 vi.mock('viem', () => ({
   createPublicClient: vi.fn(),
   http: vi.fn(),
+  fallback: vi.fn(),
 }));
 
 // Import the module after mocking
-import { getChain } from '../viem.config';
+import { http, fallback } from 'viem';
+import { getChain, getTransport } from '../viem.config';
 
 describe('viem.config', () => {
   beforeEach(() => {
@@ -50,6 +52,27 @@ describe('viem.config', () => {
     it('should handle hex chain IDs', () => {
       expect(getChain('0x1')).toBe(mainnet); // mainnet hex ID
       expect(getChain('0x89')).toBe(polygon); // polygon hex ID
+    });
+  });
+
+  describe('getTransport', () => {
+    it('keeps a single transport for chains without public peers (hardhat)', () => {
+      getTransport(hardhat);
+      expect(fallback).not.toHaveBeenCalled();
+    });
+
+    it('wraps polygon reads in a fallback across public endpoints', () => {
+      getTransport(polygon);
+      expect(fallback).toHaveBeenCalledTimes(1);
+      expect(http).toHaveBeenCalledWith('https://polygon.drpc.org');
+      expect(http).toHaveBeenCalledWith('https://polygon-bor-rpc.publicnode.com');
+    });
+
+    it('wraps mainnet reads in a fallback across public endpoints', () => {
+      getTransport(mainnet);
+      expect(fallback).toHaveBeenCalledTimes(1);
+      expect(http).toHaveBeenCalledWith('https://eth.drpc.org');
+      expect(http).toHaveBeenCalledWith('https://ethereum-rpc.publicnode.com');
     });
   });
 });

--- a/backend/src/utils/viem.config.ts
+++ b/backend/src/utils/viem.config.ts
@@ -1,8 +1,25 @@
-import { createPublicClient, http } from 'viem';
+import { createPublicClient, http, fallback, type Chain, type Transport } from 'viem';
 import { mainnet, sepolia, polygon, hardhat, polygonAmoy } from 'viem/chains';
 
 const chainId = process.env.CHAIN_ID;
 const rpcUrl = process.env.RPC_URL;
+
+// Public RPC endpoints used as automatic failover. viem's `http()` only retries
+// the *same* endpoint, so a dead, rate-limited, or gated provider (e.g. Polygon's
+// `polygon-rpc.com`, which is also viem's hard-coded chain default) takes reads
+// down with it. `fallback()` rotates to the next endpoint instead. These are
+// current-state reads (`eth_call`/`getBalance`), so the public endpoints' log
+// pruning is irrelevant here. Hardhat has no public peers and is omitted.
+const PUBLIC_FALLBACK_RPCS: Record<number, string[]> = {
+  [mainnet.id]: ['https://eth.drpc.org', 'https://ethereum-rpc.publicnode.com'],
+  [sepolia.id]: ['https://sepolia.drpc.org', 'https://ethereum-sepolia-rpc.publicnode.com'],
+  [polygon.id]: ['https://polygon.drpc.org', 'https://polygon-bor-rpc.publicnode.com'],
+  [polygonAmoy.id]: [
+    'https://polygon-amoy.drpc.org',
+    'https://polygon-amoy-bor-rpc.publicnode.com',
+  ],
+};
+
 export const getChain = (chainIdStr: string | undefined) => {
   if (!chainIdStr) return sepolia; // default to sepolia
 
@@ -24,9 +41,21 @@ export const getChain = (chainIdStr: string | undefined) => {
   }
 };
 
+// A configured RPC_URL stays first (top priority); the chain's public endpoints
+// are appended as failover. Chains without public peers (hardhat) keep the
+// single transport, deferring to viem's chain default when RPC_URL is unset.
+export const getTransport = (chain: Chain): Transport => {
+  const urls = [...(rpcUrl ? [rpcUrl] : []), ...(PUBLIC_FALLBACK_RPCS[chain.id] ?? [])];
+  if (urls.length === 0) return http();
+  if (urls.length === 1) return http(urls[0]);
+  return fallback(urls.map((url) => http(url)));
+};
+
+const chain = getChain(chainId);
+
 const publicClient = createPublicClient({
-  chain: getChain(chainId),
-  transport: rpcUrl ? http(rpcUrl) : http(),
+  chain,
+  transport: getTransport(chain),
 });
 
 export default publicClient;

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -7,8 +7,9 @@ NUXT_PUBLIC_BACKEND_URL=http://localhost:3000
 # Chain ID for the connected blockchain network (e.g., 1 for Ethereum mainnet, 11155111 for Sepolia testnet, 31337 for local Hardhat)
 NUXT_PUBLIC_CHAIN_ID=31337
 
-# Polygon RPC URL
-NUXT_PUBLIC_POLYGON_RPC_URL=https://polygon-rpc.com
+# Polygon RPC URL — used as the first endpoint; public RPCs are wired as
+# automatic fallback in code. Left unset, the app defaults to polygon.drpc.org.
+NUXT_PUBLIC_POLYGON_RPC_URL=https://polygon.drpc.org
 
 # Etherscan API V2 key — used server-side to read Polygon (chainid=137) USDC
 # deposits/withdrawals for Polymarket accounting. Create one at

--- a/dashboard/app/plugins/wagmi.client.ts
+++ b/dashboard/app/plugins/wagmi.client.ts
@@ -2,17 +2,31 @@ import { WagmiPlugin, http, createConfig } from '@wagmi/vue'
 import { mainnet, sepolia, polygon, hardhat, polygonAmoy } from '@wagmi/vue/chains'
 import { injected } from '@wagmi/vue/connectors'
 import { VueQueryPlugin, QueryClient } from '@tanstack/vue-query'
+import { fallback } from 'viem'
 
 export default defineNuxtPlugin((nuxtApp) => {
   const config = useRuntimeConfig()
 
+  // Multi-endpoint failover. viem's `http()` only retries the *same* endpoint,
+  // so a dead, rate-limited, or gated provider takes reads down with it;
+  // `fallback()` rotates to the next endpoint instead. The configured
+  // `polygonRpcUrl` stays first (top priority) and the public endpoints (drpc,
+  // publicnode) are the safety net.
   const wagmiConfig = createConfig({
     chains: [mainnet, sepolia, polygon, hardhat, polygonAmoy],
     connectors: [injected()],
     transports: {
-      [mainnet.id]: http(),
+      [mainnet.id]: fallback([
+        http(),
+        http('https://eth.drpc.org'),
+        http('https://ethereum-rpc.publicnode.com')
+      ]),
       [sepolia.id]: http('https://sepolia.drpc.org'),
-      [polygon.id]: http(config.public.polygonRpcUrl),
+      [polygon.id]: fallback([
+        http(config.public.polygonRpcUrl),
+        http('https://polygon.drpc.org'),
+        http('https://polygon-bor-rpc.publicnode.com')
+      ]),
       [polygonAmoy.id]: http(),
       [hardhat.id]: http()
     }

--- a/dashboard/nuxt.config.ts
+++ b/dashboard/nuxt.config.ts
@@ -29,7 +29,7 @@ export default defineNuxtConfig({
     public: {
       backendUrl: process.env.NUXT_PUBLIC_BACKEND_URL || 'https://apiv2.cncportal.io',
       chainId: process.env.NUXT_PUBLIC_CHAIN_ID || '137',
-      polygonRpcUrl: process.env.NUXT_PUBLIC_POLYGON_RPC_URL || 'https://polygon-rpc.com'
+      polygonRpcUrl: process.env.NUXT_PUBLIC_POLYGON_RPC_URL || 'https://polygon.drpc.org'
     }
   },
 


### PR DESCRIPTION
## What & why

Neither frontend nor the backend had any RPC failover: each chain was wired to a **single** viem `http()` transport, so a down, rate-limited, or gated endpoint took reads down with it. viem's `http()` retries the **same** endpoint (transient blips only) — endpoint failover needs `fallback([http(a), http(b), …])`, the pattern the `ponder` indexer already adopted in #2041.

This wraps the Polygon (and mainnet) transports in `fallback([...])` across **app, dashboard, and backend**, and removes the dead `polygon-rpc.com` default (currently gated — returns `API key disabled, tenant disabled`).

> #2065 explicitly scoped the backend **out** ("track separately if wanted"). Per request, this PR pulls the backend into the same change so all three clients share one failover story.

## Changes

| Project | File | Change |
|---|---|---|
| app | `app/src/wagmi.config.ts` | Polygon + mainnet wrapped in `fallback([...])`; dead `polygon-rpc.com` default dropped |
| dashboard | `dashboard/app/plugins/wagmi.client.ts` | Polygon + mainnet wrapped in `fallback([...])` |
| dashboard | `dashboard/nuxt.config.ts` + `.env.example` | default RPC `polygon-rpc.com` → `polygon.drpc.org` |
| backend | `backend/src/utils/viem.config.ts` | `getTransport(chain)` builds a per-chain `fallback([...])`; a set `RPC_URL` stays first, public endpoints (drpc, publicnode) are appended as failover |
| backend | `backend/src/utils/__tests__/viem.config.test.ts` | covers `getTransport` branch selection |

A configured `VITE_APP_POLYGON_RPC_URL` / `NUXT_PUBLIC_POLYGON_RPC_URL` / `RPC_URL` always stays the **first** endpoint in the list (top priority). The frontends and backend do current-state reads (`eth_call` / `getBalance`), so publicnode's log pruning is irrelevant here — no `loadBalance` / `rateLimit` needed (those stay indexer concerns).

The web3Util bullet from the issue is moot — `app/src/utils/web3Util.ts` was already removed as dead code.

## Verification

- `backend`: `tsc --noEmit` clean; `eslint` clean; `vitest` — 11/11 pass (incl. 3 new `getTransport` tests).
- `app`: `eslint` + `prettier --check` clean; `wagmi.spec.ts` passes (config still exposes a transport per chain).
- `dashboard`: `eslint` clean (it uses ESLint stylistic, not prettier).

Acceptance criteria from #2065:
- [x] Polygon reads survive the primary endpoint being unreachable (automatic failover).
- [x] No remaining hard-coded reference to the gated `polygon-rpc.com` (only a test fixture + explanatory comments remain).
- [x] A configured RPC URL still takes priority as the first endpoint.

Closes #2065
