### PR TITLE
feat: ✨ companies table view + pagination — step 3/8

### DIFF
--- a/app/src/components/sections/CompaniesView/CompaniesTable.vue
+++ b/app/src/components/sections/CompaniesView/CompaniesTable.vue
@@ -1,0 +1,190 @@
+<template>
+  <div data-test="companies-table" class="border-default overflow-hidden rounded-xl border">
+    <UTable
+      :data="pagedRows"
+      :columns="columns"
+      :ui="{
+        tr: 'cursor-pointer hover:bg-elevated/50',
+        th: 'text-muted',
+        td: 'text-default'
+      }"
+    >
+      <template #company-cell="{ row }">
+        <div
+          data-test="table-row"
+          :data-team-id="row.original.teamId"
+          class="flex items-center gap-3"
+          @click="emit('open', row.original.teamId)"
+        >
+          <CompanyMonogram :name="row.original.name" :role="row.original.role" />
+          <div class="min-w-0">
+            <div class="text-default text-sm font-semibold">{{ row.original.name }}</div>
+            <div class="text-muted max-w-[360px] truncate text-xs">
+              {{ row.original.description }}
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <template #role-cell="{ row }">
+        <RoleBadge :role="row.original.role" />
+      </template>
+
+      <template #members-cell="{ row }">
+        <div class="flex items-center gap-2.5">
+          <AvatarGroup :members="row.original.members" :max="3" size="sm" />
+          <span class="text-muted text-sm font-medium">{{ row.original.memberCount }}</span>
+        </div>
+      </template>
+
+      <template #treasury-cell="{ row }">
+        <div class="text-default text-right text-sm font-bold">
+          {{ row.original.balanceLabel }}
+        </div>
+      </template>
+
+      <template #actions-cell="{ row }">
+        <div class="flex justify-end" @click.stop>
+          <UDropdownMenu :items="menuItems(row.original)">
+            <UButton
+              icon="heroicons:ellipsis-vertical"
+              color="neutral"
+              variant="ghost"
+              size="sm"
+              data-test="row-kebab"
+              :aria-label="`Actions for ${row.original.name}`"
+              @click.stop
+            />
+
+            <template #item="{ item }">
+              <span :data-test="item.dataTest" class="flex w-full items-center gap-2">
+                <UIcon v-if="item.icon" :name="item.icon" class="size-4 shrink-0" />
+                {{ item.label }}
+              </span>
+            </template>
+          </UDropdownMenu>
+        </div>
+      </template>
+    </UTable>
+
+    <div class="px-4">
+      <TablePagination
+        v-model:page="page"
+        v-model:page-size="pageSize"
+        :total="rows.length"
+        noun="companies"
+        data-test-prefix="companies-table"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { TableColumn, DropdownMenuItem } from '@nuxt/ui'
+import type { Team, CompanyRole } from '@/types'
+import { useTeamsTreasury } from '@/composables/treasury/useTeamsTreasury'
+import TablePagination from '@/components/TablePagination.vue'
+import CompanyMonogram from '@/components/sections/CompaniesView/CompanyMonogram.vue'
+import AvatarGroup from '@/components/sections/CompaniesView/AvatarGroup.vue'
+import RoleBadge from '@/components/sections/CompaniesView/RoleBadge.vue'
+
+type CompanyAction = 'update' | 'archive' | 'hide' | 'delete'
+
+interface CompanyRow {
+  teamId: string
+  name: string
+  description: string
+  role: CompanyRole
+  members: { name?: string; address?: string; imageUrl?: string }[]
+  memberCount: number
+  balanceLabel: string
+}
+
+const props = defineProps<{
+  teams: Team[]
+}>()
+
+const emit = defineEmits<{
+  open: [teamId: string]
+  action: [payload: { teamId: string; action: CompanyAction }]
+}>()
+
+const { byTeamId } = useTeamsTreasury(() => props.teams)
+
+const rows = computed<CompanyRow[]>(() =>
+  props.teams.map((team) => {
+    const treasury = byTeamId.value[team.id]
+    const role: CompanyRole = treasury?.role ?? 'employee'
+    return {
+      teamId: team.id,
+      name: team.name,
+      description: team.description,
+      role,
+      members: team.members.map((member) => ({
+        name: member.name,
+        address: member.address,
+        imageUrl: member.imageUrl
+      })),
+      memberCount: team._count?.members ?? team.members.length,
+      balanceLabel: treasury?.balanceLabel ?? '—'
+    }
+  })
+)
+
+const columns: TableColumn<CompanyRow>[] = [
+  { id: 'company', header: 'Company' },
+  { id: 'role', header: 'Role' },
+  { id: 'members', header: 'Members' },
+  { id: 'treasury', header: 'Treasury' },
+  { id: 'actions', header: '' }
+]
+
+const page = ref(1)
+const pageSize = ref(10)
+
+// Reset to the first page whenever the dataset shrinks below the current page.
+watch(
+  () => rows.value.length,
+  (total) => {
+    const lastPage = Math.max(1, Math.ceil(total / pageSize.value))
+    if (page.value > lastPage) page.value = lastPage
+  }
+)
+
+watch(pageSize, () => {
+  page.value = 1
+})
+
+const pagedRows = computed<CompanyRow[]>(() => {
+  const start = (page.value - 1) * pageSize.value
+  return rows.value.slice(start, start + pageSize.value)
+})
+
+/** A kebab item that also carries its `data-test` hook for the `#item` slot. */
+type CompanyMenuItem = DropdownMenuItem & { dataTest: string }
+
+/** Role-based kebab actions, mirroring the cards view (owner gets the full set). */
+const ACTION_DEFS: Record<CompanyAction, { label: string; icon: string; dataTest: string }> = {
+  update: { label: 'Update', icon: 'heroicons:pencil-square', dataTest: 'row-menu-update' },
+  archive: { label: 'Archive', icon: 'heroicons:archive-box', dataTest: 'row-menu-archive' },
+  hide: { label: 'Hide', icon: 'heroicons:eye-slash', dataTest: 'row-menu-hide' },
+  delete: { label: 'Delete', icon: 'heroicons:trash', dataTest: 'row-menu-delete' }
+}
+
+const OWNER_ACTIONS: CompanyAction[] = ['update', 'archive', 'hide', 'delete']
+const EMPLOYEE_ACTIONS: CompanyAction[] = ['hide']
+
+function menuItems(row: CompanyRow): CompanyMenuItem[] {
+  const actions = row.role === 'owner' ? OWNER_ACTIONS : EMPLOYEE_ACTIONS
+  return actions.map((action) => {
+    const def = ACTION_DEFS[action]
+    return {
+      label: def.label,
+      icon: def.icon,
+      dataTest: def.dataTest,
+      onSelect: () => emit('action', { teamId: row.teamId, action })
+    }
+  })
+}
+</script>

