### PR TITLE
refactor: ♻️ companies list header — role filter, search, filters popover, view toggle — step 2/8

### DIFF
--- a/app/src/composables/__tests__/useCompaniesFilter.spec.ts
+++ b/app/src/composables/__tests__/useCompaniesFilter.spec.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useCompaniesFilter, type CompanyRoleFilter } from '@/composables/useCompaniesFilter'
+import type { Team } from '@/types/team'
+
+const USER = '0x1111111111111111111111111111111111111111'
+const OTHER = '0x2222222222222222222222222222222222222222'
+
+function makeTeam(overrides: Partial<Team> = {}): Team {
+  return {
+    id: '1',
+    name: 'Team',
+    description: '',
+    isHidden: false,
+    isArchived: false,
+    members: [],
+    ownerAddress: OTHER as Team['ownerAddress'],
+    teamContracts: [],
+    ...overrides
+  }
+}
+
+describe('useCompaniesFilter', () => {
+  describe('counts', () => {
+    it('splits visible teams into owner / employee buckets', () => {
+      const teams = [
+        makeTeam({ id: '1', ownerAddress: USER as Team['ownerAddress'] }),
+        makeTeam({ id: '2', ownerAddress: USER as Team['ownerAddress'] }),
+        makeTeam({ id: '3', ownerAddress: OTHER as Team['ownerAddress'] })
+      ]
+      const { counts } = useCompaniesFilter(teams, {
+        userAddress: USER,
+        role: 'all',
+        query: '',
+        showHidden: false,
+        showArchived: false
+      })
+      expect(counts.value).toEqual({ all: 3, owner: 2, employee: 1 })
+    })
+
+    it('matches owner address case-insensitively', () => {
+      const teams = [makeTeam({ ownerAddress: USER.toUpperCase() as Team['ownerAddress'] })]
+      const { counts } = useCompaniesFilter(teams, {
+        userAddress: USER.toLowerCase(),
+        role: 'all',
+        query: '',
+        showHidden: false,
+        showArchived: false
+      })
+      expect(counts.value).toEqual({ all: 1, owner: 1, employee: 0 })
+    })
+
+    it('ignores role + query when computing counts', () => {
+      const teams = [
+        makeTeam({ id: '1', name: 'Alpha', ownerAddress: USER as Team['ownerAddress'] }),
+        makeTeam({ id: '2', name: 'Beta', ownerAddress: OTHER as Team['ownerAddress'] })
+      ]
+      const { counts } = useCompaniesFilter(teams, {
+        userAddress: USER,
+        role: 'owner',
+        query: 'zzz',
+        showHidden: false,
+        showArchived: false
+      })
+      expect(counts.value).toEqual({ all: 2, owner: 1, employee: 1 })
+    })
+
+    it('returns zeros for null / non-array input', () => {
+      const { counts, filtered } = useCompaniesFilter(null, {
+        userAddress: USER,
+        role: 'all',
+        query: '',
+        showHidden: false,
+        showArchived: false
+      })
+      expect(counts.value).toEqual({ all: 0, owner: 0, employee: 0 })
+      expect(filtered.value).toEqual([])
+    })
+  })
+
+  describe('role filter', () => {
+    const teams = [
+      makeTeam({ id: '1', name: 'Owned', ownerAddress: USER as Team['ownerAddress'] }),
+      makeTeam({ id: '2', name: 'Joined', ownerAddress: OTHER as Team['ownerAddress'] })
+    ]
+
+    it("keeps everything for role 'all'", () => {
+      const { filtered } = useCompaniesFilter(teams, {
+        userAddress: USER,
+        role: 'all',
+        query: '',
+        showHidden: false,
+        showArchived: false
+      })
+      expect(filtered.value.map((t) => t.id)).toEqual(['1', '2'])
+    })
+
+    it("keeps only owned teams for role 'owner'", () => {
+      const { filtered } = useCompaniesFilter(teams, {
+        userAddress: USER,
+        role: 'owner',
+        query: '',
+        showHidden: false,
+        showArchived: false
+      })
+      expect(filtered.value.map((t) => t.id)).toEqual(['1'])
+    })
+
+    it("keeps only employee teams for role 'employee'", () => {
+      const { filtered } = useCompaniesFilter(teams, {
+        userAddress: USER,
+        role: 'employee',
+        query: '',
+        showHidden: false,
+        showArchived: false
+      })
+      expect(filtered.value.map((t) => t.id)).toEqual(['2'])
+    })
+  })
+
+  describe('query match', () => {
+    const teams = [
+      makeTeam({ id: '1', name: 'Acme Corp', description: 'rockets' }),
+      makeTeam({ id: '2', name: 'Globex', description: 'widgets' })
+    ]
+
+    it('matches the team name case-insensitively', () => {
+      const { filtered } = useCompaniesFilter(teams, {
+        userAddress: USER,
+        role: 'all',
+        query: 'ACME',
+        showHidden: false,
+        showArchived: false
+      })
+      expect(filtered.value.map((t) => t.id)).toEqual(['1'])
+    })
+
+    it('matches the team description', () => {
+      const { filtered } = useCompaniesFilter(teams, {
+        userAddress: USER,
+        role: 'all',
+        query: 'widget',
+        showHidden: false,
+        showArchived: false
+      })
+      expect(filtered.value.map((t) => t.id)).toEqual(['2'])
+    })
+
+    it('ignores surrounding whitespace and an empty query', () => {
+      const { filtered } = useCompaniesFilter(teams, {
+        userAddress: USER,
+        role: 'all',
+        query: '   ',
+        showHidden: false,
+        showArchived: false
+      })
+      expect(filtered.value).toHaveLength(2)
+    })
+  })
+
+  describe('visibility', () => {
+    const teams = [
+      makeTeam({ id: '1', name: 'Active' }),
+      makeTeam({ id: '2', name: 'Hidden', isHidden: true }),
+      makeTeam({ id: '3', name: 'Archived', isArchived: true })
+    ]
+
+    it('drops hidden and archived teams by default', () => {
+      const { filtered, counts } = useCompaniesFilter(teams, {
+        userAddress: USER,
+        role: 'all',
+        query: '',
+        showHidden: false,
+        showArchived: false
+      })
+      expect(filtered.value.map((t) => t.id)).toEqual(['1'])
+      expect(counts.value.all).toBe(1)
+    })
+
+    it('keeps hidden teams when showHidden is on', () => {
+      const { filtered } = useCompaniesFilter(teams, {
+        userAddress: USER,
+        role: 'all',
+        query: '',
+        showHidden: true,
+        showArchived: false
+      })
+      expect(filtered.value.map((t) => t.id)).toEqual(['1', '2'])
+    })
+
+    it('keeps archived teams when showArchived is on', () => {
+      const { filtered } = useCompaniesFilter(teams, {
+        userAddress: USER,
+        role: 'all',
+        query: '',
+        showHidden: false,
+        showArchived: true
+      })
+      expect(filtered.value.map((t) => t.id)).toEqual(['1', '3'])
+    })
+  })
+
+  describe('reactivity', () => {
+    it('recomputes when reactive inputs change', () => {
+      const role = ref<CompanyRoleFilter>('all')
+      const query = ref('')
+      const teams = ref([
+        makeTeam({ id: '1', name: 'Owned', ownerAddress: USER as Team['ownerAddress'] }),
+        makeTeam({ id: '2', name: 'Joined', ownerAddress: OTHER as Team['ownerAddress'] })
+      ])
+      const { filtered } = useCompaniesFilter(teams, {
+        userAddress: USER,
+        role,
+        query,
+        showHidden: false,
+        showArchived: false
+      })
+
+      expect(filtered.value).toHaveLength(2)
+
+      role.value = 'owner'
+      expect(filtered.value.map((t) => t.id)).toEqual(['1'])
+
+      role.value = 'all'
+      query.value = 'joined'
+      expect(filtered.value.map((t) => t.id)).toEqual(['2'])
+    })
+  })
+})

