### PR TITLE
feat: ✨ shared UI blocks — monogram, avatar group, distribution bar, role badge — step 2/8

### DIFF
--- a/app/src/components/sections/CompaniesView/AvatarGroup.vue
+++ b/app/src/components/sections/CompaniesView/AvatarGroup.vue
@@ -1,0 +1,61 @@
+<template>
+  <div data-test="avatar-group" class="flex items-center">
+    <UAvatar
+      v-for="(member, index) in visibleMembers"
+      :key="member.address ?? member.name ?? index"
+      data-test="avatar-group-item"
+      :size="size"
+      :src="member.imageUrl"
+      :alt="member.name ?? member.address"
+      :text="initials(member)"
+      class="ring-default ring-2"
+      :class="index > 0 ? '-ml-2' : ''"
+    />
+    <div
+      v-if="overflow > 0"
+      data-test="avatar-overflow"
+      class="ring-default bg-elevated text-muted -ml-2 flex items-center justify-center rounded-full font-semibold ring-2"
+      :class="overflowSizeClass"
+    >
+      +{{ overflow }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface AvatarMember {
+  name?: string
+  address?: string
+  imageUrl?: string
+}
+
+interface Props {
+  members: AvatarMember[]
+  max?: number
+  size?: 'xs' | 'sm' | 'md'
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  max: 3,
+  size: 'sm'
+})
+
+const visibleMembers = computed(() => props.members.slice(0, props.max))
+const overflow = computed(() => Math.max(0, props.members.length - props.max))
+
+const overflowSizeClass = computed(
+  () =>
+    ({
+      xs: 'h-6 w-6 text-[9px]',
+      sm: 'h-8 w-8 text-[11px]',
+      md: 'h-10 w-10 text-xs'
+    })[props.size]
+)
+
+function initials(member: AvatarMember): string {
+  const source = member.name ?? member.address ?? ''
+  return source.trim().slice(0, 2).toUpperCase()
+}
+</script>

--- a/app/src/components/sections/CompaniesView/CompanyMonogram.vue
+++ b/app/src/components/sections/CompaniesView/CompanyMonogram.vue
@@ -1,0 +1,38 @@
+<template>
+  <div
+    data-test="company-monogram"
+    :data-role="role"
+    class="flex shrink-0 items-center justify-center rounded-[10px] font-bold"
+    :class="role === 'owner' ? 'bg-success/15 text-success' : 'bg-secondary/15 text-secondary'"
+    :style="tileStyle"
+  >
+    {{ initials }}
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  name: string
+  code?: string
+  role: 'owner' | 'employee'
+  size?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  code: undefined,
+  size: 34
+})
+
+const initials = computed(() => {
+  if (props.code) return props.code.slice(0, 2).toUpperCase()
+  return props.name.trim().slice(0, 2).toUpperCase()
+})
+
+const tileStyle = computed(() => ({
+  width: `${props.size}px`,
+  height: `${props.size}px`,
+  fontSize: `${Math.round(props.size * 0.38)}px`
+}))
+</script>

--- a/app/src/components/sections/CompaniesView/DistributionBar.vue
+++ b/app/src/components/sections/CompaniesView/DistributionBar.vue
@@ -1,0 +1,51 @@
+<template>
+  <div data-test="distribution-bar">
+    <div class="bg-muted flex w-full gap-px overflow-hidden rounded-full" :style="{ height }">
+      <div
+        v-for="(segment, index) in validSegments"
+        :key="`${segment.label}-${index}`"
+        data-test="distribution-segment"
+        :data-label="segment.label"
+        class="h-full first:rounded-l-full last:rounded-r-full"
+        :style="{ width: `${segment.pct}%`, background: segment.color }"
+      />
+    </div>
+
+    <div
+      v-if="legend && validSegments.length"
+      data-test="distribution-legend"
+      class="mt-2 flex flex-wrap gap-x-3 gap-y-1"
+    >
+      <span
+        v-for="(segment, index) in validSegments"
+        :key="`legend-${segment.label}-${index}`"
+        data-test="distribution-legend-item"
+        class="text-default inline-flex items-center gap-1.5 text-xs"
+      >
+        <span class="h-[7px] w-[7px] shrink-0 rounded-sm" :style="{ background: segment.color }" />
+        {{ segment.label }} {{ segment.pct }}%
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+type Segment = { label: string; pct: number; color: string }
+
+interface Props {
+  segments: Segment[]
+  legend?: boolean
+  height?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  legend: false,
+  height: '7px'
+})
+
+const validSegments = computed(() =>
+  (props.segments ?? []).filter((segment) => segment && segment.pct > 0)
+)
+</script>

