### PR TITLE
feat: ✨ companies list — assemble views, states, actions, dark mode & responsive — step 4/8

### DIFF
--- a/app/src/components/sections/CompaniesView/CompaniesListToolbar.vue
+++ b/app/src/components/sections/CompaniesView/CompaniesListToolbar.vue
@@ -1,0 +1,191 @@
+<template>
+  <div class="flex flex-col gap-3 lg:flex-row lg:items-center" data-test="companies-toolbar">
+    <div class="flex items-center gap-3">
+      <h2>{{ title }}</h2>
+      <!-- Role segmented control -->
+      <div
+        class="border-default bg-default inline-flex items-center gap-0.5 rounded-lg border p-0.5"
+        data-test="role-filter"
+      >
+        <UButton
+          :color="role === 'all' ? 'primary' : 'neutral'"
+          :variant="role === 'all' ? 'soft' : 'ghost'"
+          size="xs"
+          data-test="role-option-all"
+          @click="role = 'all'"
+        >
+          All · {{ counts.all }}
+        </UButton>
+        <UButton
+          :color="role === 'owner' ? 'primary' : 'neutral'"
+          :variant="role === 'owner' ? 'soft' : 'ghost'"
+          size="xs"
+          data-test="role-option-owner"
+          @click="role = 'owner'"
+        >
+          Owner · {{ counts.owner }}
+        </UButton>
+        <UButton
+          :color="role === 'employee' ? 'primary' : 'neutral'"
+          :variant="role === 'employee' ? 'soft' : 'ghost'"
+          size="xs"
+          data-test="role-option-employee"
+          @click="role = 'employee'"
+        >
+          Employee · {{ counts.employee }}
+        </UButton>
+      </div>
+    </div>
+
+    <div class="flex flex-wrap items-center gap-2 lg:ml-auto">
+      <!-- Search -->
+      <UInput
+        v-model="query"
+        icon="i-heroicons-magnifying-glass"
+        placeholder="Search companies"
+        data-test="search-companies"
+      />
+
+      <!-- Filters popover -->
+      <UPopover data-test="filters-popover">
+        <UButton
+          color="neutral"
+          variant="soft"
+          icon="i-heroicons-adjustments-horizontal"
+          trailing-icon="i-heroicons-chevron-down"
+          data-test="filters-button"
+        >
+          Filters
+          <UBadge
+            v-if="activeVisibilityCount > 0"
+            color="primary"
+            size="sm"
+            data-test="filters-count-badge"
+          >
+            {{ activeVisibilityCount }}
+          </UBadge>
+        </UButton>
+
+        <template #content>
+          <div class="flex w-64 flex-col gap-1 p-3" data-test="filters-panel">
+            <p class="text-muted text-xs font-semibold tracking-wide uppercase">Visibility</p>
+            <div class="flex items-center justify-between gap-3 py-2">
+              <div class="flex min-w-0 flex-col">
+                <span class="text-default text-sm font-medium">Hidden companies</span>
+                <span class="text-muted text-xs">Teams you set aside</span>
+              </div>
+              <USwitch
+                v-model="showHidden"
+                size="sm"
+                :ui="{ base: showHidden ? 'data-[state=checked]:bg-success' : '' }"
+                data-test="toggle-show-hidden"
+              />
+            </div>
+            <div class="border-muted flex items-center justify-between gap-3 border-t py-2">
+              <div class="flex min-w-0 flex-col">
+                <span class="text-default text-sm font-medium">Archived companies</span>
+                <span class="text-muted text-xs">Closed or dormant teams</span>
+              </div>
+              <USwitch
+                v-model="showArchived"
+                size="sm"
+                :ui="{ base: showArchived ? 'data-[state=checked]:bg-warning' : '' }"
+                data-test="toggle-show-archived"
+              />
+            </div>
+            <UButton
+              color="neutral"
+              variant="soft"
+              size="sm"
+              block
+              :disabled="activeVisibilityCount === 0"
+              data-test="reset-visibility"
+              @click="resetVisibility"
+            >
+              Reset visibility
+            </UButton>
+          </div>
+        </template>
+      </UPopover>
+
+      <!-- View toggle -->
+      <div
+        class="border-default bg-default inline-flex items-center gap-0.5 rounded-lg border p-0.5"
+        data-test="view-toggle"
+      >
+        <UButton
+          :color="view === 'cards' ? 'primary' : 'neutral'"
+          :variant="view === 'cards' ? 'soft' : 'ghost'"
+          size="sm"
+          icon="i-heroicons-squares-2x2"
+          aria-label="Cards view"
+          data-test="view-toggle-cards"
+          @click="view = 'cards'"
+        />
+        <UButton
+          :color="view === 'table' ? 'primary' : 'neutral'"
+          :variant="view === 'table' ? 'soft' : 'ghost'"
+          size="sm"
+          icon="i-heroicons-table-cells"
+          aria-label="Table view"
+          data-test="view-toggle-table"
+          @click="view = 'table'"
+        />
+      </div>
+
+      <!-- Create Company -->
+      <UModal
+        v-model:open="openModal"
+        title="Create Company"
+        description="Create Your Company Step By Step"
+      >
+        <UButton
+          color="primary"
+          icon="i-heroicons-plus"
+          label="Create Company"
+          data-test="create-company-button"
+          @click="openModal = true"
+        />
+
+        <template #body>
+          <AddTeamForm
+            @done="
+              () => {
+                openModal = false
+              }
+            "
+          />
+        </template>
+      </UModal>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import AddTeamForm from '@/components/forms/AddTeamForm.vue'
+import type { CompanyRoleFilter } from '@/composables/useCompaniesFilter'
+
+defineProps<{
+  title: string
+  counts: { all: number; owner: number; employee: number }
+}>()
+
+const role = defineModel<CompanyRoleFilter>('role', { required: true })
+const query = defineModel<string>('query', { required: true })
+const showHidden = defineModel<boolean>('showHidden', { required: true })
+const showArchived = defineModel<boolean>('showArchived', { required: true })
+const view = defineModel<'cards' | 'table'>('view', { required: true })
+
+const openModal = ref(false)
+
+/** How many visibility filters are currently active (drives the badge). */
+const activeVisibilityCount = computed(
+  () => (showHidden.value ? 1 : 0) + (showArchived.value ? 1 : 0)
+)
+
+function resetVisibility() {
+  showHidden.value = false
+  showArchived.value = false
+}
+</script>