--- a/app/src/composables/useCompaniesFilter.ts
+++ b/app/src/composables/useCompaniesFilter.ts
@@ -1,0 +1,94 @@
+import { computed, toValue, type ComputedRef, type MaybeRefOrGetter } from 'vue'
+import type { Team } from '@/types/team'
+
+/** Role of a team relative to the current user. */
+export type CompanyRole = 'owner' | 'employee'
+
+/** Role filter applied to the companies list. 'all' keeps every team. */
+export type CompanyRoleFilter = 'all' | CompanyRole
+
+export interface UseCompaniesFilterOptions {
+  /** Address of the signed-in user; drives the owner/employee split. */
+  userAddress: MaybeRefOrGetter<string | null | undefined>
+  /** Active role filter: 'all' | 'owner' | 'employee'. */
+  role: MaybeRefOrGetter<CompanyRoleFilter>
+  /** Free-text query matched (case-insensitive) against name + description. */
+  query: MaybeRefOrGetter<string | null | undefined>
+  /** Keep hidden teams in the result set. */
+  showHidden: MaybeRefOrGetter<boolean | undefined>
+  /** Keep archived teams in the result set. */
+  showArchived: MaybeRefOrGetter<boolean | undefined>
+}
+
+export interface CompanyCounts {
+  all: number
+  owner: number
+  employee: number
+}
+
+export interface UseCompaniesFilter {
+  /** Teams left after visibility, role and query filtering. */
+  filtered: ComputedRef<Team[]>
+  /** Role split over the visibility-filtered set (ignores role + query). */
+  counts: ComputedRef<CompanyCounts>
+}
+
+/**
+ * Resolve a team's role for the given user. A team is 'owner' when its
+ * `ownerAddress` matches the user (case-insensitive), otherwise 'employee'.
+ */
+function roleOf(team: Team, userAddress: string | null | undefined): CompanyRole {
+  return team.ownerAddress?.toLowerCase() === userAddress?.toLowerCase() ? 'owner' : 'employee'
+}
+
+/**
+ * Pure, reactive filtering for the companies list. All inputs are
+ * `MaybeRefOrGetter`, so callers can pass refs, getters or plain values.
+ *
+ * The backing query already honours `showHidden` / `showArchived`, so the
+ * visibility check here is a light guard (drop hidden/archived teams the query
+ * may still return). Counts are the owner/employee split over that
+ * visibility-filtered set and are independent of the active role + query, so
+ * the segmented control keeps showing every bucket's size.
+ */
+export function useCompaniesFilter(
+  teams: MaybeRefOrGetter<Team[] | null | undefined>,
+  opts: UseCompaniesFilterOptions
+): UseCompaniesFilter {
+  /** Teams passing the visibility guard — the basis for counts and filtering. */
+  const visible = computed<Team[]>(() => {
+    const list = toValue(teams)
+    if (!Array.isArray(list)) return []
+    const showHidden = toValue(opts.showHidden) ?? false
+    const showArchived = toValue(opts.showArchived) ?? false
+    return list.filter(
+      (team) => (showHidden || !team.isHidden) && (showArchived || !team.isArchived)
+    )
+  })
+
+  const counts = computed<CompanyCounts>(() => {
+    const userAddress = toValue(opts.userAddress)
+    let owner = 0
+    for (const team of visible.value) {
+      if (roleOf(team, userAddress) === 'owner') owner += 1
+    }
+    return { all: visible.value.length, owner, employee: visible.value.length - owner }
+  })
+
+  const filtered = computed<Team[]>(() => {
+    const userAddress = toValue(opts.userAddress)
+    const role = toValue(opts.role)
+    const query = (toValue(opts.query) ?? '').trim().toLowerCase()
+
+    return visible.value.filter((team) => {
+      if (role !== 'all' && roleOf(team, userAddress) !== role) return false
+      if (query) {
+        const haystack = `${team.name ?? ''} ${team.description ?? ''}`.toLowerCase()
+        if (!haystack.includes(query)) return false
+      }
+      return true
+    })
+  })
+
+  return { filtered, counts }
+}

