### PR TITLE
fix: 🐛 allow Excel files in claim upload

### DIFF
--- a/app/src/components/sections/CashRemunerationView/Form/UploadFileDB.vue
+++ b/app/src/components/sections/CashRemunerationView/Form/UploadFileDB.vue
@@ -98,7 +98,8 @@ const fileSchema = z
       return byMime || byExt
     },
     {
-      message: 'Only images (png, jpg, jpeg, webp) and documents (pdf, txt, zip, docx) are allowed'
+      message:
+        'Only images (png, jpg, jpeg, webp) and documents (pdf, txt, zip, docx, xls, xlsx) are allowed'
     }
   )
   .refine((file) => file.size <= MAX_FILE_SIZE, {

--- a/app/src/components/sections/CashRemunerationView/Form/__tests__/UploadFileDB.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/Form/__tests__/UploadFileDB.spec.ts
@@ -67,7 +67,7 @@ describe('UploadFileDB', () => {
   })
 
   describe('File Type Validation', () => {
-    it('should accept document files (pdf, txt, zip, docx)', async () => {
+    it('should accept document files (pdf, txt, zip, docx, xls, xlsx)', async () => {
       wrapper = createWrapper()
 
       const validDocs = [
@@ -76,12 +76,29 @@ describe('UploadFileDB', () => {
         new File([''], 'test.zip', { type: 'application/zip' }),
         new File([''], 'test.docx', {
           type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        }),
+        new File([''], 'test.xls', { type: 'application/vnd.ms-excel' }),
+        new File([''], 'test.xlsx', {
+          type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
         })
       ]
 
       await emitFilesUpdate(validDocs)
 
-      expect(wrapper.emitted('update:files')?.[0]?.[0]).toHaveLength(4)
+      expect(wrapper.emitted('update:files')?.[0]?.[0]).toHaveLength(6)
+    })
+
+    it('should accept excel files by extension when MIME type is missing', async () => {
+      wrapper = createWrapper()
+
+      const validDocs = [
+        new File([''], 'report.xlsx', { type: '' }),
+        new File([''], 'legacy.xls', { type: 'application/octet-stream' })
+      ]
+
+      await emitFilesUpdate(validDocs)
+
+      expect(wrapper.emitted('update:files')?.[0]?.[0]).toHaveLength(2)
     })
 
     it('should reject invalid file types', async () => {

--- a/app/src/types/upload.ts
+++ b/app/src/types/upload.ts
@@ -4,7 +4,7 @@ export const MAX_FILES = 10
 
 // Allowed file types
 export const ALLOWED_IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.webp']
-export const ALLOWED_DOCUMENT_EXTENSIONS = ['.pdf', '.txt', '.zip', '.docx']
+export const ALLOWED_DOCUMENT_EXTENSIONS = ['.pdf', '.txt', '.zip', '.docx', '.xls', '.xlsx']
 export const ACCEPTED_FILE_TYPES = [
   ...ALLOWED_IMAGE_EXTENSIONS,
   ...ALLOWED_DOCUMENT_EXTENSIONS
@@ -16,7 +16,9 @@ export const ALLOWED_DOCUMENT_MIMETYPES = [
   'text/plain',
   'application/zip',
   'application/x-zip-compressed',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 ]
 export const ALLOWED_MIMETYPES = [...ALLOWED_IMAGE_MIMETYPES, ...ALLOWED_DOCUMENT_MIMETYPES]
 

--- a/backend/src/services/storageService.ts
+++ b/backend/src/services/storageService.ts
@@ -32,6 +32,8 @@ export const ALLOWED_DOCUMENT_MIMETYPES = [
   'application/zip',
   'application/x-zip-compressed',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 ] as const;
 export const ALLOWED_MIMETYPES = [
   ...ALLOWED_IMAGE_MIMETYPES,


### PR DESCRIPTION
FIxed #2156

## Summary

- Add `.xls` and `.xlsx` to allowed document extensions and MIME types in `app/src/types/upload.ts`
- Mirror the same MIME allowlist in `backend/src/services/storageService.ts` so uploads are accepted server-side
- Update validation message in `UploadFileDB.vue` and extend unit tests (including extension fallback when MIME is missing)