--- a/app/src/components/sections/CompaniesView/__tests__/CompaniesTable.spec.ts
+++ b/app/src/components/sections/CompaniesView/__tests__/CompaniesTable.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CompaniesTable from '@/components/sections/CompaniesView/CompaniesTable.vue'
+import { mockUserStore } from '@/tests/mocks'
+import type { Team } from '@/types'
+
+const OWNER = '0x0000000000000000000000000000000000000099'
+
+function makeTeam(id: string, ownerAddress: string, overrides: Partial<Team> = {}): Team {
+  return {
+    id,
+    name: `Company ${id}`,
+    description: `Description for company ${id}`,
+    isHidden: false,
+    isArchived: false,
+    members: [
+      { id: `${id}-m1`, name: 'Alice', address: '0xaa', teamId: Number(id) },
+      { id: `${id}-m2`, name: 'Bob', address: '0xbb', teamId: Number(id) }
+    ],
+    ownerAddress: ownerAddress as Team['ownerAddress'],
+    teamContracts: [],
+    ...overrides
+  }
+}
+
+function mountTable(teams: Team[]) {
+  return mount(CompaniesTable, { props: { teams } })
+}
+
+type MenuItem = { label: string; onSelect?: () => void }
+
+const dropdownItems = (wrapper: ReturnType<typeof mountTable>, index: number): MenuItem[] =>
+  wrapper.findAllComponents({ name: 'UDropdown' })[index].props('items') as MenuItem[]
+
+describe('CompaniesTable', () => {
+  it('renders the table shell', () => {
+    mockUserStore.address = OWNER
+    const wrapper = mountTable([makeTeam('1', OWNER)])
+    expect(wrapper.find('[data-test="companies-table"]').exists()).toBe(true)
+  })
+
+  it('renders one row per team carrying its teamId', () => {
+    mockUserStore.address = OWNER
+    const wrapper = mountTable([makeTeam('1', OWNER), makeTeam('2', '0xother')])
+    const rows = wrapper.findAll('[data-test="table-row"]')
+    expect(rows).toHaveLength(2)
+    expect(rows[0].attributes('data-team-id')).toBe('1')
+    expect(rows[1].attributes('data-team-id')).toBe('2')
+  })
+
+  it('shows the role badge and treasury balance for each row', () => {
+    mockUserStore.address = OWNER
+    const wrapper = mountTable([makeTeam('1', OWNER), makeTeam('2', '0xother')])
+    const badges = wrapper.findAll('[data-test="role-badge"]')
+    expect(badges[0].attributes('data-role')).toBe('owner')
+    expect(badges[1].attributes('data-role')).toBe('employee')
+    // Treasury labels come from useTeamsTreasury and are formatted as USD.
+    expect(wrapper.text()).toContain('$')
+  })
+
+  it('emits `open` with the teamId when a row is clicked', async () => {
+    mockUserStore.address = OWNER
+    const wrapper = mountTable([makeTeam('7', OWNER)])
+    await wrapper.find('[data-test="table-row"]').trigger('click')
+    expect(wrapper.emitted('open')?.[0]).toEqual(['7'])
+  })
+
+  it('exposes the four owner actions on an owned company', () => {
+    mockUserStore.address = OWNER
+    const wrapper = mountTable([makeTeam('1', OWNER)])
+    expect(dropdownItems(wrapper, 0).map((item) => item.label)).toEqual([
+      'Update',
+      'Archive',
+      'Hide',
+      'Delete'
+    ])
+  })
+
+  it('exposes only Hide on a company the user does not own', () => {
+    mockUserStore.address = OWNER
+    const wrapper = mountTable([makeTeam('1', '0xother')])
+    expect(dropdownItems(wrapper, 0).map((item) => item.label)).toEqual(['Hide'])
+  })
+
+  it('emits `action` with teamId + action when a menu item is selected', () => {
+    mockUserStore.address = OWNER
+    const wrapper = mountTable([makeTeam('5', OWNER)])
+    const items = dropdownItems(wrapper, 0)
+    items.find((item) => item.label === 'Archive')?.onSelect?.()
+    expect(wrapper.emitted('action')?.[0]).toEqual([{ teamId: '5', action: 'archive' }])
+  })
+
+  it('does not navigate when the kebab trigger is clicked', async () => {
+    mockUserStore.address = OWNER
+    const wrapper = mountTable([makeTeam('1', OWNER)])
+    await wrapper.find('[data-test="row-kebab"]').trigger('click')
+    expect(wrapper.emitted('open')).toBeUndefined()
+  })
+
+  it('paginates client-side, slicing rows beyond the page size', () => {
+    mockUserStore.address = OWNER
+    const teams = Array.from({ length: 12 }, (_, i) => makeTeam(String(i + 1), OWNER))
+    const wrapper = mountTable(teams)
+    // Default page size is 10, so the first page shows 10 of 12 rows.
+    expect(wrapper.findAll('[data-test="table-row"]')).toHaveLength(10)
+    expect(wrapper.find('[data-test="companies-table-pagination"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('12')
+  })
+})


### PR DESCRIPTION
Dense table alternative to the cards view: Company (monogram + name) · Role · Members · Treasury · ⋮, with client-side pagination (TablePagination). Row click emits `open(teamId)`; kebab emits `action {teamId, action}`. Last-activity column omitted per the ADR. 9 unit tests.

Gate: type-check ✓ · eslint ✓ · vitest 9/9 ✓.

Refs #2135 · part of #2128