--- a/app/src/views/team/ListIndex.vue
+++ b/app/src/views/team/ListIndex.vue
@@ -1,56 +1,167 @@
 <template>
   <div class="flex flex-col gap-6">
-    <div class="flex flex-col gap-3 md:flex-row md:items-center">
-      <h2 v-if="hasVisibleTeams">{{ route.meta.name }}</h2>
-      <div
-        class="flex items-center gap-3 md:ml-auto"
-        v-if="!teamsError && !teamsAreFetching"
-        data-test="team-visibility-toggles"
-      >
-        <span class="text-muted text-sm">Show also</span>
+    <!-- Toolbar -->
+    <div class="flex flex-col gap-3 lg:flex-row lg:items-center" data-test="companies-toolbar">
+      <div class="flex items-center gap-3">
+        <h2>{{ route.meta.name }}</h2>
+        <!-- Role segmented control -->
         <div
-          class="border-default bg-default/70 inline-flex items-center rounded-full border px-2 py-1 shadow-xs"
+          class="border-default bg-default inline-flex items-center gap-0.5 rounded-lg border p-0.5"
+          data-test="role-filter"
         >
-          <div class="flex items-center gap-2 px-2">
-            <USwitch
-              v-model="showHidden"
-              size="sm"
-              :ui="{ base: showHidden ? 'data-[state=checked]:bg-success  ' : '' }"
-              data-test="toggle-show-hidden"
-            />
-            <UIcon
-              name="i-tabler-eye-off"
-              class="size-4 transition-colors"
-              :class="showHidden ? 'text-success' : 'text-muted'"
-            />
-            <span
-              class="text-sm font-medium transition-colors"
-              :class="showHidden ? 'text-success' : 'text-muted'"
-              >Hidden</span
-            >
-          </div>
-          <div class="bg-default/70 mx-1 h-6 w-px" />
-          <div class="flex items-center gap-2 px-2">
-            <USwitch
-              v-model="showArchived"
-              size="sm"
-              :ui="{ base: showArchived ? 'data-[state=checked]:bg-warning' : '' }"
-              data-test="toggle-show-archived"
-            />
-            <UIcon
-              name="i-tabler-archive"
-              class="size-4 transition-colors"
-              :class="showArchived ? 'text-warning' : 'text-muted'"
-            />
-            <span
-              class="text-sm font-medium transition-colors"
-              :class="showArchived ? 'text-warning' : 'text-muted'"
-              >Archived</span
-            >
-          </div>
+          <UButton
+            :color="role === 'all' ? 'primary' : 'neutral'"
+            :variant="role === 'all' ? 'soft' : 'ghost'"
+            size="xs"
+            data-test="role-option-all"
+            @click="role = 'all'"
+          >
+            All · {{ counts.all }}
+          </UButton>
+          <UButton
+            :color="role === 'owner' ? 'primary' : 'neutral'"
+            :variant="role === 'owner' ? 'soft' : 'ghost'"
+            size="xs"
+            data-test="role-option-owner"
+            @click="role = 'owner'"
+          >
+            Owner · {{ counts.owner }}
+          </UButton>
+          <UButton
+            :color="role === 'employee' ? 'primary' : 'neutral'"
+            :variant="role === 'employee' ? 'soft' : 'ghost'"
+            size="xs"
+            data-test="role-option-employee"
+            @click="role = 'employee'"
+          >
+            Employee · {{ counts.employee }}
+          </UButton>
         </div>
       </div>
