### PR TITLE
feat: ✨ reuse accounting date picker in transaction history filter

### DIFF
--- a/app/src/components/CustomDatePicker.vue
+++ b/app/src/components/CustomDatePicker.vue
@@ -1,49 +1,17 @@
 <!-- CustomDatePicker.vue -->
-<template>
-  <USelectMenu
-    v-model="selectedOption"
-    :items="options"
-    value-key="value"
-    :search-input="false"
-    v-model:open="isDropdownOpen"
-    :data-test="`${dataTestPrefix}-date-select`"
-  >
-    <template #default>
-      <span>{{ displayDateRange }}</span>
-    </template>
-    <template #content-bottom>
-      <div class="border-t border-gray-200 p-1">
-        <div
-          class="flex w-full cursor-pointer items-center rounded-md px-2 py-1.5 text-sm select-none hover:bg-gray-100 dark:hover:bg-gray-800"
-          @click="openCustomRangeModal"
-        >
-          Custom Range
-        </div>
-      </div>
-    </template>
-  </USelectMenu>
+<!--
+  Range date filter for the transaction-history tables.
 
-  <UModal v-model:open="isModalOpen" title="Custom Date Range">
-    <template #body>
-      <div class="flex justify-center py-2">
-        <UCalendar range v-model="calendarRange" :number-of-months="2" />
-      </div>
-    </template>
-    <template #footer>
-      <div class="flex w-full justify-end gap-2">
-        <UButton color="neutral" variant="ghost" @click="isModalOpen = false">Cancel</UButton>
-        <UButton :disabled="!calendarRange?.start || !calendarRange?.end" @click="applyCustomRange">
-          Apply
-        </UButton>
-      </div>
-    </template>
-  </UModal>
-</template>
-
+  Thin adapter over the ported `AccountingDatePicker` (run in `range` mode): it keeps the
+  legacy tuple contract (`v-model: [Date, Date] | null`) so the existing tables, their test
+  stubs and `useTransactionTable` bind it unchanged, while delegating all of the UI and date
+  logic to the shared picker. Defaults to "All time" and persists each table's selection
+  under a `dataTestPrefix`-scoped key.
+-->
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
-import { CalendarDate } from '@internationalized/date'
-import type { DateRange } from 'reka-ui'
+import { ref, watch } from 'vue'
+import AccountingDatePicker from '@/components/AccountingDatePicker.vue'
+import type { DatePickerValue } from '@/utils/datePicker'
 
 interface Props {
   modelValue: [Date, Date] | null
@@ -58,94 +26,25 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: [Date, Date] | null): void
 }>()
 