--- a/app/src/components/sections/CompaniesView/RoleBadge.vue
+++ b/app/src/components/sections/CompaniesView/RoleBadge.vue
@@ -1,0 +1,22 @@
+<template>
+  <UBadge
+    data-test="role-badge"
+    :data-role="role"
+    :color="role === 'owner' ? 'primary' : 'secondary'"
+    variant="solid"
+    size="sm"
+    :label="label"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  role: 'owner' | 'employee'
+}
+
+const props = defineProps<Props>()
+
+const label = computed(() => props.role.charAt(0).toUpperCase() + props.role.slice(1))
+</script>

--- a/app/src/components/sections/CompaniesView/__tests__/AvatarGroup.spec.ts
+++ b/app/src/components/sections/CompaniesView/__tests__/AvatarGroup.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AvatarGroup from '@/components/sections/CompaniesView/AvatarGroup.vue'
+
+describe('AvatarGroup', () => {
+  const members = [
+    { name: 'Alice', address: '0x1', imageUrl: 'https://example.com/a.png' },
+    { name: 'Bob', address: '0x2' },
+    { name: 'Carol', address: '0x3' },
+    { name: 'Dave', address: '0x4' },
+    { name: 'Erin', address: '0x5' }
+  ]
+
+  const avatars = (wrapper: ReturnType<typeof mount>) =>
+    wrapper.findAll('[data-test="avatar-group-item"]')
+
+  it('renders the root with a data-test attribute', () => {
+    const wrapper = mount(AvatarGroup, { props: { members } })
+    expect(wrapper.find('[data-test="avatar-group"]').exists()).toBe(true)
+  })
+
+  it('renders at most `max` avatars (default 3)', () => {
+    const wrapper = mount(AvatarGroup, { props: { members } })
+    expect(avatars(wrapper)).toHaveLength(3)
+  })
+
+  it('honors a custom max', () => {
+    const wrapper = mount(AvatarGroup, { props: { members, max: 4 } })
+    expect(avatars(wrapper)).toHaveLength(4)
+  })
+
+  it('renders every avatar when count is at or below max', () => {
+    const wrapper = mount(AvatarGroup, { props: { members: members.slice(0, 2) } })
+    expect(avatars(wrapper)).toHaveLength(2)
+    expect(wrapper.find('[data-test="avatar-overflow"]').exists()).toBe(false)
+  })
+
+  it('shows a +N overflow chip when members exceed max', () => {
+    const wrapper = mount(AvatarGroup, { props: { members, max: 3 } })
+    const overflow = wrapper.find('[data-test="avatar-overflow"]')
+    expect(overflow.exists()).toBe(true)
+    expect(overflow.text()).toBe('+2')
+  })
+
+  it('uses imageUrl as the avatar image source when present', () => {
+    const wrapper = mount(AvatarGroup, { props: { members } })
+    expect(avatars(wrapper)[0].attributes('src')).toBe('https://example.com/a.png')
+    expect(avatars(wrapper)[0].attributes('alt')).toBe('Alice')
+  })
+
+  it('derives initials for members without an image', () => {
+    const wrapper = mount(AvatarGroup, { props: { members } })
+    expect(avatars(wrapper)[1].attributes('src')).toBeUndefined()
+    expect(avatars(wrapper)[1].text()).toBe('BO')
+  })
+
+  it('forwards the size prop to the avatars', () => {
+    const sm = mount(AvatarGroup, { props: { members, size: 'sm' } })
+    const md = mount(AvatarGroup, { props: { members, size: 'md' } })
+    const smWidth = avatars(sm)[0].attributes('width')
+    const mdWidth = avatars(md)[0].attributes('width')
+    expect(smWidth).toBeDefined()
+    expect(mdWidth).toBeDefined()
+    expect(Number(mdWidth)).toBeGreaterThan(Number(smWidth))
+  })
+
+  it('handles an empty member list', () => {
+    const wrapper = mount(AvatarGroup, { props: { members: [] } })
+    expect(avatars(wrapper)).toHaveLength(0)
+    expect(wrapper.find('[data-test="avatar-overflow"]').exists()).toBe(false)
+  })
+})