+
+      <div class="flex flex-wrap items-center gap-2 lg:ml-auto">
+        <!-- Search -->
+        <UInput
+          v-model="query"
+          icon="i-heroicons-magnifying-glass"
+          placeholder="Search companies"
+          data-test="search-companies"
+        />
+
+        <!-- Filters popover -->
+        <UPopover data-test="filters-popover">
+          <UButton
+            color="neutral"
+            variant="soft"
+            icon="i-heroicons-adjustments-horizontal"
+            trailing-icon="i-heroicons-chevron-down"
+            data-test="filters-button"
+          >
+            Filters
+            <UBadge
+              v-if="activeVisibilityCount > 0"
+              color="primary"
+              size="sm"
+              data-test="filters-count-badge"
+            >
+              {{ activeVisibilityCount }}
+            </UBadge>
+          </UButton>
+
+          <template #content>
+            <div class="flex w-64 flex-col gap-1 p-3" data-test="filters-panel">
+              <p class="text-muted text-xs font-semibold tracking-wide uppercase">Visibility</p>
+              <div class="flex items-center justify-between gap-3 py-2">
+                <div class="flex min-w-0 flex-col">
+                  <span class="text-default text-sm font-medium">Hidden companies</span>
+                  <span class="text-muted text-xs">Teams you set aside</span>
+                </div>
+                <USwitch
+                  v-model="showHidden"
+                  size="sm"
+                  :ui="{ base: showHidden ? 'data-[state=checked]:bg-success' : '' }"
+                  data-test="toggle-show-hidden"
+                />
+              </div>
+              <div class="border-muted flex items-center justify-between gap-3 border-t py-2">
+                <div class="flex min-w-0 flex-col">
+                  <span class="text-default text-sm font-medium">Archived companies</span>
+                  <span class="text-muted text-xs">Closed or dormant teams</span>
+                </div>
+                <USwitch
+                  v-model="showArchived"
+                  size="sm"
+                  :ui="{ base: showArchived ? 'data-[state=checked]:bg-warning' : '' }"
+                  data-test="toggle-show-archived"
+                />
+              </div>
+              <UButton
+                color="neutral"
+                variant="soft"
+                size="sm"
+                block
+                :disabled="activeVisibilityCount === 0"
+                data-test="reset-visibility"
+                @click="resetVisibility"
+              >
+                Reset visibility
+              </UButton>
+            </div>
+          </template>
+        </UPopover>
+
+        <!-- View toggle -->
+        <div
+          class="border-default bg-default inline-flex items-center gap-0.5 rounded-lg border p-0.5"
+          data-test="view-toggle"
+        >
+          <UButton
+            :color="view === 'cards' ? 'primary' : 'neutral'"
+            :variant="view === 'cards' ? 'soft' : 'ghost'"
+            size="sm"
+            icon="i-heroicons-squares-2x2"
+            aria-label="Cards view"
+            data-test="view-toggle-cards"
+            @click="view = 'cards'"
+          />
+          <UButton
+            :color="view === 'table' ? 'primary' : 'neutral'"
+            :variant="view === 'table' ? 'soft' : 'ghost'"
+            size="sm"
+            icon="i-heroicons-table-cells"
+            aria-label="Table view"
+            data-test="view-toggle-table"
+            @click="view = 'table'"
+          />
+        </div>
+
+        <!-- Create Company -->
+        <UModal
+          v-model:open="openModal"
+          title="Create Company"
+          description="Create Your Company Step By Step"
+        >
+          <UButton
+            color="primary"
+            icon="i-heroicons-plus"
+            label="Create Company"
+            data-test="create-company-button"
+            @click="openModal = true"
+          />
+
+          <template #body>
+            <AddTeamForm
+              @done="
+                () => {
+                  openModal = false
+                }
+              "
+            />
+          </template>
+        </UModal>
+      </div>
     </div>