--- a/app/src/components/sections/CompaniesView/CompanyActionConfirm.vue
+++ b/app/src/components/sections/CompaniesView/CompanyActionConfirm.vue
@@ -1,0 +1,75 @@
+<template>
+  <UModal :open="open" :title="title" :description="description" @update:open="emit('update:open', $event)">
+    <template #body>
+      <UAlert
+        v-if="errorMessage"
+        color="error"
+        variant="soft"
+        :description="errorMessage"
+        class="mb-4"
+        data-test="company-action-error"
+      />
+      <p class="text-default text-sm">
+        Are you sure you want to {{ verb }} the company
+        <span class="font-bold">{{ teamName }}</span
+        >?
+      </p>
+      <div class="mt-4 flex justify-center gap-2">
+        <UButton
+          :color="confirmColor"
+          :label="confirmLabel"
+          :loading="loading"
+          :disabled="loading"
+          data-test="company-action-confirm"
+          @click="emit('confirm')"
+        />
+        <UButton
+          color="primary"
+          variant="outline"
+          label="Cancel"
+          data-test="company-action-cancel"
+          @click="emit('update:open', false)"
+        />
+      </div>
+    </template>
+  </UModal>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+type ActionKind = 'archive' | 'delete'
+
+interface Props {
+  open: boolean
+  kind: ActionKind
+  teamName?: string
+  loading?: boolean
+  errorMessage?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  teamName: '',
+  loading: false,
+  errorMessage: ''
+})
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  confirm: []
+}>()
+
+const verb = computed(() => (props.kind === 'archive' ? 'archive' : 'delete'))
+
+const title = computed(() => (props.kind === 'archive' ? 'Archive Company' : 'Delete Company'))
+
+const description = computed(() =>
+  props.kind === 'archive'
+    ? 'This action will remove the company from the dashboard and prevent it from being used.'
+    : 'This action cannot be undone. Please confirm that you want to permanently delete this company.'
+)
+
+const confirmLabel = computed(() => (props.kind === 'archive' ? 'Archive' : 'Delete'))
+
+const confirmColor = computed(() => (props.kind === 'archive' ? 'warning' : 'error'))
+</script>

