### PR TITLE
Feature/fess

### DIFF
--- a/dashboard/app/api/polymarket.ts
+++ b/dashboard/app/api/polymarket.ts
@@ -1,8 +1,9 @@
 import { isAddress } from 'viem'
-import type { PolymarketActivity, PolymarketPosition } from '~/types/polymarket'
+import type { PolymarketActivity, PolymarketPosition, PolymarketUserPnlPoint } from '~/types/polymarket'
 
 const POLYMARKET_ACTIVITY_URL = 'https://data-api.polymarket.com/activity'
 const POLYMARKET_POSITIONS_URL = 'https://data-api.polymarket.com/positions'
+const POLYMARKET_USER_PNL_URL = 'https://user-pnl-api.polymarket.com/user-pnl'
 
 export type PolymarketActivitySortBy = 'TIMESTAMP' | 'TOKENS' | 'CASH'
 export type PolymarketActivitySortDirection = 'ASC' | 'DESC'
@@ -144,4 +145,31 @@ export async function fetchAllPolymarketPositions(user: string): Promise<Polymar
     offset => fetchPolymarketPositions({ user, limit: pageSize, offset, sizeThreshold: 0 }),
     pageSize
   )
+}
+
+/**
+ * Fetches the all-time Profit/Loss time series Polymarket renders on profile pages.
+ * The latest `p` value matches polymarket.com/profile/{address} — unlike
+ * Σ `/positions` realizedPnl + cashPnl, which diverges once closed markets drop
+ * off the positions feed or carry stale per-row P&L.
+ */
+export async function fetchPolymarketUserPnl(user: string): Promise<PolymarketUserPnlPoint[]> {
+  const trimmed = user.trim()
+  if (!isAddress(trimmed as `0x${string}`)) {
+    throw new Error('Invalid Polymarket user address')
+  }
+  const url = new URL(POLYMARKET_USER_PNL_URL)
+  url.searchParams.set('user_address', trimmed)
+  return await $fetch<PolymarketUserPnlPoint[]>(url.toString())
+}
+
+/** Latest all-time P&L from {@link fetchPolymarketUserPnl}. */
+export async function fetchPolymarketLatestPnl(user: string): Promise<number> {
+  const points = await fetchPolymarketUserPnl(user)
+  if (points.length === 0) {
+    return 0
+  }
+  // Pick the most recent point by timestamp rather than trusting array order.
+  const latest = points.reduce((newest, point) => (point.t > newest.t ? point : newest))
+  return latest.p
 }

--- a/dashboard/app/components/accounting/AccountingSummary.vue
+++ b/dashboard/app/components/accounting/AccountingSummary.vue
@@ -1,5 +1,46 @@
 <template>
   <div class="space-y-4">
+    <!-- Polymarket profile comparison -->
+    <div class="grid grid-cols-2 gap-4">
+      <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
+        <div class="flex items-center gap-2">
+          <p class="text-xs uppercase tracking-wide text-muted">
+            Profit / loss
+          </p>
+          <AccountingMetricExplainer
+            title="Profit / loss"
+            description="All-time profit or loss — the same figure Polymarket shows on your profile page Profit/Loss chart. Pulled from Polymarket's user-pnl API (not reconstructed from /positions), so it stays in sync with polymarket.com/profile even when individual position rows are purged or carry stale per-market P&L."
+            formula="Latest point from user-pnl-api.polymarket.com"
+          />
+        </div>
+        <p class="text-3xl font-bold tabular-nums" :class="signClass(summary.polymarketPnl)">
+          {{ formatSignedUsd(summary.polymarketPnl) }}
+        </p>
+        <p class="text-xs text-muted">
+          All-time (Polymarket)
+        </p>
+      </UPageCard>
+      <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
+        <div class="flex items-center gap-2">
+          <p class="text-xs uppercase tracking-wide text-muted">
+            Fees
+          </p>
+          <AccountingMetricExplainer
+            title="Fees"
+            description="Trading and settlement costs detected when on-chain USDC moved less than Polymarket's activity feed reported for the same transaction — almost always a fee or slippage."
+            formula="Σ |cashFlow| over SETTLEMENT_ADJUSTMENT where cashFlow < 0"
+            example="A trade is reported as $50 in the activity feed, but $49.97 actually moved on-chain. Fee = $0.03."
+          />
+        </div>
+        <p class="text-3xl font-bold tabular-nums">
+          {{ formatUsd(summary.totalFees) }}
+        </p>
+        <p class="text-xs text-muted">
+          {{ summary.feeTransactionCount === 1 ? '1 transaction' : `${summary.feeTransactionCount} transactions` }}
+        </p>
+      </UPageCard>
+    </div>
+
     <!-- Bottom line -->
     <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
       <div class="flex items-center gap-2">