+
     <!-- Loader -->
     <div class="flex gap-3" data-test="loader" v-if="teamsAreFetching">
       <div class="flex w-1/4 flex-col gap-4" v-for="i in 4" :key="i">
@@ -89,65 +200,49 @@
     </div>
 
     <!-- Teams List -->
-
-    <div
-      class="grid grid-cols-1 gap-20 md:grid-cols-2 lg:grid-cols-3"
-      data-test="team-list"
-      v-if="Array.isArray(teams) && teams.length > 0"
-    >
-      <TeamCard
-        v-for="team in teams"
-        :key="team.id"
-        :team="team"
-        :data-test="`team-card-${team.id}`"
-        class="cursor-pointer transition duration-300 hover:scale-105"
-        @click="navigateToTeam(team.id)"
-      />
-    </div>
-
-    <!-- Add Team Button -->
-    <div
-      class="flex justify-center"
-      data-test="add-team-button"
-      v-if="!teamsError && !teamsAreFetching"
-    >
-      <UModal
-        v-model:open="openModal"
-        title="Create Company"
-        description="Create Your Company Step By Step"
+    <template v-if="!teamsError && !teamsAreFetching && Array.isArray(teams) && teams.length > 0">
+      <!-- Table view placeholder (real table comes in a later ticket) -->
+      <div
+        v-if="view === 'table'"
+        class="text-muted border-default rounded-lg border border-dashed p-8 text-center text-sm"
+        data-test="table-placeholder"
       >
-        <AddTeamCard
-          data-test="add-team-card"
-          @click="openModal = true"
-          class="animate-fade-in h-16 w-72 transform text-sm transition duration-300 hover:scale-105"
-        />
+        Table view — coming soon
+      </div>
 
-        <template #body>
-          <AddTeamForm
-            @done="
-              () => {
-                console.log('Team created successfully, closing modal and refetching teams list')
-                openModal = false
-              }
-            "
-          />
-        </template>
-      </UModal>
-    </div>
+      <!-- Cards grid -->
+      <div
+        v-else
+        class="grid grid-cols-1 gap-20 md:grid-cols-2 lg:grid-cols-3"
+        data-test="team-list"
+      >
+        <TeamCard
+          v-for="team in filtered"
+          :key="team.id"
+          :team="team"
+          :data-test="`team-card-${team.id}`"
+          class="cursor-pointer transition duration-300 hover:scale-105"
+          @click="navigateToTeam(team.id)"
+        />
+      </div>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useRouter, useRoute } from 'vue-router'
 import { useUserDataStore } from '@/stores'
-import AddTeamCard from '@/components/sections/TeamView/AddTeamCard.vue'
 import TeamCard from '@/components/sections/TeamView/TeamCard.vue'
 import { useGetTeamsQuery } from '@/queries/team.queries'
+import { useCompaniesFilter, type CompanyRoleFilter } from '@/composables/useCompaniesFilter'
 import { computed, ref } from 'vue'
 
 const openModal = ref(false)
 const showHidden = ref(false)
 const showArchived = ref(false)
+const role = ref<CompanyRoleFilter>('all')
+const query = ref('')
+const view = ref<'cards' | 'table'>('cards')
 
 const route = useRoute()
 const userDataStore = useUserDataStore()
@@ -164,13 +259,23 @@ const {
   }
 })
 
-const hasVisibleTeams = computed(
-  () =>
-    !teamsAreFetching.value &&
-    !teamsError.value &&
-    Array.isArray(teams.value) &&
-    teams.value.length > 0
+const { filtered, counts } = useCompaniesFilter(teams, {
+  userAddress: () => userDataStore.address,
+  role,
+  query,
+  showHidden,
+  showArchived
+})
+
+/** How many visibility filters are currently active (drives the badge). */
+const activeVisibilityCount = computed(
+  () => (showHidden.value ? 1 : 0) + (showArchived.value ? 1 : 0)
 )
+
+function resetVisibility() {
+  showHidden.value = false
+  showArchived.value = false
+}
 
 const router = useRouter()
 

--- a/app/src/views/team/__tests__/ListIndex.spec.ts
+++ b/app/src/views/team/__tests__/ListIndex.spec.ts
@@ -1,9 +1,8 @@
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
 import ListIndex from '@/views/team/ListIndex.vue'
 import { mount } from '@vue/test-utils'
-import { createTestingPinia } from '@pinia/testing'
 import { createMockQueryResponse } from '@/tests/mocks/query.mock'
-import { mockTeamsData, mockTeamData, mockRouterPush } from '@/tests/mocks'
+import { mockTeamsData, mockTeamData, mockRouterPush, mockUserStore } from '@/tests/mocks'
 import type { Team } from '@/types'
 import { useRoute } from 'vue-router'
 
@@ -15,7 +14,7 @@ describe('ListIndex - Team List View', () => {
     vi.clearAllMocks()
     vi.mocked(useRoute).mockReturnValue({
       params: { id: '0' },
-      meta: { name: 'Team List View' }
+      meta: { name: 'Companies' }
     } as ReturnType<typeof useRoute>)
   })
 
@@ -25,7 +24,7 @@ describe('ListIndex - Team List View', () => {
 
   // Helper function for component mounting
   const createWrapper = (
-    teamsData: Team[] = mockTeamsData,
+    teamsData: Team[] | null = mockTeamsData,
     isLoading = false,
     error: Error | null = null
   ) => {
@@ -35,38 +34,47 @@ describe('ListIndex - Team List View', () => {
 
     return mount(ListIndex, {
       global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn })],
         stubs: {
-          AddTeamCard: {
-            template:
-              '<div data-test="add-team-card"><button data-test="add-team">Add Team</button></div>'
-          },
           TeamCard: {
             template:
               '<div :data-test="`team-card-${team.id}`" class="team-card"><strong>{{ team.name }}</strong></div>',
             props: ['team']
-          }
+          },
+          AddTeamForm: { template: '<div data-test="add-team-form"></div>' }
         }
       }
     })
   }
 