--- a/app/src/components/sections/CompaniesView/__tests__/CompanyMonogram.spec.ts
+++ b/app/src/components/sections/CompaniesView/__tests__/CompanyMonogram.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CompanyMonogram from '@/components/sections/CompaniesView/CompanyMonogram.vue'
+
+describe('CompanyMonogram', () => {
+  const root = (wrapper: ReturnType<typeof mount>) => wrapper.find('[data-test="company-monogram"]')
+
+  it('renders the root with a data-test attribute', () => {
+    const wrapper = mount(CompanyMonogram, { props: { name: 'Acme', role: 'owner' } })
+    expect(root(wrapper).exists()).toBe(true)
+  })
+
+  it('derives initials from the first two letters of the name', () => {
+    const wrapper = mount(CompanyMonogram, { props: { name: 'globe', role: 'owner' } })
+    expect(root(wrapper).text()).toBe('GL')
+  })
+
+  it('prefers the explicit code over the name', () => {
+    const wrapper = mount(CompanyMonogram, {
+      props: { name: 'Globe and Citizen', code: 'gc', role: 'owner' }
+    })
+    expect(root(wrapper).text()).toBe('GC')
+  })
+
+  it('truncates a long code to two characters', () => {
+    const wrapper = mount(CompanyMonogram, {
+      props: { name: 'Acme', code: 'ACME', role: 'owner' }
+    })
+    expect(root(wrapper).text()).toBe('AC')
+  })
+
+  it('marks an owner tile via data-role', () => {
+    const wrapper = mount(CompanyMonogram, { props: { name: 'Acme', role: 'owner' } })
+    expect(root(wrapper).attributes('data-role')).toBe('owner')
+  })
+
+  it('marks an employee tile via data-role', () => {
+    const wrapper = mount(CompanyMonogram, { props: { name: 'Acme', role: 'employee' } })
+    expect(root(wrapper).attributes('data-role')).toBe('employee')
+  })
+
+  it('defaults to a 34px tile', () => {
+    const wrapper = mount(CompanyMonogram, { props: { name: 'Acme', role: 'owner' } })
+    const style = root(wrapper).attributes('style') ?? ''
+    expect(style).toContain('width: 34px')
+    expect(style).toContain('height: 34px')
+  })
+
+  it('honors a custom size', () => {
+    const wrapper = mount(CompanyMonogram, { props: { name: 'Acme', role: 'owner', size: 48 } })
+    const style = root(wrapper).attributes('style') ?? ''
+    expect(style).toContain('width: 48px')
+    expect(style).toContain('height: 48px')
+  })
+})