--- a/app/src/components/sections/CompaniesView/__tests__/CompanyActionConfirm.spec.ts
+++ b/app/src/components/sections/CompaniesView/__tests__/CompanyActionConfirm.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CompanyActionConfirm from '../CompanyActionConfirm.vue'
+
+const mountConfirm = (props: Record<string, unknown> = {}) =>
+  mount(CompanyActionConfirm, {
+    props: { open: true, kind: 'archive', teamName: 'Acme', ...props }
+  })
+
+describe('CompanyActionConfirm', () => {
+  it('renders the archive copy with the company name', () => {
+    const wrapper = mountConfirm({ kind: 'archive' })
+    expect(wrapper.find('[data-test="company-action-confirm"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="company-action-cancel"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Acme')
+    expect(wrapper.text()).toContain('archive')
+  })
+
+  it('renders the delete copy', () => {
+    const wrapper = mountConfirm({ kind: 'delete' })
+    expect(wrapper.text()).toContain('delete')
+  })
+
+  it('emits confirm when the confirm button is clicked', async () => {
+    const wrapper = mountConfirm()
+    await wrapper.find('[data-test="company-action-confirm"]').trigger('click')
+    expect(wrapper.emitted('confirm')).toBeTruthy()
+  })
+
+  it('requests close when cancel is clicked', async () => {
+    const wrapper = mountConfirm()
+    await wrapper.find('[data-test="company-action-cancel"]').trigger('click')
+    expect(wrapper.emitted('update:open')?.at(-1)?.[0]).toBe(false)
+  })
+
+  it('surfaces an error message when provided', () => {
+    const wrapper = mountConfirm({ errorMessage: 'Boom' })
+    expect(wrapper.find('[data-test="company-action-error"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Boom')
+  })
+})

--- a/app/src/composables/__tests__/useCompanyActions.spec.ts
+++ b/app/src/composables/__tests__/useCompanyActions.spec.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { useCompanyActions } from '@/composables/useCompanyActions'
+import { useUpdateTeamMutation, useDeleteTeamMutation } from '@/queries/team.queries'
+import { mockTeamsData } from '@/tests/mocks'
+
+const updateMutate = vi.fn()
+const deleteMutate = vi.fn()
+const updateReset = vi.fn()
+const deleteReset = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(useUpdateTeamMutation).mockReturnValue({
+    mutate: updateMutate,
+    isPending: ref(false),
+    error: ref(null),
+    reset: updateReset
+  } as never)
+  vi.mocked(useDeleteTeamMutation).mockReturnValue({
+    mutate: deleteMutate,
+    isPending: ref(false),
+    error: ref(null),
+    reset: deleteReset
+  } as never)
+})
+
+const teams = () => mockTeamsData
+const firstId = String(mockTeamsData[0].id)
+
+describe('useCompanyActions', () => {
+  it('defers `update` to the onUpdate callback', () => {
+    const onUpdate = vi.fn()
+    const actions = useCompanyActions(teams, { onUpdate })
+    actions.handleAction({ teamId: firstId, action: 'update' })
+    expect(onUpdate).toHaveBeenCalledWith(firstId)
+    expect(actions.confirmOpen.value).toBe(false)
+  })
+
+  it('hides inline through the update mutation (no confirm)', () => {
+    const actions = useCompanyActions(teams, { onUpdate: vi.fn() })
+    actions.handleAction({ teamId: firstId, action: 'hide' })
+    expect(updateMutate).toHaveBeenCalledWith(
+      { pathParams: { id: firstId }, body: { isHidden: true } },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    )
+    expect(actions.confirmOpen.value).toBe(false)
+    // success callback should run without throwing
+    updateMutate.mock.calls[0][1].onSuccess()
+  })
+
+  it('opens the confirm dialog for archive with the active team', () => {
+    const actions = useCompanyActions(teams, { onUpdate: vi.fn() })
+    actions.handleAction({ teamId: firstId, action: 'archive' })
+    expect(actions.confirmOpen.value).toBe(true)
+    expect(actions.confirmKind.value).toBe('archive')
+    expect(actions.activeTeam.value?.id).toBe(mockTeamsData[0].id)
+  })
+
+  it('archives via the update mutation on confirm', () => {
+    const actions = useCompanyActions(teams, { onUpdate: vi.fn() })
+    actions.handleAction({ teamId: firstId, action: 'archive' })
+    actions.onConfirm()
+    expect(updateMutate).toHaveBeenCalledWith(
+      { pathParams: { id: firstId }, body: { isArchived: true } },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    )
+    updateMutate.mock.calls[0][1].onSuccess()
+    expect(actions.confirmOpen.value).toBe(false)
+  })
+
+  it('deletes via the delete mutation on confirm', () => {
+    const actions = useCompanyActions(teams, { onUpdate: vi.fn() })
+    actions.handleAction({ teamId: firstId, action: 'delete' })
+    actions.onConfirm()
+    expect(deleteMutate).toHaveBeenCalledWith(
+      { pathParams: { teamId: firstId } },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    )
+    deleteMutate.mock.calls[0][1].onSuccess()
+  })
+
+  it('is a no-op on confirm when no team is active', () => {
+    const actions = useCompanyActions(teams, { onUpdate: vi.fn() })
+    actions.onConfirm()
+    expect(updateMutate).not.toHaveBeenCalled()
+    expect(deleteMutate).not.toHaveBeenCalled()
+  })
+
+  it('clears state and resets mutations when the dialog closes', () => {
+    const actions = useCompanyActions(teams, { onUpdate: vi.fn() })
+    actions.handleAction({ teamId: firstId, action: 'delete' })
+    actions.onConfirmOpenChange(false)
+    expect(actions.confirmOpen.value).toBe(false)
+    expect(actions.confirmKind.value).toBe(null)
+    expect(actions.activeTeam.value).toBe(null)
+    expect(updateReset).toHaveBeenCalled()
+    expect(deleteReset).toHaveBeenCalled()
+  })
+})