-  describe('Component Rendering', () => {
-    it('should render the page heading when teams are visible', () => {
+  describe('Toolbar', () => {
+    it('renders the page heading', () => {
       const wrapper = createWrapper()
-      expect(wrapper.find('h2').text()).toContain('Team List View')
+      expect(wrapper.find('h2').text()).toContain('Companies')
     })
 
-    it('should hide the page heading when no teams are visible', async () => {
-      const wrapper = createWrapper([])
+    it('keeps the toolbar visible while loading', async () => {
+      const wrapper = createWrapper([], true)
       await wrapper.vm.$nextTick()
 
-      expect(wrapper.find('h2').exists()).toBe(false)
+      expect(wrapper.find('[data-test="companies-toolbar"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="create-company-button"]').exists()).toBe(true)
     })
 
-    it('should render component structure correctly', () => {
+    it('keeps the toolbar visible on error', async () => {
+      const wrapper = createWrapper([], false, new Error('boom'))
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('[data-test="companies-toolbar"]').exists()).toBe(true)
+    })
+
+    it('renders every toolbar control', () => {
       const wrapper = createWrapper()
-      expect(wrapper.find('.flex.flex-col.gap-6').exists()).toBe(true)
+      expect(wrapper.find('[data-test="role-filter"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="search-companies"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="filters-button"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="view-toggle-cards"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="view-toggle-table"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="create-company-button"]').exists()).toBe(true)
     })
   })
 
@@ -85,20 +93,6 @@ describe('ListIndex - Team List View', () => {
 
       expect(wrapper.find('[data-test="team-list"]').exists()).toBe(false)
     })
-
-    it('should hide add team button during loading', async () => {
-      const wrapper = createWrapper([], true)
-      await wrapper.vm.$nextTick()
-
-      expect(wrapper.find('[data-test="add-team-button"]').exists()).toBe(false)
-    })
-
-    it('should hide the page heading during loading', async () => {
-      const wrapper = createWrapper([], true)
-      await wrapper.vm.$nextTick()
-
-      expect(wrapper.find('h2').exists()).toBe(false)
-    })
   })
 
   describe('Empty State', () => {
@@ -116,6 +110,7 @@ describe('ListIndex - Team List View', () => {
       const emptyState = wrapper.find('[data-test="empty-state"]')
       expect(emptyState.text()).toContain('You are currently not a part of any team')
       expect(emptyState.text()).toContain('Create a new team now!')
+      expect(emptyState.text()).toContain(mockUserStore.name)
     })
 
     it('should display illustration in empty state', async () => {
@@ -134,11 +129,11 @@ describe('ListIndex - Team List View', () => {
       expect(wrapper.find('[data-test="team-list"]').exists()).toBe(false)
     })
 
-    it('should display add team button when no teams and not loading', async () => {
+    it('should display the create company button when no teams', async () => {
       const wrapper = createWrapper([], false)
       await wrapper.vm.$nextTick()
 
-      expect(wrapper.find('[data-test="add-team-button"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="create-company-button"]').exists()).toBe(true)
     })
   })
 
@@ -168,22 +163,6 @@ describe('ListIndex - Team List View', () => {
 
       expect(wrapper.find('[data-test="team-list"]').exists()).toBe(false)
     })
-
-    it('should hide add team button on error', async () => {
-      const error = new Error('Failed to fetch')
-      const wrapper = createWrapper([], false, error)
-      await wrapper.vm.$nextTick()
-
-      expect(wrapper.find('[data-test="add-team-button"]').exists()).toBe(false)
-    })
-
-    it('should hide the page heading on error', async () => {
-      const error = new Error('Failed to fetch')
-      const wrapper = createWrapper([], false, error)
-      await wrapper.vm.$nextTick()
-
-      expect(wrapper.find('h2').exists()).toBe(false)
-    })
   })
 
   describe('Teams List Display', () => {
@@ -210,13 +189,122 @@ describe('ListIndex - Team List View', () => {
       expect(teamCard.exists()).toBe(true)
       expect(teamCard.text()).toContain(mockTeamData.name)
     })
+  })
 
-    it('should display add team button even when teams exist and not loading', async () => {
-      const wrapper = createWrapper(mockTeamsData, false)
-      await wrapper.vm.$nextTick()
+  describe('Role filter', () => {
+    const ownerTeam: Team = {
+      ...mockTeamData,
+      id: '10',
+      name: 'Owned Co',
+      ownerAddress: mockUserStore.address as Team['ownerAddress']
+    }
+    const employeeTeam: Team = {
+      ...mockTeamData,
+      id: '20',
+      name: 'Employed Co',
+      ownerAddress: '0x9999999999999999999999999999999999999999'
+    }
 
-      // The button shows when there's no error and not loading, regardless of team count
-      expect(wrapper.find('[data-test="add-team-button"]').exists()).toBe(true)
+    it('counts owner / employee teams relative to the signed-in user', () => {
+      const wrapper = createWrapper([ownerTeam, employeeTeam])
+      const roleFilter = wrapper.find('[data-test="role-filter"]')
+      expect(roleFilter.find('[data-test="role-option-all"]').text()).toContain('All · 2')
+      expect(roleFilter.find('[data-test="role-option-owner"]').text()).toContain('Owner · 1')
+      expect(roleFilter.find('[data-test="role-option-employee"]').text()).toContain('Employee · 1')
+    })
+
+    it('filters the rendered list when a role is selected', async () => {
+      const wrapper = createWrapper([ownerTeam, employeeTeam])
+      expect(wrapper.findAll('[data-test^="team-card-"]')).toHaveLength(2)
+
+      await wrapper.find('[data-test="role-option-owner"]').trigger('click')
+      const cards = wrapper.findAll('[data-test^="team-card-"]')
+      expect(cards).toHaveLength(1)
+      expect(cards[0]?.text()).toContain('Owned Co')
+
+      await wrapper.find('[data-test="role-option-employee"]').trigger('click')
+      const empCards = wrapper.findAll('[data-test^="team-card-"]')
+      expect(empCards).toHaveLength(1)
+      expect(empCards[0]?.text()).toContain('Employed Co')
+    })
+  })
+
+  describe('Search', () => {
+    const teams: Team[] = [
+      { ...mockTeamData, id: '1', name: 'Alpha', description: 'first' },
+      { ...mockTeamData, id: '2', name: 'Beta', description: 'second' }
+    ]
+
+    it('filters the list by name (case-insensitive)', async () => {
+      const wrapper = createWrapper(teams)
+      await wrapper.find('[data-test="search-companies"]').setValue('alpha')
+
+      const cards = wrapper.findAll('[data-test^="team-card-"]')
+      expect(cards).toHaveLength(1)
+      expect(cards[0]?.text()).toContain('Alpha')
+    })
+
+    it('filters the list by description', async () => {
+      const wrapper = createWrapper(teams)
+      await wrapper.find('[data-test="search-companies"]').setValue('second')
+
+      const cards = wrapper.findAll('[data-test^="team-card-"]')
+      expect(cards).toHaveLength(1)
+      expect(cards[0]?.text()).toContain('Beta')
+    })
+  })
+
+  describe('View toggle', () => {
+    it('renders the cards grid by default', () => {
+      const wrapper = createWrapper(mockTeamsData)
+      expect(wrapper.find('[data-test="team-list"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="table-placeholder"]').exists()).toBe(false)
+    })
+
+    it('switches to the table placeholder and back', async () => {
+      const wrapper = createWrapper(mockTeamsData)
+
+      await wrapper.find('[data-test="view-toggle-table"]').trigger('click')
+      expect(wrapper.find('[data-test="team-list"]').exists()).toBe(false)
+      const placeholder = wrapper.find('[data-test="table-placeholder"]')
+      expect(placeholder.exists()).toBe(true)
+      expect(placeholder.text()).toContain('coming soon')
+
+      await wrapper.find('[data-test="view-toggle-cards"]').trigger('click')
+      expect(wrapper.find('[data-test="team-list"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="table-placeholder"]').exists()).toBe(false)
+    })
+  })
+
+  describe('Filters popover', () => {
+    it('exposes hidden / archived switches in the panel', () => {
+      const wrapper = createWrapper(mockTeamsData)
+      const panel = wrapper.find('[data-test="filters-panel"]')
+      expect(panel.exists()).toBe(true)
+      expect(panel.find('[data-test="toggle-show-hidden"]').exists()).toBe(true)
+      expect(panel.find('[data-test="toggle-show-archived"]').exists()).toBe(true)
+    })
+
+    it('shows an active-count badge once a visibility switch is on', async () => {
+      const wrapper = createWrapper(mockTeamsData)
+      expect(wrapper.find('[data-test="filters-count-badge"]').exists()).toBe(false)
+
+      // USwitch renders the data-test on its own button[role="switch"].
+      await wrapper.find('[data-test="toggle-show-hidden"]').trigger('click')
+
+      const badge = wrapper.find('[data-test="filters-count-badge"]')
+      expect(badge.exists()).toBe(true)
+      expect(badge.text()).toContain('1')
+    })
+
+    it('reset visibility turns both switches back off', async () => {
+      const wrapper = createWrapper(mockTeamsData)
+      await wrapper.find('[data-test="toggle-show-hidden"]').trigger('click')
+      await wrapper.find('[data-test="toggle-show-archived"]').trigger('click')
+      expect(wrapper.find('[data-test="filters-count-badge"]').text()).toContain('2')
+
+      await wrapper.find('[data-test="reset-visibility"]').trigger('click')
+      expect(wrapper.find('[data-test="filters-count-badge"]').exists()).toBe(false)
     })
   })
 
@@ -229,25 +317,6 @@ describe('ListIndex - Team List View', () => {
       await teamCard.trigger('click')
 
       expect(mockRouterPush).toHaveBeenCalledWith(`/teams/${mockTeamData.id}`)
-    })
-
-    it('should navigate with correct team ID', async () => {
-      const testTeam = { ...mockTeamData, id: '123' }
-      const wrapper = createWrapper([testTeam])
-      await wrapper.vm.$nextTick()
-
-      const teamCard = wrapper.find(`[data-test="team-card-${testTeam.id}"]`)
-      await teamCard.trigger('click')
-
-      expect(mockRouterPush).toHaveBeenCalledWith('/teams/123')
-    })
-
-    it('should open add team modal when add team button is clicked', async () => {
-      const wrapper = createWrapper([], false)
-      await wrapper.vm.$nextTick()
-
-      const addTeamBtn = wrapper.find('[data-test="add-team"]')
-      expect(addTeamBtn.exists()).toBe(true)
     })
 
     it('should handle multiple team clicks correctly', async () => {
@@ -273,54 +342,9 @@ describe('ListIndex - Team List View', () => {
     })
   })
 
-  describe('Add Team Button', () => {
-    it('should display add team button when empty and not loading', async () => {
-      const wrapper = createWrapper([], false)
-      await wrapper.vm.$nextTick()
-
-      expect(wrapper.find('[data-test="add-team-button"]').exists()).toBe(true)
-    })
-  })
-
-  describe('Empty State with User Data', () => {
-    it('should display user name in empty state message', async () => {
-      const wrapper = createWrapper([], false)
-      await wrapper.vm.$nextTick()
-
-      const emptyState = wrapper.find('[data-test="empty-state"]')
-      // The component uses userDataStore.name, which is mocked by createTestingPinia
-      expect(emptyState.exists()).toBe(true)
-    })
-  })
-
   describe('Edge Cases', () => {
-    it('should handle loading state that transitions to success', async () => {
-      const wrapper = createWrapper([], true)
-      await wrapper.vm.$nextTick()
-
-      expect(wrapper.find('[data-test="loader"]').exists()).toBe(true)
-
-      // Simulate data loaded
-      await wrapper.setData({}) // Force re-render
-      vi.mocked(useGetTeamsQuery).mockReturnValue(createMockQueryResponse(mockTeamsData, false))
-      await wrapper.vm.$nextTick()
-    })
-
     it('should handle null/undefined team data gracefully', async () => {
-      const useTeamsMock = vi.fn()
-      useTeamsMock.mockReturnValue(createMockQueryResponse(null, false))
-      vi.mocked(useGetTeamsQuery).mockImplementation(useTeamsMock)
-
-      const wrapper = mount(ListIndex, {
-        global: {
-          plugins: [createTestingPinia({ createSpy: vi.fn })],
-          stubs: {
-            AddTeamCard: { template: '<div data-test="add-team-card"></div>' },
-            TeamCard: { template: '<div></div>', props: ['team'] }
-          }
-        }
-      })
-
+      const wrapper = createWrapper(null, false)
       await wrapper.vm.$nextTick()
       // Should render without crashing
       expect(wrapper.exists()).toBe(true)


### PR DESCRIPTION
Rebuilds the Companies list toolbar: role segmented control (All/Owner/Employee with live counts), name+description search, Filters popover (Hidden/Archived switches + Reset + active badge), Cards/Table view toggle, and a permanent Create Company button. Extracts filtering into `useCompaniesFilter`. Table view shows a placeholder until step 3. Loader/empty/error preserved.

Gate: type-check ✓ · eslint ✓ · vitest 44/44 ✓.

Refs #2132 · part of #2128