### PR TITLE
feat: ✨ constrain page content width on large screens

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -33,7 +33,9 @@
               </template>
 
               <template #body>
-                <RouterView />
+                <UContainer :ui="{ base: 'px-0 sm:px-0 lg:px-0' }">
+                  <RouterView />
+                </UContainer>
               </template>
             </UDashboardPanel>
           </UDashboardGroup>


### PR DESCRIPTION
## What

Wrap the routed page content in `app/src/App.vue` with a Nuxt UI `UContainer` so pages are centered and capped at the default max width (80rem) on wide viewports.

## Why

Page content previously stretched to the full `UDashboardPanel` width, becoming hard to read on large screens.

## Notes

- Single insertion point: the `UContainer` wraps `<RouterView />` in the panel body, so every routed page is covered.
- `px-0` overrides the container's default horizontal padding, since the panel body already provides `p-4 sm:p-6` — avoids doubled gutters.
- No visible change below ~1280px of content width (full-width as before); the cap only kicks in on wider screens.

Closes #2183