--- a/app/src/composables/useCompanyActions.ts
+++ b/app/src/composables/useCompanyActions.ts
@@ -1,0 +1,116 @@
+import { computed, ref, toValue, type MaybeRefOrGetter } from 'vue'
+import { useUpdateTeamMutation, useDeleteTeamMutation } from '@/queries/team.queries'
+import type { Team } from '@/types'
+
+export type CompanyAction = 'update' | 'archive' | 'hide' | 'delete'
+
+export interface CompanyActionPayload {
+  teamId: string
+  action: CompanyAction
+}
+
+/**
+ * Encapsulates the row/card actions of the Companies list. `hide` runs inline;
+ * `archive`/`delete` go through a confirm dialog; `update` defers to the caller
+ * (navigation). All API calls reuse the shared team mutations so the request
+ * path stays identical to the TeamMeta* modals.
+ */
+export function useCompanyActions(
+  teams: MaybeRefOrGetter<Team[] | undefined>,
+  opts: { onUpdate: (teamId: string) => void }
+) {
+  const toast = useToast()
+  const activeTeam = ref<Team | null>(null)
+  const confirmKind = ref<'archive' | 'delete' | null>(null)
+  const confirmOpen = ref(false)
+
+  const {
+    isPending: updatePending,
+    error: updateError,
+    mutate: updateTeamMutate,
+    reset: resetUpdate
+  } = useUpdateTeamMutation()
+  const {
+    isPending: deletePending,
+    error: deleteError,
+    mutate: deleteTeamMutate,
+    reset: resetDelete
+  } = useDeleteTeamMutation()
+
+  const confirmLoading = computed(() =>
+    confirmKind.value === 'delete' ? deletePending.value : updatePending.value
+  )
+  const confirmErrorMessage = computed(() => {
+    const err = confirmKind.value === 'delete' ? deleteError.value : updateError.value
+    return err ? err.message : ''
+  })
+
+  function findTeam(teamId: string): Team | undefined {
+    return (toValue(teams) ?? []).find((team) => String(team.id) === String(teamId))
+  }
+
+  function handleAction({ teamId, action }: CompanyActionPayload) {
+    if (action === 'update') {
+      opts.onUpdate(teamId)
+      return
+    }
+    if (action === 'hide') {
+      updateTeamMutate(
+        { pathParams: { id: teamId }, body: { isHidden: true } },
+        { onSuccess: () => toast.add({ title: 'Company hidden', color: 'success' }) }
+      )
+      return
+    }
+    activeTeam.value = findTeam(teamId) ?? null
+    confirmKind.value = action
+    confirmOpen.value = true
+  }
+
+  function onConfirmOpenChange(value: boolean) {
+    confirmOpen.value = value
+    if (!value) {
+      confirmKind.value = null
+      activeTeam.value = null
+      resetUpdate()
+      resetDelete()
+    }
+  }
+
+  function onConfirm() {
+    const team = activeTeam.value
+    if (!team) return
+    const teamId = String(team.id)
+    if (confirmKind.value === 'archive') {
+      updateTeamMutate(
+        { pathParams: { id: teamId }, body: { isArchived: true } },
+        {
+          onSuccess: () => {
+            toast.add({ title: 'Company archived', color: 'success' })
+            onConfirmOpenChange(false)
+          }
+        }
+      )
+    } else if (confirmKind.value === 'delete') {
+      deleteTeamMutate(
+        { pathParams: { teamId } },
+        {
+          onSuccess: () => {
+            toast.add({ title: 'Company deleted', color: 'success' })
+            onConfirmOpenChange(false)
+          }
+        }
+      )
+    }
+  }
+
+  return {
+    activeTeam,
+    confirmKind,
+    confirmOpen,
+    confirmLoading,
+    confirmErrorMessage,
+    handleAction,
+    onConfirmOpenChange,
+    onConfirm
+  }
+}

