### PR TITLE
feat: ✨ companies treasury recap strip — step 3/8

### DIFF
--- a/app/src/components/sections/CompaniesView/CompaniesTreasuryRecap.vue
+++ b/app/src/components/sections/CompaniesView/CompaniesTreasuryRecap.vue
@@ -1,0 +1,94 @@
+<template>
+  <UCard data-test="treasury-recap">
+    <div class="flex flex-wrap items-start justify-between gap-8">
+      <div>
+        <div class="text-muted text-[13px] font-medium">Total treasury across your companies</div>
+        <div
+          data-test="recap-total"
+          class="text-default mt-1 text-4xl leading-tight font-extrabold tracking-tight"
+        >
+          {{ aggregate.totalLabel }}
+        </div>
+        <div v-if="polLabel" data-test="recap-pol" class="text-muted mt-1 font-mono text-[13px]">
+          {{ polLabel }}
+        </div>
+      </div>
+
+      <div class="flex items-start gap-7">
+        <div>
+          <div class="text-muted text-xs font-medium">You own · {{ ownerCount }}</div>
+          <div data-test="recap-own" class="text-default mt-0.5 text-xl font-bold tracking-tight">
+            {{ aggregate.ownLabel }}
+          </div>
+        </div>
+        <div class="border-default self-stretch border-l" />
+        <div>
+          <div class="text-muted text-xs font-medium">Member · {{ memberCount }}</div>
+          <div
+            data-test="recap-member"
+            class="text-default mt-0.5 text-xl font-bold tracking-tight"
+          >
+            {{ aggregate.memberLabel }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-5">
+      <div class="mb-3.5 flex flex-wrap items-center justify-between gap-3">
+        <span class="text-muted text-xs font-semibold">Distribution</span>
+        <div class="border-default bg-default inline-flex gap-0.5 rounded-lg border p-0.5">
+          <UButton
+            v-for="option in modeOptions"
+            :key="option.value"
+            :data-test="`recap-mode-${option.value}`"
+            :color="mode === option.value ? 'primary' : 'neutral'"
+            :variant="mode === option.value ? 'solid' : 'ghost'"
+            size="xs"
+            :label="option.label"
+            @click="mode = option.value"
+          />
+        </div>
+      </div>
+      <DistributionBar :segments="activeSegments" legend height="14px" />
+    </div>
+  </UCard>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { TreasuryAggregate } from '@/types'
+import DistributionBar from '@/components/sections/CompaniesView/DistributionBar.vue'
+
+type Mode = 'company' | 'token' | 'account'
+
+interface Props {
+  aggregate: TreasuryAggregate
+  ownerCount?: number
+  memberCount?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  ownerCount: 0,
+  memberCount: 0
+})
+
+const mode = ref<Mode>('company')
+
+const modeOptions: { value: Mode; label: string }[] = [
+  { value: 'company', label: 'By company' },
+  { value: 'token', label: 'By token' },
+  { value: 'account', label: 'By account' }
+]
+
+const polLabel = computed(() => {
+  const label = (props.aggregate as { polLabel?: unknown }).polLabel
+  return typeof label === 'string' && label.length ? label : ''
+})
+
+const activeSegments = computed(() => {
+  if (mode.value === 'token') return props.aggregate.byToken
+  if (mode.value === 'account') return props.aggregate.byAccount
+  return props.aggregate.byCompany
+})
+</script>

