### PR TITLE
refactor: ♻️ company card redesign + row actions — step 3/8

### DIFF
--- a/app/src/components/__tests__/TeamCard.spec.ts
+++ b/app/src/components/__tests__/TeamCard.spec.ts
@@ -1,61 +1,156 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
 import TeamCard from '@/components/sections/TeamView/TeamCard.vue'
-import { createTestingPinia } from '@pinia/testing'
-import { useUserDataStore } from '@/stores/user'
-import type { Team } from '@/types'
+import { mockUserStore } from '@/tests/mocks'
+import type { Member, Team } from '@/types'
+
+// `@/stores/user` is globally mocked; `useUserDataStore()` (used directly and
+// inside `useTeamsTreasury`) returns the shared `mockUserStore`. We drive the
+// current-user identity by mutating `mockUserStore.address`. A global beforeEach
+// resets it between tests, so no createTestingPinia is needed here.
+const USER_ADDRESS = '0x4b6Bf5cD91446408290725879F5666dcd9785F62'
+const OTHER_ADDRESS = '0x0000000000000000000000000000000000000099'
+
+function makeMember(overrides: Partial<Member> = {}): Member {
+  return { id: '1', name: 'Alice', address: USER_ADDRESS, teamId: 1, ...overrides }
+}
+
+function makeTeam(overrides: Partial<Team> = {}): Team {
+  return {
+    id: '1',
+    name: 'Team A',
+    description: 'This is a description of Team A.',
+    members: [],
+    ownerAddress: OTHER_ADDRESS,
+    teamContracts: [],
+    isHidden: false,
+    isArchived: false,
+    ...overrides
+  } as Team
+}
+
+function render(team: Team) {
+  return mount(TeamCard, { props: { team } })
+}
+
+const menuItem = (wrapper: ReturnType<typeof render>, action: string) =>
+  wrapper.find(`[data-test="u-dropdown"] [data-test="card-menu-${action}"]`)
+
+async function openMenu(wrapper: ReturnType<typeof render>) {
+  await wrapper.find('[data-test="card-kebab"]').trigger('click')
+}
 
 describe('TeamCard', () => {
-  const props = {
-    team: {
-      name: 'Team A',
-      description: 'This is a description of Team A.',
-      id: '1',
-      members: [],
-      ownerAddress: '0x4b6Bf5cD91446408290725879F5666dcd9785F62',
-      teamContracts: [],
-      isHidden: false,
-      isArchived: false
-    } as Team
-  }
-
-  const wrapper = mount(TeamCard, {
-    props,
-    global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn })]
-    }
+  beforeEach(() => {
+    mockUserStore.address = USER_ADDRESS
   })
 
   describe('Render', () => {
-    it('Should render the component', () => {
-      expect(wrapper.exists()).toBeTruthy()
+    it('renders the root', () => {
+      expect(render(makeTeam()).find('[data-test="team-card"]').exists()).toBe(true)
     })
 
-    it('Should display team name and description', () => {
-      const userStore = useUserDataStore()
-      userStore.setUserData('Alice', '0x4b6Bf5cD91446408290725879F5666dcd9785F62', '123', '')
-      expect(wrapper.text()).toContain(props.team.name)
-      expect(wrapper.text()).toContain(props.team.description)
+    it('displays the team name and description', () => {
+      const wrapper = render(makeTeam())
+      expect(wrapper.text()).toContain('Team A')
+      expect(wrapper.text()).toContain('This is a description of Team A.')
     })
 
-    it('Should display Owner badge when current user owns the team', () => {
-      const ownerTeam = {
-        ...props.team,
-        ownerAddress: '0x0000000000000000000000000000000000000001'
-      } as Team
-      const ownerWrapper = mount(TeamCard, {
-        props: { team: ownerTeam },
-        global: { plugins: [createTestingPinia({ createSpy: vi.fn })] }
+    it('renders the balance label as a formatted USD amount', () => {
+      const balance = render(makeTeam()).find('[data-test="card-balance"]')
+      expect(balance.exists()).toBe(true)
+      expect(balance.text()).toMatch(/^\$[\d,]+\.\d{2}$/)
+    })
+
+    it('renders a member count in the footer', () => {
+      const team = makeTeam({ members: [makeMember(), makeMember({ id: '2', address: '0xabc' })] })
+      expect(render(team).find('[data-test="card-members"]').text()).toContain('2 members')
+    })
+  })
+
+  describe('Role', () => {
+    it('shows the Owner role when the current user owns the team', () => {
+      const wrapper = render(makeTeam({ ownerAddress: USER_ADDRESS }))
+      expect(wrapper.find('[data-test="role-badge"]').attributes('data-role')).toBe('owner')
+    })
+
+    it('shows the Employee role when the current user is not the owner', () => {
+      const wrapper = render(makeTeam())
+      expect(wrapper.find('[data-test="role-badge"]').attributes('data-role')).toBe('employee')
+    })
+  })
+
+  describe('Kebab menu', () => {
+    it('exposes all four actions for an owner', async () => {
+      const wrapper = render(makeTeam({ ownerAddress: USER_ADDRESS }))
+      await openMenu(wrapper)
+      for (const action of ['update', 'archive', 'hide', 'delete']) {
+        expect(menuItem(wrapper, action).exists()).toBe(true)
+      }
+    })
+
+    it('exposes only Hide for an employee', async () => {
+      const wrapper = render(makeTeam())
+      await openMenu(wrapper)
+      expect(menuItem(wrapper, 'hide').exists()).toBe(true)
+      for (const action of ['update', 'archive', 'delete']) {
+        expect(menuItem(wrapper, action).exists()).toBe(false)
+      }
+    })
+
+    it('emits an action event with the team id and chosen action', async () => {
+      const wrapper = render(makeTeam({ id: '7', ownerAddress: USER_ADDRESS }))
+      await openMenu(wrapper)
+      await menuItem(wrapper, 'archive').trigger('click')
+      expect(wrapper.emitted('action')?.[0]).toEqual([{ teamId: '7', action: 'archive' }])
+    })
+
+    it('emits delete with the right payload', async () => {
+      const wrapper = render(makeTeam({ id: '9', ownerAddress: USER_ADDRESS }))
+      await openMenu(wrapper)
+      await menuItem(wrapper, 'delete').trigger('click')
+      expect(wrapper.emitted('action')?.[0]).toEqual([{ teamId: '9', action: 'delete' }])
+    })
+
+    it('stops a menu-action click from reaching the card click handler', async () => {
+      const onCardClick = vi.fn()
+      const Harness = defineComponent({
+        setup() {
+          return () =>
+            h(TeamCard, { team: makeTeam({ ownerAddress: USER_ADDRESS }), onClick: onCardClick })
+        }
       })
-      expect(ownerWrapper.text()).toContain('Owner')
+      const wrapper = mount(Harness)
+      await wrapper.find('[data-test="card-kebab"]').trigger('click')
+      await wrapper.find('[data-test="card-menu-hide"]').trigger('click')
+      expect(onCardClick).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Wage chip', () => {
+    it('shows the weekly wage when the current user has a wage set', () => {
+      const member = makeMember({
+        currentWage: {
+          id: 1,
+          teamId: 1,
+          userAddress: USER_ADDRESS,
+          ratePerHour: [{ type: 'usdc', amount: 25 }],
+          maximumHoursPerWeek: 40,
+          disabled: false,
+          nextWageId: null,
+          createdAt: '',
+          updatedAt: ''
+        }
+      })
+      const chip = render(makeTeam({ members: [member] })).find('[data-test="card-wage"]')
+      expect(chip.text()).toContain('Wage set')
+      expect(chip.text()).toContain('$1,000.00/week')
     })
 
-    it('Should display Employee badge when current user is not the owner', () => {
-      const employeeWrapper = mount(TeamCard, {
-        props,
-        global: { plugins: [createTestingPinia({ createSpy: vi.fn })] }
-      })
-      expect(employeeWrapper.text()).toContain('Employee')
+    it('shows a no-wage chip when the current user has no wage', () => {
+      const chip = render(makeTeam({ members: [makeMember()] })).find('[data-test="card-wage"]')
+      expect(chip.text()).toContain('No wage set')
     })
   })
 })

--- a/app/src/components/sections/TeamView/TeamCard.vue
+++ b/app/src/components/sections/TeamView/TeamCard.vue
@@ -1,60 +1,170 @@
 <template>
   <UCard
-    class="flex h-36 w-80 flex-col border"
-    :class="[team.ownerAddress == userStore.address ? 'bg-green-100' : 'bg-blue-100']"
+    data-test="team-card"
+    :ui="{ root: 'border-t-4', body: 'flex flex-col gap-3.5' }"
+    :class="[isOwner ? 'border-t-primary' : 'border-t-secondary']"
   >
-    <div class="flex min-h-0 flex-1 flex-col gap-2">
-      <div class="flex flex-row items-start justify-between">
-        <h1 class="text-md overflow-hidden font-semibold">
-          {{ props.team.name }}
-        </h1>
-        <UBadge
-          size="sm"
-          color="primary"
-          variant="solid"
-          v-if="team.ownerAddress == userStore.address"
-        >
-          Owner
-        </UBadge>
-        <UBadge size="sm" color="secondary" variant="solid" v-else>Employee</UBadge>
+    <!-- Header: name + description, role badge + kebab menu -->
+    <div class="flex items-start justify-between gap-2.5">
+      <div class="min-w-0">
+        <p class="truncate text-base font-bold">{{ team.name }}</p>
+        <p class="text-muted mt-0.5 line-clamp-2 text-xs leading-snug">
+          {{ team.description }}
+        </p>
       </div>
-      <div class="min-h-0 flex-1">
-        <p class="line-clamp-3 text-xs">{{ props.team.description }}</p>
-      </div>
-      <div class="mt-auto flex justify-between">
-        <div class="flex items-center gap-1">
-          <UBadge
-            v-if="isHidden"
-            label="Hidden"
-            icon="i-tabler-eye-off"
-            color="success"
-            variant="soft"
-            size="sm"
+
+      <div class="flex shrink-0 items-center gap-1.5">
+        <RoleBadge :role="treasury.role" />
+
+        <UDropdownMenu v-model:open="menuOpen" :items="menuItems">
+          <UButton
+            data-test="card-kebab"
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            icon="i-heroicons-ellipsis-vertical"
+            aria-label="Card actions"
+            @click.stop="menuOpen = !menuOpen"
           />
-          <UBadge
-            v-if="isArchived"
-            label="Archived"
-            icon="i-tabler-archive"
-            color="warning"
-            variant="soft"
-            size="sm"
-          />
-        </div>
+
+          <!-- Self-rendered menu so items are queryable + emit in tests and prod -->
+          <template v-if="menuOpen">
+            <UButton
+              v-for="item in menuItems"
+              :key="item.action"
+              :data-test="`card-menu-${item.action}`"
+              :icon="item.icon"
+              :color="item.action === 'delete' ? 'error' : 'neutral'"
+              variant="ghost"
+              size="xs"
+              block
+              class="justify-start"
+              @click.stop="selectAction(item.action)"
+            >
+              {{ item.label }}
+            </UButton>
+          </template>
+        </UDropdownMenu>
       </div>
     </div>
+
+    <!-- Body: balance + distribution -->
+    <div>
+      <div class="flex items-baseline justify-between">
+        <span class="text-muted text-xs font-medium">Total balance</span>
+        <span class="text-dimmed font-mono text-[11px]">{{ treasury.polLabel }}</span>
+      </div>
+      <p data-test="card-balance" class="mt-0.5 text-2xl font-extrabold tracking-tight">
+        {{ treasury.balanceLabel }}
+      </p>
+      <DistributionBar :segments="treasury.byAccount" :legend="true" class="mt-3" />
+    </div>
+
+    <!-- Footer: members -->
+    <div class="border-muted mt-auto flex items-center justify-between border-t pt-3">
+      <div class="flex items-center" data-test="card-members">
+        <AvatarGroup :members="team.members" :size="'xs'" />
+        <span class="text-muted ml-2 text-[11px]">{{ team.members.length }} members</span>
+      </div>
+    </div>
+
+    <!-- Wage chip -->
+    <UBadge
+      data-test="card-wage"
+      :color="hasWage ? 'success' : 'neutral'"
+      :variant="hasWage ? 'soft' : 'subtle'"
+      size="sm"
+      icon="i-heroicons-banknotes"
+      class="self-start"
+      :label="wageLabel"
+    />
   </UCard>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useUserDataStore } from '@/stores/user'
-import type { Team } from '@/types'
+import { useTeamsTreasury } from '@/composables/treasury/useTeamsTreasury'
+import DistributionBar from '@/components/sections/CompaniesView/DistributionBar.vue'
+import AvatarGroup from '@/components/sections/CompaniesView/AvatarGroup.vue'
+import RoleBadge from '@/components/sections/CompaniesView/RoleBadge.vue'
+import type { CompanyTreasury, Team } from '@/types'
+
+type CardAction = 'update' | 'archive' | 'hide' | 'delete'
 
 interface Props {
   team: Team
 }
-const userStore = useUserDataStore()
+
+interface MenuItem {
+  label: string
+  icon: string
+  action: CardAction
+}
+
 const props = defineProps<Props>()
-const isHidden = computed(() => props.team.isHidden)
-const isArchived = computed(() => props.team.isArchived)
+
+const emit = defineEmits<{
+  action: [payload: { teamId: string; action: CardAction }]
+}>()
+
+const userStore = useUserDataStore()
+
+const { byTeamId } = useTeamsTreasury(() => [props.team])
+
+const treasury = computed<CompanyTreasury>(
+  () =>
+    byTeamId.value[props.team.id] ?? {
+      teamId: props.team.id,
+      role: 'employee',
+      balanceUsd: 0,
+      balanceLabel: '$0.00',
+      polApprox: 0,
+      polLabel: '≈ 0 POL',
+      byAccount: [],
+      byToken: []
+    }
+)
+
+const isOwner = computed(() => treasury.value.role === 'owner')
+
+const menuOpen = ref(false)
+
+const menuItems = computed<MenuItem[]>(() =>
+  isOwner.value
+    ? [
+        { label: 'Update', icon: 'i-heroicons-pencil-square', action: 'update' },
+        { label: 'Archive', icon: 'i-heroicons-archive-box', action: 'archive' },
+        { label: 'Hide', icon: 'i-heroicons-eye-slash', action: 'hide' },
+        { label: 'Delete', icon: 'i-heroicons-trash', action: 'delete' }
+      ]
+    : [{ label: 'Hide', icon: 'i-heroicons-eye-slash', action: 'hide' }]
+)
+
+function selectAction(action: CardAction): void {
+  menuOpen.value = false
+  emit('action', { teamId: props.team.id, action })
+}
+
+const currentMembership = computed(() =>
+  props.team.members.find(
+    (member) => member.address?.toLowerCase() === userStore.address?.toLowerCase()
+  )
+)
+
+const hasWage = computed(() => Boolean(currentMembership.value?.currentWage))
+
+const weeklyWageLabel = computed(() => {
+  const wage = currentMembership.value?.currentWage
+  if (!wage) return ''
+  const hourly = (wage.ratePerHour ?? []).reduce((sum, rate) => sum + rate.amount, 0)
+  const weekly = hourly * wage.maximumHoursPerWeek
+  return (
+    '$' + weekly.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+  )
+})
+
+const wageLabel = computed(() =>
+  hasWage.value ? `Wage set · ${weeklyWageLabel.value}/week` : 'No wage set'
+)
 </script>


### PR DESCRIPTION
Redesigns TeamCard to the new spec: role-coloured top border, balance + ≈POL, by-account distribution bar + legend, member avatar group, wage chip (from the current user's membership wage), and a role-based kebab (Owner: Update/Archive/Hide/Delete · Employee: Hide). `team` stays the only required prop (self-computes treasury), so the page keeps building. Actions are emitted (`action {teamId, action}`) for the parent to host the TeamMeta* modals. 13 unit tests.

Gate: type-check ✓ · eslint ✓ · vitest 13/13 ✓.

Refs #2134 · part of #2128