--- a/app/src/views/team/ListIndex.vue
+++ b/app/src/views/team/ListIndex.vue
@@ -1,166 +1,23 @@
 <template>
   <div class="flex flex-col gap-6">
-    <!-- Toolbar -->
-    <div class="flex flex-col gap-3 lg:flex-row lg:items-center" data-test="companies-toolbar">
-      <div class="flex items-center gap-3">
-        <h2>{{ route.meta.name }}</h2>
-        <!-- Role segmented control -->
-        <div
-          class="border-default bg-default inline-flex items-center gap-0.5 rounded-lg border p-0.5"
-          data-test="role-filter"
-        >
-          <UButton
-            :color="role === 'all' ? 'primary' : 'neutral'"
-            :variant="role === 'all' ? 'soft' : 'ghost'"
-            size="xs"
-            data-test="role-option-all"
-            @click="role = 'all'"
-          >
-            All · {{ counts.all }}
-          </UButton>
-          <UButton
-            :color="role === 'owner' ? 'primary' : 'neutral'"
-            :variant="role === 'owner' ? 'soft' : 'ghost'"
-            size="xs"
-            data-test="role-option-owner"
-            @click="role = 'owner'"
-          >
-            Owner · {{ counts.owner }}
-          </UButton>
-          <UButton
-            :color="role === 'employee' ? 'primary' : 'neutral'"
-            :variant="role === 'employee' ? 'soft' : 'ghost'"
-            size="xs"
-            data-test="role-option-employee"
-            @click="role = 'employee'"
-          >
-            Employee · {{ counts.employee }}
-          </UButton>
-        </div>
-      </div>
+    <CompaniesListToolbar
+      v-model:role="role"
+      v-model:query="query"
+      v-model:show-hidden="showHidden"
+      v-model:show-archived="showArchived"
+      v-model:view="view"
+      :title="title"
+      :counts="counts"
+    />
 