--- a/app/src/components/sections/CompaniesView/__tests__/DistributionBar.spec.ts
+++ b/app/src/components/sections/CompaniesView/__tests__/DistributionBar.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import DistributionBar from '@/components/sections/CompaniesView/DistributionBar.vue'
+
+describe('DistributionBar', () => {
+  const segments = [
+    { label: 'Bank', pct: 60, color: '#3b82f6' },
+    { label: 'Investor', pct: 40, color: '#22c55e' }
+  ]
+
+  it('renders the root with a data-test attribute', () => {
+    const wrapper = mount(DistributionBar, { props: { segments } })
+    expect(wrapper.find('[data-test="distribution-bar"]').exists()).toBe(true)
+  })
+
+  it('renders one segment per non-zero entry', () => {
+    const wrapper = mount(DistributionBar, { props: { segments } })
+    expect(wrapper.findAll('[data-test="distribution-segment"]')).toHaveLength(2)
+  })
+
+  it('sets each segment width and background from the props', () => {
+    const wrapper = mount(DistributionBar, { props: { segments } })
+    const first = wrapper.findAll('[data-test="distribution-segment"]')[0]
+    const style = first.attributes('style') ?? ''
+    expect(style).toContain('width: 60%')
+    expect(style).toContain('background: rgb(59, 130, 246)')
+    expect(first.attributes('data-label')).toBe('Bank')
+  })
+
+  it('honors a custom height', () => {
+    const wrapper = mount(DistributionBar, { props: { segments, height: '12px' } })
+    const bar = wrapper.find('[data-test="distribution-bar"] > div')
+    expect(bar.attributes('style')).toContain('height: 12px')
+  })
+
+  it('drops zero-percent segments', () => {
+    const wrapper = mount(DistributionBar, {
+      props: {
+        segments: [
+          { label: 'Bank', pct: 100, color: '#3b82f6' },
+          { label: 'Empty', pct: 0, color: '#22c55e' }
+        ]
+      }
+    })
+    expect(wrapper.findAll('[data-test="distribution-segment"]')).toHaveLength(1)
+  })
+
+  it('renders nothing when there are no segments', () => {
+    const wrapper = mount(DistributionBar, { props: { segments: [] } })
+    expect(wrapper.findAll('[data-test="distribution-segment"]')).toHaveLength(0)
+  })
+
+  it('hides the legend by default', () => {
+    const wrapper = mount(DistributionBar, { props: { segments } })
+    expect(wrapper.find('[data-test="distribution-legend"]').exists()).toBe(false)
+  })
+
+  it('renders a legend row per segment when legend is enabled', () => {
+    const wrapper = mount(DistributionBar, { props: { segments, legend: true } })
+    expect(wrapper.find('[data-test="distribution-legend"]').exists()).toBe(true)
+    const items = wrapper.findAll('[data-test="distribution-legend-item"]')
+    expect(items).toHaveLength(2)
+    expect(items[0].text()).toContain('Bank 60%')
+    expect(items[1].text()).toContain('Investor 40%')
+  })
+
+  it('does not render an empty legend container', () => {
+    const wrapper = mount(DistributionBar, { props: { segments: [], legend: true } })
+    expect(wrapper.find('[data-test="distribution-legend"]').exists()).toBe(false)
+  })
+})

--- a/app/src/components/sections/CompaniesView/__tests__/RoleBadge.spec.ts
+++ b/app/src/components/sections/CompaniesView/__tests__/RoleBadge.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import RoleBadge from '@/components/sections/CompaniesView/RoleBadge.vue'
+
+describe('RoleBadge', () => {
+  const badge = (wrapper: ReturnType<typeof mount>) => wrapper.find('[data-test="role-badge"]')
+
+  it('renders the root with a data-test attribute', () => {
+    const wrapper = mount(RoleBadge, { props: { role: 'owner' } })
+    expect(badge(wrapper).exists()).toBe(true)
+  })
+
+  it('renders Owner with an owner role badge', () => {
+    const wrapper = mount(RoleBadge, { props: { role: 'owner' } })
+    expect(badge(wrapper).attributes('data-role')).toBe('owner')
+    expect(badge(wrapper).text()).toBe('Owner')
+  })
+
+  it('renders Employee with an employee role badge', () => {
+    const wrapper = mount(RoleBadge, { props: { role: 'employee' } })
+    expect(badge(wrapper).attributes('data-role')).toBe('employee')
+    expect(badge(wrapper).text()).toBe('Employee')
+  })
+
+  it('capitalizes the role label', () => {
+    const wrapper = mount(RoleBadge, { props: { role: 'employee' } })
+    expect(badge(wrapper).text()).toBe('Employee')
+  })
+})


### PR DESCRIPTION
Four reusable presentational components for the Companies list (in `components/sections/CompaniesView/`): CompanyMonogram, AvatarGroup (overlapping avatars + overflow), DistributionBar (segmented bar + optional legend), RoleBadge. Dark-mode-safe semantic classes; data-driven segment colors only. 30 unit tests.

Gate: type-check ✓ · eslint ✓ · vitest 30/30 ✓.

Refs #2131 · part of #2128