--- a/app/src/components/sections/CompaniesView/__tests__/CompaniesTreasuryRecap.spec.ts
+++ b/app/src/components/sections/CompaniesView/__tests__/CompaniesTreasuryRecap.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CompaniesTreasuryRecap from '@/components/sections/CompaniesView/CompaniesTreasuryRecap.vue'
+import type { TreasuryAggregate } from '@/types'
+
+const seg = (label: string, pct: number) => ({ label, pct, valueUsd: pct, color: '#3b82f6' })
+
+const aggregate: TreasuryAggregate = {
+  totalUsd: 27900.45,
+  totalLabel: '$27,900.45',
+  ownUsd: 22392.4,
+  ownLabel: '$22,392.40',
+  memberUsd: 5508.05,
+  memberLabel: '$5,508.05',
+  byCompany: [seg('Acme', 70), seg('Globex', 30)],
+  byToken: [seg('USDC', 55), seg('POL', 25), seg('ETH', 20)],
+  byAccount: [seg('Bank', 50), seg('Safe', 30), seg('Cash', 12), seg('Expense', 8)]
+}
+
+const mountRecap = (props: Partial<Parameters<typeof mount<typeof CompaniesTreasuryRecap>>[1]>) =>
+  mount(CompaniesTreasuryRecap, {
+    props: { aggregate, ownerCount: 2, memberCount: 3, ...(props as object) }
+  })
+
+const legendLabels = (wrapper: ReturnType<typeof mountRecap>) =>
+  wrapper.findAll('[data-test="distribution-legend-item"]').map((item) => item.text())
+
+describe('CompaniesTreasuryRecap', () => {
+  it('renders the root card', () => {
+    const wrapper = mountRecap({})
+    expect(wrapper.find('[data-test="treasury-recap"]').exists()).toBe(true)
+  })
+
+  it('renders the total label', () => {
+    const wrapper = mountRecap({})
+    expect(wrapper.find('[data-test="recap-total"]').text()).toBe('$27,900.45')
+  })
+
+  it('renders the owner stat with its count', () => {
+    const wrapper = mountRecap({})
+    expect(wrapper.find('[data-test="recap-own"]').text()).toBe('$22,392.40')
+    expect(wrapper.text()).toContain('You own · 2')
+  })
+
+  it('renders the member stat with its count', () => {
+    const wrapper = mountRecap({})
+    expect(wrapper.find('[data-test="recap-member"]').text()).toBe('$5,508.05')
+    expect(wrapper.text()).toContain('Member · 3')
+  })
+
+  it('defaults the counts to zero when omitted', () => {
+    const wrapper = mount(CompaniesTreasuryRecap, { props: { aggregate } })
+    expect(wrapper.text()).toContain('You own · 0')
+    expect(wrapper.text()).toContain('Member · 0')
+  })
+
+  it('omits the POL approximation when the aggregate has no polLabel', () => {
+    const wrapper = mountRecap({})
+    expect(wrapper.find('[data-test="recap-pol"]').exists()).toBe(false)
+  })
+
+  it('renders the POL approximation when a polLabel is present', () => {
+    const wrapper = mount(CompaniesTreasuryRecap, {
+      props: { aggregate: { ...aggregate, polLabel: '≈ 65,418.2 POL' } as TreasuryAggregate }
+    })
+    expect(wrapper.find('[data-test="recap-pol"]').text()).toBe('≈ 65,418.2 POL')
+  })
+
+  it('feeds the by-company segments to the bar by default', () => {
+    const wrapper = mountRecap({})
+    const labels = legendLabels(wrapper)
+    expect(labels).toHaveLength(2)
+    expect(labels[0]).toContain('Acme')
+    expect(labels[1]).toContain('Globex')
+  })
+
+  it('switches to the by-token segments when "By token" is clicked', async () => {
+    const wrapper = mountRecap({})
+    await wrapper.find('[data-test="recap-mode-token"]').trigger('click')
+    const labels = legendLabels(wrapper)
+    expect(labels).toHaveLength(3)
+    expect(labels.join(' ')).toContain('USDC')
+    expect(labels.join(' ')).toContain('ETH')
+  })
+
+  it('switches to the by-account segments when "By account" is clicked', async () => {
+    const wrapper = mountRecap({})
+    await wrapper.find('[data-test="recap-mode-account"]').trigger('click')
+    const segments = wrapper.findAll('[data-test="distribution-segment"]')
+    expect(segments).toHaveLength(4)
+    expect(legendLabels(wrapper).join(' ')).toContain('Bank')
+  })
+
+  it('switches back to the by-company segments', async () => {
+    const wrapper = mountRecap({})
+    await wrapper.find('[data-test="recap-mode-token"]').trigger('click')
+    await wrapper.find('[data-test="recap-mode-company"]').trigger('click')
+    expect(wrapper.findAll('[data-test="distribution-segment"]')).toHaveLength(2)
+    expect(legendLabels(wrapper).join(' ')).toContain('Acme')
+  })
+})


### PR DESCRIPTION
Summary card above the list: total treasury ($ + ≈POL), You own / Member split, and a By company / By token / By account toggle driving the distribution bar + legend. Consumes `TreasuryAggregate`. 11 unit tests.

Gate: type-check ✓ · eslint ✓ · vitest 11/11 ✓.

Refs #2133 · part of #2128