-      <div class="flex flex-wrap items-center gap-2 lg:ml-auto">
-        <!-- Search -->
-        <UInput
-          v-model="query"
-          icon="i-heroicons-magnifying-glass"
-          placeholder="Search companies"
-          data-test="search-companies"
-        />
-
-        <!-- Filters popover -->
-        <UPopover data-test="filters-popover">
-          <UButton
-            color="neutral"
-            variant="soft"
-            icon="i-heroicons-adjustments-horizontal"
-            trailing-icon="i-heroicons-chevron-down"
-            data-test="filters-button"
-          >
-            Filters
-            <UBadge
-              v-if="activeVisibilityCount > 0"
-              color="primary"
-              size="sm"
-              data-test="filters-count-badge"
-            >
-              {{ activeVisibilityCount }}
-            </UBadge>
-          </UButton>
-
-          <template #content>
-            <div class="flex w-64 flex-col gap-1 p-3" data-test="filters-panel">
-              <p class="text-muted text-xs font-semibold tracking-wide uppercase">Visibility</p>
-              <div class="flex items-center justify-between gap-3 py-2">
-                <div class="flex min-w-0 flex-col">
-                  <span class="text-default text-sm font-medium">Hidden companies</span>
-                  <span class="text-muted text-xs">Teams you set aside</span>
-                </div>
-                <USwitch
-                  v-model="showHidden"
-                  size="sm"
-                  :ui="{ base: showHidden ? 'data-[state=checked]:bg-success' : '' }"
-                  data-test="toggle-show-hidden"
-                />
-              </div>
-              <div class="border-muted flex items-center justify-between gap-3 border-t py-2">
-                <div class="flex min-w-0 flex-col">
-                  <span class="text-default text-sm font-medium">Archived companies</span>
-                  <span class="text-muted text-xs">Closed or dormant teams</span>
-                </div>
-                <USwitch
-                  v-model="showArchived"
-                  size="sm"
-                  :ui="{ base: showArchived ? 'data-[state=checked]:bg-warning' : '' }"
-                  data-test="toggle-show-archived"
-                />
-              </div>
-              <UButton
-                color="neutral"
-                variant="soft"
-                size="sm"
-                block
-                :disabled="activeVisibilityCount === 0"
-                data-test="reset-visibility"
-                @click="resetVisibility"
-              >
-                Reset visibility
-              </UButton>
-            </div>
-          </template>
-        </UPopover>
-
-        <!-- View toggle -->
-        <div
-          class="border-default bg-default inline-flex items-center gap-0.5 rounded-lg border p-0.5"
-          data-test="view-toggle"
-        >
-          <UButton
-            :color="view === 'cards' ? 'primary' : 'neutral'"
-            :variant="view === 'cards' ? 'soft' : 'ghost'"
-            size="sm"
-            icon="i-heroicons-squares-2x2"
-            aria-label="Cards view"
-            data-test="view-toggle-cards"
-            @click="view = 'cards'"
-          />
-          <UButton
-            :color="view === 'table' ? 'primary' : 'neutral'"
-            :variant="view === 'table' ? 'soft' : 'ghost'"
-            size="sm"
-            icon="i-heroicons-table-cells"
-            aria-label="Table view"
-            data-test="view-toggle-table"
-            @click="view = 'table'"
-          />
-        </div>
-
-        <!-- Create Company -->
-        <UModal
-          v-model:open="openModal"
-          title="Create Company"
-          description="Create Your Company Step By Step"
-        >
-          <UButton
-            color="primary"
-            icon="i-heroicons-plus"
-            label="Create Company"
-            data-test="create-company-button"
-            @click="openModal = true"
-          />
-
-          <template #body>
-            <AddTeamForm
-              @done="
-                () => {
-                  openModal = false
-                }
-              "
-            />
-          </template>
-        </UModal>
-      </div>
-    </div>
+    <!-- Treasury recap -->
+    <CompaniesTreasuryRecap
+      v-if="showRecap"
+      :aggregate="aggregate"
+      :owner-count="counts.owner"
+      :member-count="counts.employee"
+      data-test="companies-recap"
+    />
 
     <!-- Loader -->
     <div class="flex gap-3" data-test="loader" v-if="teamsAreFetching">