-const selectedOption = ref('current')
-const dateRange = ref<[Date, Date] | null>(null)
-const isDropdownOpen = ref(false)
-const isModalOpen = ref(false)
-const calendarRange = ref<DateRange | undefined>()
-
-const getCurrentMonthName = () => new Date().toLocaleString('default', { month: 'long' })
-
-const getPreviousMonthName = () => {
-  const now = new Date()
-  return new Date(now.getFullYear(), now.getMonth() - 1).toLocaleString('default', {
-    month: 'long'
-  })
-}
-
-const options = computed(() => [
-  { value: 'current', label: getCurrentMonthName() },
-  { value: 'previous', label: getPreviousMonthName() }
-])
-
-const getCurrentMonthRange = (): [Date, Date] => {
-  const now = new Date()
-  return [
-    new Date(now.getFullYear(), now.getMonth(), 1),
-    new Date(now.getFullYear(), now.getMonth() + 1, 0)
-  ]
-}
-
-const getPreviousMonthRange = (): [Date, Date] => {
-  const now = new Date()
-  return [
-    new Date(now.getFullYear(), now.getMonth() - 1, 1),
-    new Date(now.getFullYear(), now.getMonth(), 0)
-  ]
-}
-
-const dateToCalendarDate = (date: Date): CalendarDate =>
-  new CalendarDate(date.getFullYear(), date.getMonth() + 1, date.getDate())
-
-const calendarDateToDate = (cd: CalendarDate): Date => new Date(cd.year, cd.month - 1, cd.day)
-
-const openCustomRangeModal = () => {
-  isDropdownOpen.value = false
-  if (dateRange.value) {
-    calendarRange.value = {
-      start: dateToCalendarDate(dateRange.value[0]),
-      end: dateToCalendarDate(dateRange.value[1])
-    }
-  }
-  isModalOpen.value = true
-}
-
-const applyCustomRange = () => {
-  if (calendarRange.value?.start && calendarRange.value?.end) {
-    dateRange.value = [
-      calendarDateToDate(calendarRange.value.start as CalendarDate),
-      calendarDateToDate(calendarRange.value.end as CalendarDate)
-    ]
-  }
-  isModalOpen.value = false
-}
-
-watch(selectedOption, (newValue) => {
-  if (newValue === 'current') dateRange.value = getCurrentMonthRange()
-  else if (newValue === 'previous') dateRange.value = getPreviousMonthRange()
-})
-
-watch(dateRange, (newValue) => {
-  if (newValue) emit('update:modelValue', newValue)
-})
-
-watch(
-  () => props.modelValue,
-  (newValue) => {
-    if (newValue) dateRange.value = newValue
-  }
+// Inner Range model handed to AccountingDatePicker; seeded from the incoming tuple (if any).
+const range = ref<DatePickerValue | undefined>(
+  props.modelValue ? { start: props.modelValue[0], end: props.modelValue[1] } : undefined
 )
 
-onMounted(() => {
-  dateRange.value = props.modelValue ?? getCurrentMonthRange()
-})
-
-const formatDisplayDate = (date: Date) =>
-  `${date.toLocaleString('default', { month: 'long' })} ${date.getDate()}`
-
-const displayDateRange = computed(() => {
-  if (!dateRange.value) return ''
-  const [start, end] = dateRange.value
-  return `${formatDisplayDate(start)} - ${formatDisplayDate(end)}`
+// Re-emit the resolved range to parents as the legacy `[start, end]` tuple.
+watch(range, (value) => {
+  if (value && !(value instanceof Date)) {
+    emit('update:modelValue', [value.start, value.end])
+  }
 })
 </script>
+
+<template>
+  <div :data-test="`${dataTestPrefix}-date-select`">
+    <AccountingDatePicker
+      v-model="range"
+      mode="range"
+      :storage-key="`transaction-history-range-${dataTestPrefix}`"
+    />
+  </div>
+</template>

--- a/app/src/components/__tests__/CustomDatePicker.spec.ts
+++ b/app/src/components/__tests__/CustomDatePicker.spec.ts
@@ -1,267 +1,68 @@
 import { describe, it, expect } from 'vitest'
+import { defineComponent, h } from 'vue'
 import { mount } from '@vue/test-utils'
-import { nextTick } from 'vue'
-import { CalendarDate } from '@internationalized/date'
 import CustomDatePicker from '../CustomDatePicker.vue'
-import { UCalendarStub, UModalStub, USelectMenuStub } from '@/tests/stubs/nuxt-ui.stubs'
+
+// Stub the shared picker: capture its props and let tests drive its `update:modelValue`.
+const AccountingDatePickerStub = defineComponent({
+  name: 'AccountingDatePicker',
+  props: ['modelValue', 'mode', 'storageKey'],
+  emits: ['update:modelValue'],
+  setup() {
+    return () => h('div', { 'data-test': 'accounting-date-picker' })
+  }
+})
+
+const PREFIX = 'expense-transaction-history'
+
+const mountComponent = (modelValue: [Date, Date] | null = null) =>
+  mount(CustomDatePicker, {
+    props: { modelValue, dataTestPrefix: PREFIX },
+    global: { stubs: { AccountingDatePicker: AccountingDatePickerStub } }
+  })
+
+const picker = (wrapper: ReturnType<typeof mountComponent>) =>
+  wrapper.findComponent(AccountingDatePickerStub)
 
 describe('CustomDatePicker', () => {
-  const mountComponent = (modelValue: [Date, Date] | null = null) =>
-    mount(CustomDatePicker, {
-      props: { modelValue, dataTestPrefix: 'test-date-picker' },
-      global: {
-        stubs: {
-          USelectMenu: USelectMenuStub,
-          UModal: UModalStub,
-          UCalendar: UCalendarStub
-        }
-      }
-    })
-
-  const openDropdown = async (wrapper: ReturnType<typeof mountComponent>) => {
-    await nextTick()
-    await wrapper
-      .find('[data-test="test-date-picker-date-select"] [data-test="select-trigger"]')
-      .trigger('click')
-    await nextTick()
-  }
-
-  const openCustomRangeModal = async (wrapper: ReturnType<typeof mountComponent>) => {
-    await openDropdown(wrapper)
-    await wrapper.find('.cursor-pointer').trigger('click')
-    await nextTick()
-  }
-
-  describe('rendering', () => {
-    it('renders the select trigger with the correct data-test attribute', () => {
-      const wrapper = mountComponent()
-      expect(wrapper.find('[data-test="test-date-picker-date-select"]').exists()).toBe(true)
-    })
-
-    it('shows the current month date range as display text by default', async () => {
-      const wrapper = mountComponent()
-      await nextTick()
-
-      const today = new Date()
-      const start = new Date(today.getFullYear(), today.getMonth(), 1)
-      const end = new Date(today.getFullYear(), today.getMonth() + 1, 0)
-      const expected = `${start.toLocaleString('default', { month: 'long' })} 1 - ${end.toLocaleString('default', { month: 'long' })} ${end.getDate()}`
-
-      expect(wrapper.find('span').text()).toBe(expected)
-    })
-
-    it('shows the provided date range as display text', async () => {
-      const wrapper = mountComponent([new Date('2024-01-01'), new Date('2024-01-31')])
-      await nextTick()
-
-      const month = new Date('2024-01-01').toLocaleString('default', { month: 'long' })
-      expect(wrapper.find('span').text()).toBe(`${month} 1 - ${month} 31`)
-    })
-
-    it('lists current and previous month as selectable options', async () => {
-      const wrapper = mountComponent()
-      await openDropdown(wrapper)
-
-      const items = wrapper.findAll('li')
-      const currentMonth = new Date().toLocaleString('default', { month: 'long' })
-      const previousMonth = new Date(
-        new Date().getFullYear(),
-        new Date().getMonth() - 1
-      ).toLocaleString('default', { month: 'long' })
-
-      expect(items).toHaveLength(2)
-      expect(items[0].text()).toBe(currentMonth)
-      expect(items[1].text()).toBe(previousMonth)
-    })
+  it('renders the shared picker inside the prefixed test wrapper', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.find(`[data-test="${PREFIX}-date-select"]`).exists()).toBe(true)
+    expect(picker(wrapper).exists()).toBe(true)
   })
 
-  describe('option selection', () => {
-    it('emits the current month range when the current month option is selected', async () => {
-      const wrapper = mountComponent()
-      await nextTick()
-
-      await openDropdown(wrapper)
-      await wrapper.findAll('li')[0].trigger('click')
-      await nextTick()
-
-      const today = new Date()
-      const emitted = wrapper.emitted('update:modelValue')!
-      expect(emitted[emitted.length - 1]).toEqual([
-        [
-          new Date(today.getFullYear(), today.getMonth(), 1),
-          new Date(today.getFullYear(), today.getMonth() + 1, 0)
-        ]
-      ])
-    })
-
-    it('emits the previous month range when the previous month option is selected', async () => {
-      const wrapper = mountComponent()
-      await nextTick()
-
-      await openDropdown(wrapper)
-      await wrapper.findAll('li')[1].trigger('click')
-      await nextTick()
-
-      const today = new Date()
-      const emitted = wrapper.emitted('update:modelValue')!
-      expect(emitted[emitted.length - 1]).toEqual([
-        [
-          new Date(today.getFullYear(), today.getMonth() - 1, 1),
-          new Date(today.getFullYear(), today.getMonth(), 0)
-        ]
-      ])
-    })
-
-    it('updates the display text when an option is selected', async () => {
-      const wrapper = mountComponent()
-      await nextTick()
-
-      await openDropdown(wrapper)
-      await wrapper.findAll('li')[1].trigger('click')
-      await nextTick()
-
-      const previousMonth = new Date(
-        new Date().getFullYear(),
-        new Date().getMonth() - 1
-      ).toLocaleString('default', { month: 'long' })
-      expect(wrapper.find('span').text()).toContain(previousMonth)
-    })
+  it('drives the shared picker in range mode with a prefixed storage key', () => {
+    const wrapper = mountComponent()
+    expect(picker(wrapper).props('mode')).toBe('range')
+    expect(picker(wrapper).props('storageKey')).toBe(`transaction-history-range-${PREFIX}`)
   })
 
-  describe('modelValue prop change', () => {
-    it('updates the display text when the modelValue prop changes', async () => {
-      const wrapper = mountComponent()
-      await wrapper.setProps({ modelValue: [new Date('2024-02-01'), new Date('2024-02-29')] })
-      await nextTick()
-
-      const month = new Date('2024-02-01').toLocaleString('default', { month: 'long' })
-      expect(wrapper.find('span').text()).toBe(`${month} 1 - ${month} 29`)
-    })
-
-    it('emits the new range when modelValue prop changes', async () => {
-      const wrapper = mountComponent()
-      await nextTick()
-      const initialEmitCount = wrapper.emitted('update:modelValue')?.length ?? 0
-
-      const newRange: [Date, Date] = [new Date('2024-02-01'), new Date('2024-02-29')]
-      await wrapper.setProps({ modelValue: newRange })
-      await nextTick()
-
-      const emitted = wrapper.emitted('update:modelValue')!
-      expect(emitted.length).toBeGreaterThan(initialEmitCount)
-      expect(emitted[emitted.length - 1]).toEqual([newRange])
-    })
+  it('seeds the picker from an incoming tuple', () => {
+    const start = new Date('2024-04-01')
+    const end = new Date('2024-04-30')
+    const wrapper = mountComponent([start, end])
+    expect(picker(wrapper).props('modelValue')).toEqual({ start, end })
   })
 
-  describe('custom range modal', () => {
-    it('shows the custom range option in the dropdown when open', async () => {
-      const wrapper = mountComponent()
-      await openDropdown(wrapper)
+  it('starts with no model when no tuple is provided', () => {
+    const wrapper = mountComponent()
+    expect(picker(wrapper).props('modelValue')).toBeUndefined()
+  })
 
-      expect(wrapper.find('.cursor-pointer').text()).toBe('Custom Range')
-    })
+  it('re-emits a resolved range as a [start, end] tuple', async () => {
+    const wrapper = mountComponent()
+    const start = new Date('2024-03-01')
+    const end = new Date('2024-03-31')
 
-    it('opens the modal when "Custom Range" is clicked', async () => {
-      const wrapper = mountComponent()
-      await openCustomRangeModal(wrapper)
+    await picker(wrapper).vm.$emit('update:modelValue', { start, end })
 
-      expect(wrapper.find('[data-test="u-modal"]').exists()).toBe(true)
-    })
+    const emitted = wrapper.emitted('update:modelValue')!
+    expect(emitted[emitted.length - 1]).toEqual([[start, end]])
+  })
 
-    it('closes the dropdown when "Custom Range" is clicked', async () => {
-      const wrapper = mountComponent()
-      await openCustomRangeModal(wrapper)
-
-      expect(wrapper.findAll('li')).toHaveLength(0)
-    })
-
-    it('emits the selected range when Apply is clicked', async () => {
-      const wrapper = mountComponent()
-      await openCustomRangeModal(wrapper)
-
-      await wrapper.findComponent({ name: 'UCalendar' }).vm.$emit('update:modelValue', {
-        start: new CalendarDate(2024, 3, 1),
-        end: new CalendarDate(2024, 3, 31)
-      })
-      await nextTick()
-
-      await wrapper
-        .findAll('button')
-        .find((b) => b.text() === 'Apply')!
-        .trigger('click')
-      await nextTick()
-
-      const emitted = wrapper.emitted('update:modelValue')!
-      expect(emitted[emitted.length - 1]).toEqual([[new Date(2024, 2, 1), new Date(2024, 2, 31)]])
-    })
-
-    it('closes the modal when Apply is clicked', async () => {
-      const wrapper = mountComponent()
-      await openCustomRangeModal(wrapper)
-
-      await wrapper.findComponent({ name: 'UCalendar' }).vm.$emit('update:modelValue', {
-        start: new CalendarDate(2024, 3, 1),
-        end: new CalendarDate(2024, 3, 31)
-      })
-      await nextTick()
-
-      await wrapper
-        .findAll('button')
-        .find((b) => b.text() === 'Apply')!
-        .trigger('click')
-      await nextTick()
-
-      expect(wrapper.find('[data-test="u-modal"]').exists()).toBe(false)
-    })
-
-    it('closes the modal without emitting when Cancel is clicked', async () => {
-      const wrapper = mountComponent()
-      await openCustomRangeModal(wrapper)
-      const emitCountBeforeCancel = wrapper.emitted('update:modelValue')?.length ?? 0
-
-      await wrapper
-        .findAll('button')
-        .find((b) => b.text() === 'Cancel')!
-        .trigger('click')
-      await nextTick()
-
-      expect(wrapper.find('[data-test="u-modal"]').exists()).toBe(false)
-      expect(wrapper.emitted('update:modelValue')?.length ?? 0).toBe(emitCountBeforeCancel)
-    })
-
-    it('opens modal with prefilled calendar range when an existing range is present', async () => {
-      const wrapper = mountComponent([new Date('2024-04-01'), new Date('2024-04-30')])
-      await openCustomRangeModal(wrapper)
-
-      const applyButton = wrapper.findAll('button').find((b) => b.text() === 'Apply')!
-      expect(applyButton.attributes('disabled')).toBeUndefined()
-    })
-
-    it('keeps Apply enabled with prefilled range and after calendar selection', async () => {
-      const wrapper = mountComponent()
-      await openCustomRangeModal(wrapper)
-
-      const applyButton = wrapper.findAll('button').find((b) => b.text() === 'Apply')!
-      expect(applyButton.attributes('disabled')).toBeUndefined()
-
-      await wrapper.findComponent({ name: 'UCalendar' }).vm.$emit('update:modelValue', {
-        start: new CalendarDate(2024, 3, 1),
-        end: new CalendarDate(2024, 3, 31)
-      })
-      await nextTick()
-
-      expect(applyButton.attributes('disabled')).toBeUndefined()
-    })
-
-    it('handles a null modelValue update without emitting a new range', async () => {
-      const wrapper = mountComponent([new Date('2024-03-01'), new Date('2024-03-31')])
-      await nextTick()
-      const emitCountBefore = wrapper.emitted('update:modelValue')?.length ?? 0
-
-      await wrapper.setProps({ modelValue: null })
-      await nextTick()
-
-      expect(wrapper.emitted('update:modelValue')?.length ?? 0).toBe(emitCountBefore)
-    })
+  it('ignores a single Date value (date mode is not used here)', async () => {
+    const wrapper = mountComponent()
+    await picker(wrapper).vm.$emit('update:modelValue', new Date('2024-03-01'))
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
   })
 })


### PR DESCRIPTION
## What

Wires the transaction-history date filter to the already-ported `AccountingDatePicker` (range mode), replacing the simple month-select `CustomDatePicker` behaviour across all transaction tables (Expense, Bank, Cash Remuneration, Investors).

`CustomDatePicker` becomes a thin adapter over `AccountingDatePicker`:
- keeps the legacy `v-model: [Date, Date] | null` + `dataTestPrefix` contract → the four tables, their test stubs and `useTransactionTable` are untouched;
- defaults to **All time** (every transaction shown on load);
- persists each table's selection under a `dataTestPrefix`-scoped localStorage key.

## Why

The dashboard date picker was already ported into `app/` with the accounting section, but the transaction tables still used the old picker. This reuses it so users get presets (All time / Month / Quarter / Year) with ◀/▶ steppers and a two-month custom-range calendar.

## Notes
- Net diff is small (`CustomDatePicker.vue` + its spec); the picker logic itself already lives on `develop`.
- The adapter keeps the tuple contract intentionally, to avoid churning every consumer and its fixtures.

## Testing
- `vitest`: adapter spec rewritten; the four transaction-table specs stay green (37 tests).
- `type-check`, `eslint`, `build-only` pass.

Closes #2179