@@ -197,16 +238,6 @@ const stats = computed<Stat[]>(() => {
       }
     },
     {
-      label: 'Polymarket realized',
-      value: formatSignedUsd(s.positionsRealizedPnl),
-      valueClass: signClass(s.positionsRealizedPnl),
-      hint: 'Reported by /positions (audit only)',
-      explainer: {
-        description: 'The same realized P&L, but as Polymarket itself reports it via their /positions API. Shown for audit only — drift between this and our own Realized P&L points to losing markets Polymarket purged from their data before you redeemed.',
-        formula: 'Σ position.realizedPnl from /positions'
-      }
-    },
-    {
       label: 'Unrealized P&L',
       value: formatSignedUsd(s.unrealizedPnl),
       valueClass: signClass(s.unrealizedPnl),
@@ -233,19 +264,6 @@ const stats = computed<Stat[]>(() => {
       explainer: {
         description: 'Gross USD value you have traded — buys + sells combined. This is a turnover number, not a profit number: a $1,000 round trip (buy and resell) counts as $2,000 of volume.',
         formula: 'Σ BUY usdcSize + Σ SELL usdcSize'
-      }
-    },
-    {
-      label: 'Settlement adjustments',
-      value: formatSignedUsd(s.settlementAdjustments),
-      valueClass: signClass(s.settlementAdjustments),
-      hint: s.settlementAdjustmentCount === 0
-        ? 'None — feeds agree'
-        : `${s.settlementAdjustmentCount} tx reconciled`,
-      explainer: {
-        description: 'Reconciliation entry for tx hashes where the on-chain USDC actually moved is a few cents different from what Polymarket\'s activity feed says. Almost always a fee or slippage. Without it, the Cash on-chain identity would gap by exactly this amount.',
-        formula: 'Σ (on-chain net − activity net) per shared tx hash',
-        example: 'A trade is reported as $50 in the activity feed, but $49.97 actually moved on-chain. Settlement adjustment = −$0.03 (a tiny fee).'
       }
     },
     {

--- a/dashboard/app/components/accounting/AccountingSummary.vue
+++ b/dashboard/app/components/accounting/AccountingSummary.vue
@@ -1,7 +1,27 @@
 <template>
   <div class="space-y-4">
-    <!-- Polymarket profile comparison -->
-    <div class="grid grid-cols-2 gap-4">
+    <!-- Headline: Polymarket comparison + our bottom line -->
+    <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
+      <div class="flex items-center gap-2">
+        <p class="text-xs uppercase tracking-wide text-muted">
+          Total return
+        </p>
+        <AccountingMetricExplainer
+          title="Total return"
+          description="The bottom-line answer to 'did I make or lose money on Polymarket?'. It compares what your wallet is worth right now to what you originally put in."
+          formula="Portfolio value − Net deposits"
+          example="If you deposited $1,000 and your wallet (cash + open bets) is now worth $1,150, total return is +$150."
+        />
+      </div>
+      <p class="text-3xl font-bold tabular-nums" :class="signClass(summary.totalReturn)">
+        {{ formatSignedUsd(summary.totalReturn) }}
+      </p>
+      <p class="text-xs text-muted">
+        Portfolio value − net deposits
+      </p>
+    </UPageCard>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
       <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
         <div class="flex items-center gap-2">
           <p class="text-xs uppercase tracking-wide text-muted">
@@ -41,124 +61,14 @@
       </UPageCard>
     </div>
 
-    <!-- Bottom line -->
-    <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
-      <div class="flex items-center gap-2">
-        <p class="text-xs uppercase tracking-wide text-muted">
-          Total return (portfolio value − net deposits)
-        </p>
-        <AccountingMetricExplainer
-          title="Total return"
-          description="The bottom-line answer to 'did I make or lose money on Polymarket?'. It compares what your wallet is worth right now to what you originally put in."
-          formula="Portfolio value − Net deposits"
-          example="If you deposited $1,000 and your wallet (cash + open bets) is now worth $1,150, total return is +$150."
-        />
-      </div>
-      <p class="text-3xl font-bold tabular-nums" :class="signClass(summary.totalReturn)">
-        {{ formatSignedUsd(summary.totalReturn) }}
-      </p>
-    </UPageCard>
-
-    <!-- Balance sheet: net deposits → cash + positions → portfolio value -->
-    <div class="grid grid-cols-2 lg:grid-cols-5 gap-4">
-      <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
-        <div class="flex items-center gap-2">
-          <p class="text-xs uppercase tracking-wide text-muted">
-            Net deposits
-          </p>
-          <AccountingMetricExplainer
-            title="Net deposits"
-            description="The capital you've actually committed to Polymarket: every USDC you sent to your Polymarket wallet, minus every USDC you withdrew."
-            formula="Total deposits − Total withdrawals"
-            example="Deposit $500, then later withdraw $100, your net deposits are $400."
-          />
-        </div>
-        <p class="text-xl font-semibold tabular-nums">
-          {{ formatUsd(summary.netDeposits) }}
-        </p>
-        <p class="text-xs text-muted">
-          Capital committed
-        </p>
-      </UPageCard>
-      <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
-        <div class="flex items-center gap-2">
-          <p class="text-xs uppercase tracking-wide text-muted">
-            Free cash balance
-          </p>
-          <AccountingMetricExplainer
-            title="Free cash balance"
-            description="USDC currently sitting idle in your wallet — what you could withdraw or use to place a new bet without selling anything. Read directly from on-chain transfers, so it always matches Polygon."
-            formula="Σ USDC received − Σ USDC sent (Etherscan)"
-          />
-        </div>
-        <p class="text-xl font-semibold tabular-nums">
-          {{ formatUsd(summary.currentCashBalance) }}
-        </p>
-        <p class="text-xs text-muted">
-          On-chain USDC
-        </p>
-      </UPageCard>
-      <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
-        <div class="flex items-center gap-2">
-          <p class="text-xs uppercase tracking-wide text-muted">
-            Open positions value
-          </p>
-          <AccountingMetricExplainer
-            title="Open positions value"
-            description="What your still-open bets would be worth if you sold them right now, at current market prices. A bet on a question that hasn't resolved yet is worth somewhere between $0 and $1 per share — this is the live market quote."
-            formula="Σ (open shares × current price) per market"
-          />
-        </div>
-        <p class="text-xl font-semibold tabular-nums">
-          {{ formatUsd(summary.openPositionsValue) }}
-        </p>
-        <p class="text-xs text-muted">
-          Mark-to-market
-        </p>
-      </UPageCard>
-      <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
-        <div class="flex items-center gap-2">
-          <p class="text-xs uppercase tracking-wide text-muted">
-            Open contracts at cost
-          </p>
-          <AccountingMetricExplainer
-            title="Open contracts at cost"
-            description="What you originally paid for the bets you still hold — their cost basis, not their current market price. Compare it to 'Open positions value' to see your paper gain or loss: paying more than they're now worth means you're sitting on an unrealized loss. This is also the value the balance sheet books open contracts at."
-            formula="Σ acquisitions − Σ disposals (cost basis)"
-            example="You paid $3.86 for bets now quoted at $0.71 → you're holding a ~$3.15 unrealized loss."
-          />
-        </div>
-        <p class="text-xl font-semibold tabular-nums">
-          {{ formatUsd(summary.openContractsAtCost) }}
-        </p>
-        <p class="text-xs text-muted">
-          Cost basis
-        </p>
-      </UPageCard>
-      <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
-        <div class="flex items-center gap-2">
-          <p class="text-xs uppercase tracking-wide text-muted">
-            Portfolio value
-          </p>
-          <AccountingMetricExplainer
-            title="Portfolio value"
-            description="Everything your Polymarket wallet is worth right now: idle cash plus the current market value of every open bet."
-            formula="Free cash balance + Open positions value"
-          />
-        </div>
-        <p class="text-xl font-semibold tabular-nums">
-          {{ formatUsd(summary.totalPortfolioValue) }}
-        </p>
-        <p class="text-xs text-muted">
-          Cash + positions
-        </p>
-      </UPageCard>
-    </div>
-
-    <!-- Detail stats -->
-    <div class="grid grid-cols-2 lg:grid-cols-3 gap-4">
+    <!-- Detail: 4 rows × 3 columns (portfolio → capital → activity) -->
+    <div
+      v-for="(row, rowIndex) in detailRows"
+      :key="rowIndex"
+      class="grid grid-cols-2 lg:grid-cols-3 gap-4"
+    >
       <UPageCard
-        v-for="stat in stats"
+        v-for="stat in row"
         :key="stat.label"
         variant="subtle"
         :ui="{ container: 'gap-1' }"
@@ -205,78 +115,137 @@ interface Stat {
   explainer: Explainer
 }
 
-const stats = computed<Stat[]>(() => {
+const detailRows = computed<Stat[][]>(() => {
   const s = props.summary
   return [
-    {
-      label: 'Total deposits',
-      value: formatUsd(s.totalDeposits),
-      valueClass: 'text-emerald-600 dark:text-emerald-400',
-      explainer: {
-        description: 'Every USDC you ever sent to your Polymarket wallet from an outside address. We get this from Polygon (Etherscan) directly — it never relies on Polymarket reporting.',
-        formula: 'Σ incoming USDC transfers (Etherscan)'
+    // Row 1 — portfolio building blocks
+    [
+      {
+        label: 'Net deposits',
+        value: formatUsd(s.netDeposits),
+        hint: 'Capital committed',
+        explainer: {
+          description: 'The capital you\'ve actually committed to Polymarket: every USDC you sent to your Polymarket wallet, minus every USDC you withdrew.',
+          formula: 'Total deposits − Total withdrawals',
+          example: 'Deposit $500, then later withdraw $100, your net deposits are $400.'
+        }
+      },
+      {
+        label: 'Free cash balance',
+        value: formatUsd(s.currentCashBalance),
+        hint: 'On-chain USDC',
+        explainer: {
+          description: 'USDC currently sitting idle in your wallet — what you could withdraw or use to place a new bet without selling anything. Read directly from on-chain transfers, so it always matches Polygon.',
+          formula: 'Σ USDC received − Σ USDC sent (Etherscan)'
+        }
+      },
+      {
+        label: 'Open positions value',
+        value: formatUsd(s.openPositionsValue),
+        hint: 'Mark-to-market',
+        explainer: {
+          description: 'What your still-open bets would be worth if you sold them right now, at current market prices. A bet on a question that hasn\'t resolved yet is worth somewhere between $0 and $1 per share — this is the live market quote.',
+          formula: 'Σ (open shares × current price) per market'
+        }
       }
-    },
-    {
-      label: 'Total withdrawals',
-      value: formatUsd(s.totalWithdrawals),
-      valueClass: 'text-rose-600 dark:text-rose-400',
-      explainer: {
-        description: 'Every USDC you ever sent out of your Polymarket wallet to an outside address.',
-        formula: 'Σ outgoing USDC transfers (Etherscan)'
+    ],
+    // Row 2 — portfolio total + realized
+    [
+      {
+        label: 'Open contracts at cost',
+        value: formatUsd(s.openContractsAtCost),
+        hint: 'Cost basis',
+        explainer: {
+          description: 'What you originally paid for the bets you still hold — their cost basis, not their current market price. Compare it to \'Open positions value\' to see your paper gain or loss: paying more than they\'re now worth means you\'re sitting on an unrealized loss. This is also the value the balance sheet books open contracts at.',
+          formula: 'Σ acquisitions − Σ disposals (cost basis)',
+          example: 'You paid $3.86 for bets now quoted at $0.71 → you\'re holding a ~$3.15 unrealized loss.'
+        }
+      },
+      {
+        label: 'Portfolio value',
+        value: formatUsd(s.totalPortfolioValue),
+        hint: 'Cash + positions',
+        explainer: {
+          description: 'Everything your Polymarket wallet is worth right now: idle cash plus the current market value of every open bet.',
+          formula: 'Free cash balance + Open positions value'
+        }
+      },
+      {
+        label: 'Realized P&L',
+        value: formatSignedUsd(s.realizedPnl),
+        valueClass: signClass(s.realizedPnl),
+        hint: 'Lot accounting — same as Income Statement',
+        explainer: {
+          description: 'Money you actually locked in: when you sold shares, when a market resolved and you redeemed, when you merged shares back to cash, or when a losing bet resolved without redemption. Computed with weighted-average-cost lot accounting on every trade.',
+          formula: 'Σ (proceeds − cost basis) per disposed lot',
+          example: 'You bought 100 "Yes" shares for $40 ($0.40 each) and sold them later for $60 ($0.60 each). Realized P&L on this trade = +$20.'
+        }
       }
-    },
-    {
-      label: 'Realized P&L',
-      value: formatSignedUsd(s.realizedPnl),
-      valueClass: signClass(s.realizedPnl),
-      hint: 'Lot accounting — same as Income Statement',
-      explainer: {
-        description: 'Money you actually locked in: when you sold shares, when a market resolved and you redeemed, when you merged shares back to cash, or when a losing bet resolved without redemption. Computed with weighted-average-cost lot accounting on every trade.',
-        formula: 'Σ (proceeds − cost basis) per disposed lot',
-        example: 'You bought 100 "Yes" shares for $40 ($0.40 each) and sold them later for $60 ($0.60 each). Realized P&L on this trade = +$20.'
+    ],
+    // Row 3 — capital flow + unrealized
+    [
+      {
+        label: 'Total deposits',
+        value: formatUsd(s.totalDeposits),
+        valueClass: 'text-emerald-600 dark:text-emerald-400',
+        explainer: {
+          description: 'Every USDC you ever sent to your Polymarket wallet from an outside address. We get this from Polygon (Etherscan) directly — it never relies on Polymarket reporting.',
+          formula: 'Σ incoming USDC transfers (Etherscan)'
+        }
+      },
+      {
+        label: 'Total withdrawals',
+        value: formatUsd(s.totalWithdrawals),
+        valueClass: 'text-rose-600 dark:text-rose-400',
+        explainer: {
+          description: 'Every USDC you ever sent out of your Polymarket wallet to an outside address.',
+          formula: 'Σ outgoing USDC transfers (Etherscan)'
+        }
+      },
+      {
+        label: 'Unrealized P&L',
+        value: formatSignedUsd(s.unrealizedPnl),
+        valueClass: signClass(s.unrealizedPnl),
+        hint: 'Open positions',
+        explainer: {
+          description: 'Paper profit or loss on bets still in play, i.e. how much the current market price differs from what you originally paid. It can swing either way until the market resolves.',
+          formula: 'Σ (current value − initial cost) per open position',
+          example: 'You paid $0.40 per share for 100 "Yes" shares. The market now trades at $0.55. Unrealized P&L = +$15.'
+        }
       }
-    },
-    {
-      label: 'Unrealized P&L',
-      value: formatSignedUsd(s.unrealizedPnl),
-      valueClass: signClass(s.unrealizedPnl),
-      hint: 'Open positions',
-      explainer: {
-        description: 'Paper profit or loss on bets still in play, i.e. how much the current market price differs from what you originally paid. It can swing either way until the market resolves.',
-        formula: 'Σ (current value − initial cost) per open position',
-        example: 'You paid $0.40 per share for 100 "Yes" shares. The market now trades at $0.55. Unrealized P&L = +$15.'
+    ],
+    // Row 4 — activity & reconciliation
+    [
+      {
+        label: 'Rewards earned',
+        value: formatUsd(s.totalRewards),
+        valueClass: 'text-emerald-600 dark:text-emerald-400',
+        explainer: {
+          description: 'Free USDC Polymarket has paid you: liquidity-provider rewards, maker rebates, and referral payouts. Not the result of any trade — it just lands in your wallet.',
+          formula: 'Σ REWARD + MAKER_REBATE + REFERRAL_REWARD activity rows'
+        }
+      },
+      {
+        label: 'Trading volume',
+        value: formatUsd(s.tradingVolume),
+        hint: `${s.tradeCount} trades`,
+        explainer: {
+          description: 'Gross USD value you have traded — buys + sells combined. This is a turnover number, not a profit number: a $1,000 round trip (buy and resell) counts as $2,000 of volume.',
+          formula: 'Σ BUY usdcSize + Σ SELL usdcSize'
+        }
+      },
+      {
+        label: 'Position basis drift',
+        value: formatSignedUsd(s.positionBasisDrift),
+        valueClass: signClass(s.positionBasisDrift),
+        hint: 'Polymarket basis vs ours',
+        explainer: {
+          description: 'Reconciliation entry for the gap between Polymarket\'s own reported cost basis on open positions (their cashPnl) and what our weighted-average-cost lot accounting derives from /activity. Without it, the Total return identity would gap by exactly this amount.',
+          formula: 'openPositionsValue − openContractsAtCost − unrealizedPnl',
+          example: 'Polymarket says you have $100 of open positions with $20 of unrealized profit (basis $80). Our /activity lot accounting computes a basis of $75. Drift = $100 − $75 − $20 = +$5.'
+        }
       }
-    },
-    {
-      label: 'Rewards earned',
-      value: formatUsd(s.totalRewards),
-      valueClass: 'text-emerald-600 dark:text-emerald-400',
-      explainer: {
-        description: 'Free USDC Polymarket has paid you: liquidity-provider rewards, maker rebates, and referral payouts. Not the result of any trade — it just lands in your wallet.',
-        formula: 'Σ REWARD + MAKER_REBATE + REFERRAL_REWARD activity rows'
-      }
-    },
-    {
-      label: 'Trading volume',
-      value: formatUsd(s.tradingVolume),
-      hint: `${s.tradeCount} trades`,
-      explainer: {
-        description: 'Gross USD value you have traded — buys + sells combined. This is a turnover number, not a profit number: a $1,000 round trip (buy and resell) counts as $2,000 of volume.',
-        formula: 'Σ BUY usdcSize + Σ SELL usdcSize'
-      }
-    },
-    {
-      label: 'Position basis drift',
-      value: formatSignedUsd(s.positionBasisDrift),
-      valueClass: signClass(s.positionBasisDrift),
-      hint: 'Polymarket basis vs ours',
-      explainer: {
-        description: 'Reconciliation entry for the gap between Polymarket\'s own reported cost basis on open positions (their cashPnl) and what our weighted-average-cost lot accounting derives from /activity. Without it, the Total return identity would gap by exactly this amount.',
-        formula: 'openPositionsValue − openContractsAtCost − unrealizedPnl',
-        example: 'Polymarket says you have $100 of open positions with $20 of unrealized profit (basis $80). Our /activity lot accounting computes a basis of $75. Drift = $100 − $75 − $20 = +$5.'
-      }
-    }
+    ]
   ]
 })
 </script>

--- a/dashboard/app/components/accounting/AccountingSummary.vue
+++ b/dashboard/app/components/accounting/AccountingSummary.vue
@@ -25,10 +25,10 @@
       <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
         <div class="flex items-center gap-2">
           <p class="text-xs uppercase tracking-wide text-muted">
-            Profit / loss
+            Polymarket displayed profit/loss
           </p>
           <AccountingMetricExplainer
-            title="Profit / loss"
+            title="Polymarket displayed profit/loss"
             description="All-time profit or loss — the same figure Polymarket shows on your profile page Profit/Loss chart. Pulled from Polymarket's user-pnl API (not reconstructed from /positions), so it stays in sync with polymarket.com/profile even when individual position rows are purged or carry stale per-market P&L."
             formula="Latest point from user-pnl-api.polymarket.com"
           />

--- a/dashboard/app/composables/useAccounting.ts
+++ b/dashboard/app/composables/useAccounting.ts
@@ -3,7 +3,8 @@ import { computed, toValue } from 'vue'
 import {
   useAllPolymarketActivityQuery,
   usePolygonscanTransfersQuery,
-  usePolymarketPositionsQuery
+  usePolymarketPositionsQuery,
+  usePolymarketUserPnlQuery
 } from '~/queries/polymarket.queries'
 import { buildLedger } from '~/utils/accounting'
 import { buildBalanceSheet } from '~/utils/balanceSheet'
@@ -21,6 +22,7 @@ import { computeRealizedTrades } from '~/utils/incomeStatement'
 export function useAccounting(address: MaybeRefOrGetter<string>) {
   const activityQuery = useAllPolymarketActivityQuery(address)
   const positionsQuery = usePolymarketPositionsQuery(address)
+  const userPnlQuery = usePolymarketUserPnlQuery(address)
   const transfersQuery = usePolygonscanTransfersQuery(address)
 
   // Dated realized disposals (lot accounting) — shared by every statement.
@@ -61,14 +63,33 @@ export function useAccounting(address: MaybeRefOrGetter<string>) {
     isAsOfToday: isAsOfToday.value
   }))
 
+  // The profile P&L feed is best-effort: when it is missing or errors, `summary`
+  // falls back to the buildLedger seed (positionsRealizedPnl + unrealizedPnl), so
+  // it is deliberately kept out of the loading/error gates below — a flaky or
+  // geo-blocked user-pnl endpoint must not take down the whole accounting page.
+  const summary = computed(() => {
+    const base = ledger.value.summary
+    const profilePnl = userPnlQuery.data.value
+    if (profilePnl == null) {
+      return base
+    }
+    return { ...base, polymarketPnl: profilePnl }
+  })
+
   const isLoading = computed(() =>
-    activityQuery.isLoading.value || positionsQuery.isLoading.value || transfersQuery.isLoading.value
+    activityQuery.isLoading.value
+    || positionsQuery.isLoading.value
+    || transfersQuery.isLoading.value
   )
   const isFetching = computed(() =>
-    activityQuery.isFetching.value || positionsQuery.isFetching.value || transfersQuery.isFetching.value
+    activityQuery.isFetching.value
+    || positionsQuery.isFetching.value
+    || transfersQuery.isFetching.value
   )
   const error = computed(() =>
-    activityQuery.error.value ?? positionsQuery.error.value ?? transfersQuery.error.value
+    activityQuery.error.value
+    ?? positionsQuery.error.value
+    ?? transfersQuery.error.value
   )
   /** True when the Etherscan history was too long to fetch in full. */
   const transfersTruncated = computed(() => transfersQuery.data.value?.truncated ?? false)
@@ -76,12 +97,13 @@ export function useAccounting(address: MaybeRefOrGetter<string>) {
   function refetch(): void {
     void activityQuery.refetch()
     void positionsQuery.refetch()
+    void userPnlQuery.refetch()
     void transfersQuery.refetch()
   }
 
   return {
     entries: computed(() => ledger.value.entries),
-    summary: computed(() => ledger.value.summary),
+    summary,
     positions: computed(() => positionsQuery.data.value ?? []),
     activities: computed(() => activityQuery.data.value ?? []),
     realizedTrades,

--- a/dashboard/app/queries/polymarket.queries.ts
+++ b/dashboard/app/queries/polymarket.queries.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/vue-query'
 import type { MaybeRefOrGetter } from 'vue'
 import { computed, toValue } from 'vue'
 import { isAddress } from 'viem'
-import { fetchAllPolymarketActivity, fetchAllPolymarketPositions } from '~/api/polymarket'
+import { fetchAllPolymarketActivity, fetchAllPolymarketPositions, fetchPolymarketLatestPnl } from '~/api/polymarket'
 import { fetchPolygonTokenTransfers } from '~/api/polygonscan'
 
 /** Normalizes and validates an address ref shared by the accounting queries. */
@@ -20,6 +20,20 @@ export function useAllPolymarketActivityQuery(address: MaybeRefOrGetter<string>)
     computed(() => ({
       queryKey: ['polymarket', 'activity-all', addr.value.value] as const,
       queryFn: async () => await fetchAllPolymarketActivity(addr.value.value),
+      enabled: addr.value.valid,
+      refetchOnWindowFocus: false,
+      staleTime: 1000 * 60 * 5
+    }))
+  )
+}
+
+/** All-time Profit/Loss — same source as the Polymarket profile chart. */
+export function usePolymarketUserPnlQuery(address: MaybeRefOrGetter<string>) {
+  const addr = useValidAddress(address)
+  return useQuery(
+    computed(() => ({
+      queryKey: ['polymarket', 'user-pnl', addr.value.value] as const,
+      queryFn: async () => await fetchPolymarketLatestPnl(addr.value.value),
       enabled: addr.value.valid,
       refetchOnWindowFocus: false,
       staleTime: 1000 * 60 * 5

--- a/dashboard/app/types/polymarket.ts
+++ b/dashboard/app/types/polymarket.ts
@@ -71,3 +71,11 @@ export interface PolymarketPosition {
   redeemable?: boolean
   mergeable?: boolean
 }
+
+/** One point from Polymarket user-pnl-api — powers the profile Profit/Loss chart. */
+export interface PolymarketUserPnlPoint {
+  /** Unix seconds. */
+  t: number
+  /** Cumulative portfolio P&L (USD) at `t`. */
+  p: number
+}

--- a/dashboard/app/utils/accounting.ts
+++ b/dashboard/app/utils/accounting.ts
@@ -80,6 +80,13 @@ export interface AccountingSummary {
   positionsRealizedPnl: number
   /** Unrealized P&L on open positions (from /positions). */
   unrealizedPnl: number
+  /**
+   * All-time P&L as Polymarket's profile page reports it — sourced from
+   * `user-pnl-api.polymarket.com` in {@link useAccounting} (latest chart point).
+   * `buildLedger()` seeds this as `positionsRealizedPnl + unrealizedPnl` until
+   * that feed loads; the two diverge once `/positions` rows go stale.
+   */
+  polymarketPnl: number
   /** Mark-to-market value of still-open positions. */
   openPositionsValue: number
   /**
@@ -103,6 +110,13 @@ export interface AccountingSummary {
   settlementAdjustments: number
   /** Number of distinct tx hashes that produced a settlement adjustment. */
   settlementAdjustmentCount: number
+  /**
+   * Trading/settlement costs: sum of |cashFlow| over SETTLEMENT_ADJUSTMENT
+   * entries where cashFlow < 0 (on-chain USDC was less than activity reported).
+   */
+  totalFees: number
+  /** Number of SETTLEMENT_ADJUSTMENT entries with negative cashFlow. */
+  feeTransactionCount: number
   /**
    * Cost-basis disagreement between Polymarket /positions (which reports
    * `cashPnl` against its own `initialValue`) and our /activity-derived basis
@@ -367,6 +381,7 @@ export function buildLedger(input: BuildLedgerInput): AccountingLedger {
     realizedPnl: 0,
     positionsRealizedPnl: 0,
     unrealizedPnl: 0,
+    polymarketPnl: 0,
     openPositionsValue: 0,
     openContractsAtCost: 0,
     totalRewards: 0,
@@ -374,6 +389,8 @@ export function buildLedger(input: BuildLedgerInput): AccountingLedger {
     tradeCount: 0,
     settlementAdjustments: 0,
     settlementAdjustmentCount: 0,
+    totalFees: 0,
+    feeTransactionCount: 0,
     positionBasisDrift: 0,
     currentCashBalance: 0,
     totalPortfolioValue: 0,
@@ -395,6 +412,10 @@ export function buildLedger(input: BuildLedgerInput): AccountingLedger {
     } else if (entry.category === 'SETTLEMENT_ADJUSTMENT') {
       summary.settlementAdjustments += entry.cashFlow
       summary.settlementAdjustmentCount += 1
+      if (entry.cashFlow < 0) {
+        summary.totalFees += Math.abs(entry.cashFlow)
+        summary.feeTransactionCount += 1
+      }
     }
     if (entry.category === 'TRADE_BUY' || entry.category === 'SPLIT') {
       acquisitionCost += entry.amount
@@ -407,6 +428,7 @@ export function buildLedger(input: BuildLedgerInput): AccountingLedger {
     summary.unrealizedPnl += position.cashPnl ?? 0
     summary.openPositionsValue += position.currentValue ?? 0
   }
+  summary.polymarketPnl = summary.positionsRealizedPnl + summary.unrealizedPnl
   // Canonical realizedPnl comes from lot accounting (Income Statement source);
   // falls back to Polymarket's reported figure when no realizedTrades supplied.
   if (input.realizedTrades) {


### PR DESCRIPTION


# Description

## Intial Issue Description

This update introduces the `PolymarketUserPnlPoint` interface for user-specific Profit/Loss data and expands the `AccountingSummary` interface to include `polymarketPnl`, `totalFees`, and `feeTransactionCount`. The `buildLedger` function is updated to calculate these new metrics, improving the financial insights available to users.


Fixes #2100