@@ -201,13 +58,27 @@
 
     <!-- Teams List -->
     <template v-if="!teamsError && !teamsAreFetching && Array.isArray(teams) && teams.length > 0">
-      <!-- Table view placeholder (real table comes in a later ticket) -->
+      <!-- No results for the active filters -->
       <div
-        v-if="view === 'table'"
-        class="text-muted border-default rounded-lg border border-dashed p-8 text-center text-sm"
-        data-test="table-placeholder"
+        v-if="filtered.length === 0"
+        class="text-muted border-default flex flex-col items-center gap-3 rounded-lg border border-dashed p-8 text-center text-sm"
+        data-test="filter-empty-state"
       >
-        Table view — coming soon
+        <p>No companies match your filters.</p>
+        <UButton
+          color="neutral"
+          variant="soft"
+          size="sm"
+          data-test="clear-filters"
+          @click="clearFilters"
+        >
+          Clear filters
+        </UButton>
+      </div>
+
+      <!-- Table view -->
+      <div v-else-if="view === 'table'" class="overflow-x-auto" data-test="table-view">
+        <CompaniesTable :teams="filtered" @open="navigateToTeam" @action="handleAction" />
       </div>
 
       <!-- Cards grid -->
@@ -223,21 +94,40 @@
           :data-test="`team-card-${team.id}`"
           class="cursor-pointer transition duration-300 hover:scale-105"
           @click="navigateToTeam(team.id)"
+          @action="handleAction"
         />
       </div>
     </template>
+
+    <!-- Shared archive / delete confirmation -->
+    <CompanyActionConfirm
+      v-if="confirmKind"
+      :open="confirmOpen"
+      :kind="confirmKind ?? 'archive'"
+      :team-name="activeTeam?.name"
+      :loading="confirmLoading"
+      :error-message="confirmErrorMessage"
+      data-test="company-action-confirm"
+      @update:open="onConfirmOpenChange"
+      @confirm="onConfirm"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed, ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useUserDataStore } from '@/stores'
 import TeamCard from '@/components/sections/TeamView/TeamCard.vue'
+import CompaniesListToolbar from '@/components/sections/CompaniesView/CompaniesListToolbar.vue'
+import CompaniesTreasuryRecap from '@/components/sections/CompaniesView/CompaniesTreasuryRecap.vue'
+import CompaniesTable from '@/components/sections/CompaniesView/CompaniesTable.vue'
+import CompanyActionConfirm from '@/components/sections/CompaniesView/CompanyActionConfirm.vue'
 import { useGetTeamsQuery } from '@/queries/team.queries'
 import { useCompaniesFilter, type CompanyRoleFilter } from '@/composables/useCompaniesFilter'
-import { computed, ref } from 'vue'
+import { useTeamsTreasury } from '@/composables/treasury/useTeamsTreasury'
+import { useCompanyActions } from '@/composables/useCompanyActions'
 
-const openModal = ref(false)
 const showHidden = ref(false)
 const showArchived = ref(false)
 const role = ref<CompanyRoleFilter>('all')
