### PR TITLE
fix: 🐛 hide pagination controls when only one page

### DIFF
--- a/app/src/components/TablePagination.vue
+++ b/app/src/components/TablePagination.vue
@@ -22,6 +22,7 @@
     </div>
 
     <UPagination
+      v-if="pageCount > 1"
       :page="page"
       :items-per-page="pageSize"
       :total="total"
@@ -45,7 +46,8 @@ import { computed } from 'vue'
  * disabled boundary states handled by `UPagination`). Both `page` and `pageSize`
  * are v-model bindings; this component is purely presentational and emits the raw
  * user intent — resize anchoring (which page to land on when the size changes) is
- * decided by the owner (see `usePagination`). Renders nothing when `total` is 0.
+ * decided by the owner (see `usePagination`). Renders nothing when `total` is 0,
+ * and the page control is hidden when everything fits on a single page.
  */
 const props = withDefaults(
   defineProps<{
@@ -72,6 +74,7 @@ const PAGE_SIZE_OPTIONS = [10, 20, 50, 100]
 
 const rangeStart = computed(() => (props.total === 0 ? 0 : (props.page - 1) * props.pageSize + 1))
 const rangeEnd = computed(() => Math.min(props.page * props.pageSize, props.total))
+const pageCount = computed(() => Math.ceil(props.total / props.pageSize))
 
 function onPageSizeChange(value: number): void {
   emit('update:pageSize', value)


### PR DESCRIPTION
# Description

## Intial Issue Description

Fixes #2181

In the transaction history (and other tables using the shared `TablePagination` component), the pagination controls — first/prev/next/last arrows and the page-number button — were always rendered, even when all rows fit on a single page (e.g. "Showing 1–10 of 10"). On a single page these controls are inert and add visual noise.

## PR Summary Or Solution description

Gate the `UPagination` control behind a new `pageCount > 1` computed in `app/src/components/TablePagination.vue`. When there is only one page, the page control is hidden while the "Showing X–Y of Z" summary line and the page-size selector remain visible. The component already rendered nothing when `total === 0`; this extends that to the single-page case.

Because the change lives in the shared `TablePagination` component, it applies everywhere it's used (bank transactions, claims, etc.), not just the transaction history view.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)