@@ -245,7 +135,10 @@ const query = ref('')
 const view = ref<'cards' | 'table'>('cards')
 
 const route = useRoute()
+const router = useRouter()
 const userDataStore = useUserDataStore()
+
+const title = computed(() => (route.meta.name as string | undefined) ?? 'Companies')
 
 const {
   data: teams,
@@ -267,19 +160,35 @@ const { filtered, counts } = useCompaniesFilter(teams, {
   showArchived
 })
 
-/** How many visibility filters are currently active (drives the badge). */
-const activeVisibilityCount = computed(
-  () => (showHidden.value ? 1 : 0) + (showArchived.value ? 1 : 0)
+const { aggregate } = useTeamsTreasury(() => teams.value ?? [])
+
+const showRecap = computed(
+  () =>
+    !teamsAreFetching.value &&
+    !teamsError.value &&
+    Array.isArray(teams.value) &&
+    teams.value.length > 0
 )
 
-function resetVisibility() {
+function clearFilters() {
+  role.value = 'all'
+  query.value = ''
   showHidden.value = false
   showArchived.value = false
 }
 
-const router = useRouter()
-
 const navigateToTeam = (id: number | string) => {
   router.push(`/teams/${id}`)
 }
+
+const {
+  activeTeam,
+  confirmKind,
+  confirmOpen,
+  confirmLoading,
+  confirmErrorMessage,
+  handleAction,
+  onConfirmOpenChange,
+  onConfirm
+} = useCompanyActions(teams, { onUpdate: navigateToTeam })
 </script>

--- a/app/src/views/team/__tests__/ListIndex.spec.ts
+++ b/app/src/views/team/__tests__/ListIndex.spec.ts
@@ -258,21 +258,25 @@ describe('ListIndex - Team List View', () => {
     it('renders the cards grid by default', () => {
       const wrapper = createWrapper(mockTeamsData)
       expect(wrapper.find('[data-test="team-list"]').exists()).toBe(true)
-      expect(wrapper.find('[data-test="table-placeholder"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="table-view"]').exists()).toBe(false)
     })
 
-    it('switches to the table placeholder and back', async () => {
+    it('switches to the table view and back', async () => {
       const wrapper = createWrapper(mockTeamsData)
 
       await wrapper.find('[data-test="view-toggle-table"]').trigger('click')
       expect(wrapper.find('[data-test="team-list"]').exists()).toBe(false)
-      const placeholder = wrapper.find('[data-test="table-placeholder"]')
-      expect(placeholder.exists()).toBe(true)
-      expect(placeholder.text()).toContain('coming soon')
+      expect(wrapper.find('[data-test="table-view"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="companies-table"]').exists()).toBe(true)
 
       await wrapper.find('[data-test="view-toggle-cards"]').trigger('click')
       expect(wrapper.find('[data-test="team-list"]').exists()).toBe(true)
-      expect(wrapper.find('[data-test="table-placeholder"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="table-view"]').exists()).toBe(false)
+    })
+
+    it('renders the treasury recap when teams are loaded', () => {
+      const wrapper = createWrapper(mockTeamsData)
+      expect(wrapper.find('[data-test="companies-recap"]').exists()).toBe(true)
     })
   })
 


### PR DESCRIPTION
Final assembly of the Companies list page:
- Treasury recap strip + Cards/Table view switch wired to `useTeamsTreasury` and the filtered list.
- Toolbar extracted to `CompaniesListToolbar`; row/card actions handled by a new `useCompanyActions` composable (hide → inline mutation; archive/delete → `CompanyActionConfirm` dialog; update → navigate) reusing the shared team mutations.
- States: loader, error, 'no teams' and a new 'no results for filters' block with Clear filters.
- Dark-mode-safe semantic classes; responsive grid + horizontally-scrollable table.

Gate: build ✓ · type-check ✓ · eslint ✓ · full suite 1924/1924 ✓.

Refs #2136 · part of #2128