### PR TITLE
[Feat] add My Offerings management dashboard for issued offerings

### DIFF
--- a/app/src/components/sections/FixedReturnView/AdminDashboard.vue
+++ b/app/src/components/sections/FixedReturnView/AdminDashboard.vue
@@ -1,0 +1,13 @@
+<template>
+  <OfferingDetail v-if="selectedOffering" :offering="selectedOffering" @back="selectedOffering = null" />
+  <OfferingsList v-else @manage="selectedOffering = $event" />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import OfferingsList from './OfferingsList.vue'
+import OfferingDetail from './OfferingDetail.vue'
+import type { OfferingSummary } from './offeringForm'
+
+const selectedOffering = ref<OfferingSummary | null>(null)
+</script>

--- a/app/src/components/sections/FixedReturnView/AdminDashboard.vue
+++ b/app/src/components/sections/FixedReturnView/AdminDashboard.vue
@@ -1,5 +1,9 @@
 <template>
-  <OfferingDetail v-if="selectedOffering" :offering="selectedOffering" @back="selectedOffering = null" />
+  <OfferingDetail
+    v-if="selectedOffering"
+    :offering="selectedOffering"
+    @back="selectedOffering = null"
+  />
   <OfferingsList v-else @manage="selectedOffering = $event" />
 </template>
 

--- a/app/src/components/sections/FixedReturnView/CreateOfferingForm.vue
+++ b/app/src/components/sections/FixedReturnView/CreateOfferingForm.vue
@@ -71,7 +71,8 @@ import StepIndicator from './StepIndicator.vue'
 import OfferingBasicsStep from './OfferingBasicsStep.vue'
 import OfferingTermsStep from './OfferingTermsStep.vue'
 import OfferingAccessStep from './OfferingAccessStep.vue'
-import { fmtDate, addTerm, termLabel, type OfferingForm } from './offeringForm'
+import { expectedReturn, formatOfferingDate, maturityLabel, termLabel } from '@/utils'
+import type { OfferingForm, WhitelistEntry } from '@/types'
 import { SUPPORTED_TOKENS } from '@/constant'
 
 const emit = defineEmits<{ close: [] }>()
@@ -120,13 +121,13 @@ const form = reactive<OfferingForm>({
   token: SUPPORTED_TOKENS[0]?.symbol
 })
 
-const whitelist = ref([
-  { username: '@liangw', address: '0x4D21…A8e1', amount: 30000 as number | null },
-  { username: '@priyan', address: '0xB1f7…3D92', amount: null as number | null }
+const whitelist = ref<WhitelistEntry[]>([
+  { username: '@liangw', address: '0x4D21…A8e1', amount: 30000 },
+  { username: '@priyan', address: '0xB1f7…3D92', amount: null }
 ])
 
-const totalInterest = computed(() => form.principal * (form.rate / 100))
-const totalReturn = computed(() => form.principal + totalInterest.value)
+const totalReturn = computed(() => expectedReturn(form.principal, form.rate))
+const totalInterest = computed(() => totalReturn.value - form.principal)
 
 const defaultAmountLabel = computed(() =>
   form.capOn ? `${Math.round(form.cap).toLocaleString('en-US')} ${form.token}` : 'No cap'
@@ -141,12 +142,8 @@ const accessLabel = computed(() =>
 )
 const accessDot = computed(() => (form.access === 'whitelist' ? '#3366ff' : '#00bf7a'))
 
-const startFmt = computed(() => fmtDate(form.startDate))
-const maturityFmt = computed(() => {
-  const d = new Date(form.startDate + 'T00:00:00')
-  if (isNaN(d.getTime())) return '—'
-  return fmtDate(addTerm(d, form.termValue, form.termUnit).toISOString().slice(0, 10))
-})
+const startFmt = computed(() => formatOfferingDate(form.startDate))
+const maturityFmt = computed(() => maturityLabel(form.startDate, form.termValue, form.termUnit))
 
 function addWhitelist(username: string, address: string, amount: number | null) {
   whitelist.value.push({ username, address, amount })

--- a/app/src/components/sections/FixedReturnView/OfferingAccessStep.vue
+++ b/app/src/components/sections/FixedReturnView/OfferingAccessStep.vue
@@ -70,13 +70,13 @@
 import { ref, computed } from 'vue'
 import { z } from 'zod'
 import WhitelistEditor from './WhitelistEditor.vue'
-import type { OfferingForm } from './offeringForm'
-import { pickerClass, sumWhitelistAmount } from './offeringForm'
+import type { OfferingForm, WhitelistEntry } from '@/types'
+import { pickerClass, sumWhitelistAmount } from '@/utils'
 
 const form = defineModel<OfferingForm>('form', { required: true })
 
 const props = defineProps<{
-  whitelist: { username: string; address: string; amount: number | null }[]
+  whitelist: WhitelistEntry[]
   defaultAmountLabel: string
 }>()
 

--- a/app/src/components/sections/FixedReturnView/OfferingBasicsStep.vue
+++ b/app/src/components/sections/FixedReturnView/OfferingBasicsStep.vue
@@ -55,7 +55,7 @@
 import { ref, computed } from 'vue'
 import { z } from 'zod'
 import { SUPPORTED_TOKENS } from '@/constant'
-import type { OfferingForm } from './offeringForm'
+import type { OfferingForm } from '@/types'
 
 const form = defineModel<OfferingForm>('form', { required: true })
 

--- a/app/src/components/sections/FixedReturnView/OfferingDetail.vue
+++ b/app/src/components/sections/FixedReturnView/OfferingDetail.vue
@@ -1,0 +1,198 @@
+<template>
+  <div class="flex flex-col gap-6">
+
+    <UButton
+      size="sm"
+      variant="ghost"
+      icon="heroicons:arrow-left"
+      label="Back to offerings"
+      data-test="offering-detail-back-button"
+      @click="$emit('back')"
+    />
+
+    <div class="flex items-center justify-between">
+      <div class="text-xl font-extrabold text-[#0f3d2e] tracking-tight">{{ offering.title }}</div>
+      <StatusBadge :status="offering.status" />
+    </div>
+
+    <!-- Funding / repayment gauges -->
+    <div class="grid grid-cols-2 gap-4">
+      <UCard>
+        <template #header>
+          <div class="text-base font-extrabold text-[#0f3d2e]">Funding progress</div>
+          <div class="text-xs text-[#9aaba2] mt-0.5">How much of the target this offering has raised from lenders.</div>
+        </template>
+        <div class="flex flex-col items-center text-center gap-0.5">
+          <ProgressGauge :percent="fundingPct" label="funded" :size="100" />
+          <div class="text-base font-extrabold text-[#0f3d2e] mt-2">{{ moneyFmt(offering.raised) }}</div>
+          <div class="text-xs text-[#9aaba2]">raised of {{ moneyFmt(offering.target) }}</div>
+          <div v-if="offering.target > offering.raised" class="text-xs font-semibold text-[#0a7a52] mt-0.5">
+            {{ moneyFmt(offering.target - offering.raised) }} remaining
+          </div>
+        </div>
+      </UCard>
+      <UCard>
+        <template #header>
+          <div class="text-base font-extrabold text-[#0f3d2e]">Repayment progress</div>
+          <div class="text-xs text-[#9aaba2] mt-0.5">How much of the total bullet repayment has been paid back to lenders.</div>
+        </template>
+        <div class="flex flex-col items-center text-center gap-0.5">
+          <ProgressGauge :percent="repaymentPct" label="repaid" :size="100" />
+          <div class="text-base font-extrabold text-[#0f3d2e] mt-2">{{ moneyFmt(totalPaid) }}</div>
+          <div class="text-xs text-[#9aaba2]">repaid of {{ moneyFmt(totalExpected) }}</div>
+          <div v-if="totalExpected > totalPaid" class="text-xs font-semibold text-[#0a7a52] mt-0.5">
+            {{ moneyFmt(totalExpected - totalPaid) }} remaining
+          </div>
+        </div>
+      </UCard>
+    </div>
+
+    <!-- Stat cards -->
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <UCard v-for="stat in statCards" :key="stat.label">
+        <div class="flex items-center gap-3 mb-3">
+          <div class="w-10 h-10 rounded-xl flex items-center justify-center flex-none" :style="{ background: stat.iconBg, color: stat.iconColor }">
+            <UIcon :name="stat.icon" class="size-5" />
+          </div>
+          <span class="text-sm text-[#7d8e84] font-semibold">{{ stat.label }}</span>
+        </div>
+        <div class="text-2xl font-extrabold tracking-tight text-[#0f3d2e]">{{ stat.value }}</div>
+      </UCard>
+    </div>
+
+    <!-- Lenders -->
+    <UCard :ui="{ body: 'p-0' }">
+      <template #header>
+        <div class="flex items-center justify-between">
+          <div class="text-base font-extrabold text-[#0f3d2e]">
+            Lenders <span class="text-sm font-semibold text-[#9aaba2]">· {{ partners.length }}</span>
+          </div>
+          <div class="flex items-center gap-2 h-9 px-3 border border-[#e0eae5] rounded-xl text-sm text-[#7d8e84] w-56">
+            <UIcon name="heroicons:magnifying-glass" class="size-4 flex-none" />
+            <span>Search lenders…</span>
+          </div>
+        </div>
+      </template>
+      <div class="overflow-x-auto">
+        <table class="w-full border-collapse" style="min-width: 820px">
+          <thead>
+            <tr class="bg-[#f7faf8]">
+              <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-5 py-3">Lender</th>
+              <th class="text-right text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Principal</th>
+              <th class="text-right text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Rate</th>
+              <th class="text-right text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Expected return</th>
+              <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Paid to date</th>
+              <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Maturity</th>
+              <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-5 py-3">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="p in partners"
+              :key="p.address"
+              class="border-t border-[#f0f4f1] hover:bg-[#f7fbf9] transition-colors"
+            >
+              <td class="px-5 py-4">
+                <UserComponent :user="{ address: p.address, name: p.name }" class="flex-1 min-w-0" />
+              </td>
+              <td class="px-4 py-4 text-right text-sm font-bold text-[#0f3d2e] whitespace-nowrap">{{ p.principalFmt }}</td>
+              <td class="px-4 py-4 text-right text-sm font-semibold text-[#0f3d2e] whitespace-nowrap">{{ p.rateFmt }}</td>
+              <td class="px-4 py-4 text-right text-sm font-bold text-[#0f3d2e] whitespace-nowrap">{{ p.expectedFmt }}</td>
+              <td class="px-4 py-4" style="min-width: 150px">
+                <div class="flex justify-between text-sm font-semibold mb-1.5">
+                  <span>{{ p.paidFmt }}</span>
+                  <span class="text-[#9aaba2]">{{ p.pctLabel }}</span>
+                </div>
+                <div class="h-1.5 rounded-full bg-[#eef3f0] overflow-hidden">
+                  <div class="h-full rounded-full" :style="{ width: p.pctWidth, background: p.barColor }"></div>
+                </div>
+              </td>
+              <td class="px-4 py-4 text-sm font-semibold text-[#0f3d2e] whitespace-nowrap">{{ p.maturityFmt }}</td>
+              <td class="px-5 py-4">
+                <StatusBadge :status="p.status" />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </UCard>
+
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import StatusBadge from './StatusBadge.vue'
+import UserComponent from '@/components/UserComponent.vue'
+import ProgressGauge from './ProgressGauge.vue'
+import { addTerm, fmtDate, money as moneyFmt, type OfferingSummary } from './offeringForm'
+
+const props = defineProps<{ offering: OfferingSummary }>()
+defineEmits<{ back: [] }>()
+
+type Status = 'overdue' | 'partial' | 'completed'
+
+// Bullet repayment: principal + interest repaid as one combined payment per lender,
+// due at the offering's maturity (start date + term) — no interim schedule.
+const maturityFmt = computed(() => {
+  const start = new Date(props.offering.startDate + 'T00:00:00')
+  return fmtDate(addTerm(start, props.offering.term, 'months').toISOString().slice(0, 10))
+})
+
+// paidRatio: 0–1 share of the bullet repayment settled so far. The admin can repay a
+// lender gradually rather than all at once, so this isn't just paid-or-not.
+const partnersRaw = [
+  { address: '0x7F3a…2B9c', name: 'Amara Okonkwo', principal: 50000, paidRatio: 1 },
+  { address: '0x4D21…A8e1', name: 'Liang Wei', principal: 120000, paidRatio: 1 },
+  { address: '0x9C56…11Fa', name: 'Sofia Marchetti', principal: 75000, paidRatio: 0 },
+  { address: '0x2E8b…7C40', name: 'Daniel Krause', principal: 30000, paidRatio: 1 },
+  { address: '0xB1f7…3D92', name: 'Priya Nair', principal: 200000, paidRatio: 0.45 },
+  { address: '0x6a09…E5Dd', name: 'Marcus Bell', principal: 45000, paidRatio: 0.7 },
+]
+
+function statusFor(paidRatio: number): Status {
+  if (paidRatio >= 1) return 'completed'
+  if (paidRatio <= 0) return 'overdue'
+  return 'partial'
+}
+
+const partners = computed(() =>
+  partnersRaw.map(p => {
+    const expected = p.principal * (1 + props.offering.rate / 100)
+    const paid = expected * p.paidRatio
+    const status = statusFor(p.paidRatio)
+    const pct = expected ? Math.min(100, Math.round((paid / expected) * 100)) : 0
+    const barColor = status === 'overdue' ? '#ff5630' : status === 'partial' ? '#ffab00' : '#00bf7a'
+    return {
+      name: p.name, address: p.address,
+      principalFmt: moneyFmt(p.principal), rateFmt: props.offering.rate.toFixed(1) + '%',
+      expectedFmt: moneyFmt(expected), paidFmt: moneyFmt(paid),
+      pctLabel: pct + '%', pctWidth: pct + '%', barColor,
+      maturityFmt: maturityFmt.value,
+      status,
+    }
+  })
+)
+
+const totalPrincipal = computed(() => partnersRaw.reduce((a, p) => a + p.principal, 0))
+const totalExpected = computed(() =>
+  partnersRaw.reduce((a, p) => a + p.principal * (1 + props.offering.rate / 100), 0)
+)
+const totalPaid = computed(() =>
+  partnersRaw.reduce((a, p) => a + p.principal * (1 + props.offering.rate / 100) * p.paidRatio, 0)
+)
+
+const fundingPct = computed(() =>
+  props.offering.target ? (props.offering.raised / props.offering.target) * 100 : 0
+)
+const repaymentPct = computed(() =>
+  totalExpected.value ? (totalPaid.value / totalExpected.value) * 100 : 0
+)
+
+const statCards = computed(() => [
+  { label: 'Total principal lent', value: moneyFmt(totalPrincipal.value), icon: 'heroicons:credit-card', iconBg: '#ebf0ff', iconColor: '#3366ff' },
+  { label: 'Total expected return', value: moneyFmt(totalExpected.value), icon: 'heroicons:arrow-trending-up', iconBg: '#e6f8f1', iconColor: '#00a86c' },
+  { label: 'Outstanding balance', value: moneyFmt(totalExpected.value - totalPaid.value), icon: 'heroicons:clock', iconBg: '#fff6e0', iconColor: '#cc8a00' },
+  { label: 'Overdue lenders', value: String(partnersRaw.filter(p => p.paidRatio <= 0).length), icon: 'heroicons:exclamation-triangle', iconBg: '#ffe9e3', iconColor: '#d6431f' },
+])
+</script>

--- a/app/src/components/sections/FixedReturnView/OfferingDetail.vue
+++ b/app/src/components/sections/FixedReturnView/OfferingDetail.vue
@@ -182,7 +182,9 @@ import { computed } from 'vue'
 import StatusBadge from './StatusBadge.vue'
 import UserComponent from '@/components/UserComponent.vue'
 import ProgressGauge from './ProgressGauge.vue'
-import { addTerm, fmtDate, money as moneyFmt, type OfferingSummary } from './offeringForm'
+import { expectedReturn, maturityLabel, percentOf } from '@/utils'
+import { money as moneyFmt } from '@/utils/accountingDemo'
+import type { OfferingSummary } from '@/types'
 
 const props = defineProps<{ offering: OfferingSummary }>()
 defineEmits<{ back: [] }>()
@@ -191,10 +193,9 @@ type Status = 'overdue' | 'partial' | 'completed'
 
 // Bullet repayment: principal + interest repaid as one combined payment per lender,
 // due at the offering's maturity (start date + term) — no interim schedule.
-const maturityFmt = computed(() => {
-  const start = new Date(props.offering.startDate + 'T00:00:00')
-  return fmtDate(addTerm(start, props.offering.term, 'months').toISOString().slice(0, 10))
-})
+const maturityFmt = computed(() =>
+  maturityLabel(props.offering.startDate, props.offering.term, 'months')
+)
 
 // paidRatio: 0–1 share of the bullet repayment settled so far. The admin can repay a
 // lender gradually rather than all at once, so this isn't just paid-or-not.
@@ -215,10 +216,10 @@ function statusFor(paidRatio: number): Status {
 
 const partners = computed(() =>
   partnersRaw.map((p) => {
-    const expected = p.principal * (1 + props.offering.rate / 100)
+    const expected = expectedReturn(p.principal, props.offering.rate)
     const paid = expected * p.paidRatio
     const status = statusFor(p.paidRatio)
-    const pct = expected ? Math.min(100, Math.round((paid / expected) * 100)) : 0
+    const pct = percentOf(paid, expected)
     const barColor = status === 'overdue' ? '#ff5630' : status === 'partial' ? '#ffab00' : '#00bf7a'
     return {
       name: p.name,
@@ -238,18 +239,17 @@ const partners = computed(() =>
 
 const totalPrincipal = computed(() => partnersRaw.reduce((a, p) => a + p.principal, 0))
 const totalExpected = computed(() =>
-  partnersRaw.reduce((a, p) => a + p.principal * (1 + props.offering.rate / 100), 0)
+  partnersRaw.reduce((a, p) => a + expectedReturn(p.principal, props.offering.rate), 0)
 )
 const totalPaid = computed(() =>
-  partnersRaw.reduce((a, p) => a + p.principal * (1 + props.offering.rate / 100) * p.paidRatio, 0)
+  partnersRaw.reduce(
+    (a, p) => a + expectedReturn(p.principal, props.offering.rate) * p.paidRatio,
+    0
+  )
 )
 
-const fundingPct = computed(() =>
-  props.offering.target ? (props.offering.raised / props.offering.target) * 100 : 0
-)
-const repaymentPct = computed(() =>
-  totalExpected.value ? (totalPaid.value / totalExpected.value) * 100 : 0
-)
+const fundingPct = computed(() => percentOf(props.offering.raised, props.offering.target))
+const repaymentPct = computed(() => percentOf(totalPaid.value, totalExpected.value))
 
 const statCards = computed(() => [
   {

--- a/app/src/components/sections/FixedReturnView/OfferingDetail.vue
+++ b/app/src/components/sections/FixedReturnView/OfferingDetail.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="flex flex-col gap-6">
-
     <UButton
       size="sm"
       variant="ghost"
@@ -11,7 +10,7 @@
     />
 
     <div class="flex items-center justify-between">
-      <div class="text-xl font-extrabold text-[#0f3d2e] tracking-tight">{{ offering.title }}</div>
+      <div class="text-xl font-extrabold tracking-tight text-[#0f3d2e]">{{ offering.title }}</div>
       <StatusBadge :status="offering.status" />
     </div>
 
@@ -20,13 +19,20 @@
       <UCard>
         <template #header>
           <div class="text-base font-extrabold text-[#0f3d2e]">Funding progress</div>
-          <div class="text-xs text-[#9aaba2] mt-0.5">How much of the target this offering has raised from lenders.</div>
+          <div class="mt-0.5 text-xs text-[#9aaba2]">
+            How much of the target this offering has raised from lenders.
+          </div>
         </template>
-        <div class="flex flex-col items-center text-center gap-0.5">
+        <div class="flex flex-col items-center gap-0.5 text-center">
           <ProgressGauge :percent="fundingPct" label="funded" :size="100" />
-          <div class="text-base font-extrabold text-[#0f3d2e] mt-2">{{ moneyFmt(offering.raised) }}</div>
+          <div class="mt-2 text-base font-extrabold text-[#0f3d2e]">
+            {{ moneyFmt(offering.raised) }}
+          </div>
           <div class="text-xs text-[#9aaba2]">raised of {{ moneyFmt(offering.target) }}</div>
-          <div v-if="offering.target > offering.raised" class="text-xs font-semibold text-[#0a7a52] mt-0.5">
+          <div
+            v-if="offering.target > offering.raised"
+            class="mt-0.5 text-xs font-semibold text-[#0a7a52]"
+          >
             {{ moneyFmt(offering.target - offering.raised) }} remaining
           </div>
         </div>
@@ -34,13 +40,15 @@
       <UCard>
         <template #header>
           <div class="text-base font-extrabold text-[#0f3d2e]">Repayment progress</div>
-          <div class="text-xs text-[#9aaba2] mt-0.5">How much of the total bullet repayment has been paid back to lenders.</div>
+          <div class="mt-0.5 text-xs text-[#9aaba2]">
+            How much of the total bullet repayment has been paid back to lenders.
+          </div>
         </template>
-        <div class="flex flex-col items-center text-center gap-0.5">
+        <div class="flex flex-col items-center gap-0.5 text-center">
           <ProgressGauge :percent="repaymentPct" label="repaid" :size="100" />
-          <div class="text-base font-extrabold text-[#0f3d2e] mt-2">{{ moneyFmt(totalPaid) }}</div>
+          <div class="mt-2 text-base font-extrabold text-[#0f3d2e]">{{ moneyFmt(totalPaid) }}</div>
           <div class="text-xs text-[#9aaba2]">repaid of {{ moneyFmt(totalExpected) }}</div>
-          <div v-if="totalExpected > totalPaid" class="text-xs font-semibold text-[#0a7a52] mt-0.5">
+          <div v-if="totalExpected > totalPaid" class="mt-0.5 text-xs font-semibold text-[#0a7a52]">
             {{ moneyFmt(totalExpected - totalPaid) }} remaining
           </div>
         </div>
@@ -48,13 +56,16 @@
     </div>
 
     <!-- Stat cards -->
-    <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+    <div class="grid grid-cols-2 gap-4 lg:grid-cols-4">
       <UCard v-for="stat in statCards" :key="stat.label">
-        <div class="flex items-center gap-3 mb-3">
-          <div class="w-10 h-10 rounded-xl flex items-center justify-center flex-none" :style="{ background: stat.iconBg, color: stat.iconColor }">
+        <div class="mb-3 flex items-center gap-3">
+          <div
+            class="flex h-10 w-10 flex-none items-center justify-center rounded-xl"
+            :style="{ background: stat.iconBg, color: stat.iconColor }"
+          >
             <UIcon :name="stat.icon" class="size-5" />
           </div>
-          <span class="text-sm text-[#7d8e84] font-semibold">{{ stat.label }}</span>
+          <span class="text-sm font-semibold text-[#7d8e84]">{{ stat.label }}</span>
         </div>
         <div class="text-2xl font-extrabold tracking-tight text-[#0f3d2e]">{{ stat.value }}</div>
       </UCard>
@@ -65,9 +76,12 @@
       <template #header>
         <div class="flex items-center justify-between">
           <div class="text-base font-extrabold text-[#0f3d2e]">
-            Lenders <span class="text-sm font-semibold text-[#9aaba2]">· {{ partners.length }}</span>
+            Lenders
+            <span class="text-sm font-semibold text-[#9aaba2]">· {{ partners.length }}</span>
           </div>
-          <div class="flex items-center gap-2 h-9 px-3 border border-[#e0eae5] rounded-xl text-sm text-[#7d8e84] w-56">
+          <div
+            class="flex h-9 w-56 items-center gap-2 rounded-xl border border-[#e0eae5] px-3 text-sm text-[#7d8e84]"
+          >
             <UIcon name="heroicons:magnifying-glass" class="size-4 flex-none" />
             <span>Search lenders…</span>
           </div>
@@ -77,37 +91,81 @@
         <table class="w-full border-collapse" style="min-width: 820px">
           <thead>
             <tr class="bg-[#f7faf8]">
-              <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-5 py-3">Lender</th>
-              <th class="text-right text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Principal</th>
-              <th class="text-right text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Rate</th>
-              <th class="text-right text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Expected return</th>
-              <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Paid to date</th>
-              <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Maturity</th>
-              <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-5 py-3">Status</th>
+              <th
+                class="px-5 py-3 text-left text-xs font-bold tracking-wide text-[#81948a] uppercase"
+              >
+                Lender
+              </th>
+              <th
+                class="px-4 py-3 text-right text-xs font-bold tracking-wide text-[#81948a] uppercase"
+              >
+                Principal
+              </th>
+              <th
+                class="px-4 py-3 text-right text-xs font-bold tracking-wide text-[#81948a] uppercase"
+              >
+                Rate
+              </th>
+              <th
+                class="px-4 py-3 text-right text-xs font-bold tracking-wide text-[#81948a] uppercase"
+              >
+                Expected return
+              </th>
+              <th
+                class="px-4 py-3 text-left text-xs font-bold tracking-wide text-[#81948a] uppercase"
+              >
+                Paid to date
+              </th>
+              <th
+                class="px-4 py-3 text-left text-xs font-bold tracking-wide text-[#81948a] uppercase"
+              >
+                Maturity
+              </th>
+              <th
+                class="px-5 py-3 text-left text-xs font-bold tracking-wide text-[#81948a] uppercase"
+              >
+                Status
+              </th>
             </tr>
           </thead>
           <tbody>
             <tr
               v-for="p in partners"
               :key="p.address"
-              class="border-t border-[#f0f4f1] hover:bg-[#f7fbf9] transition-colors"
+              class="border-t border-[#f0f4f1] transition-colors hover:bg-[#f7fbf9]"
             >
               <td class="px-5 py-4">
-                <UserComponent :user="{ address: p.address, name: p.name }" class="flex-1 min-w-0" />
+                <UserComponent
+                  :user="{ address: p.address, name: p.name }"
+                  class="min-w-0 flex-1"
+                />
               </td>
-              <td class="px-4 py-4 text-right text-sm font-bold text-[#0f3d2e] whitespace-nowrap">{{ p.principalFmt }}</td>
-              <td class="px-4 py-4 text-right text-sm font-semibold text-[#0f3d2e] whitespace-nowrap">{{ p.rateFmt }}</td>
-              <td class="px-4 py-4 text-right text-sm font-bold text-[#0f3d2e] whitespace-nowrap">{{ p.expectedFmt }}</td>
+              <td class="px-4 py-4 text-right text-sm font-bold whitespace-nowrap text-[#0f3d2e]">
+                {{ p.principalFmt }}
+              </td>
+              <td
+                class="px-4 py-4 text-right text-sm font-semibold whitespace-nowrap text-[#0f3d2e]"
+              >
+                {{ p.rateFmt }}
+              </td>
+              <td class="px-4 py-4 text-right text-sm font-bold whitespace-nowrap text-[#0f3d2e]">
+                {{ p.expectedFmt }}
+              </td>
               <td class="px-4 py-4" style="min-width: 150px">
-                <div class="flex justify-between text-sm font-semibold mb-1.5">
+                <div class="mb-1.5 flex justify-between text-sm font-semibold">
                   <span>{{ p.paidFmt }}</span>
                   <span class="text-[#9aaba2]">{{ p.pctLabel }}</span>
                 </div>
-                <div class="h-1.5 rounded-full bg-[#eef3f0] overflow-hidden">
-                  <div class="h-full rounded-full" :style="{ width: p.pctWidth, background: p.barColor }"></div>
+                <div class="h-1.5 overflow-hidden rounded-full bg-[#eef3f0]">
+                  <div
+                    class="h-full rounded-full"
+                    :style="{ width: p.pctWidth, background: p.barColor }"
+                  ></div>
                 </div>
               </td>
-              <td class="px-4 py-4 text-sm font-semibold text-[#0f3d2e] whitespace-nowrap">{{ p.maturityFmt }}</td>
+              <td class="px-4 py-4 text-sm font-semibold whitespace-nowrap text-[#0f3d2e]">
+                {{ p.maturityFmt }}
+              </td>
               <td class="px-5 py-4">
                 <StatusBadge :status="p.status" />
               </td>
@@ -116,7 +174,6 @@
         </table>
       </div>
     </UCard>
-
   </div>
 </template>
 
@@ -147,7 +204,7 @@ const partnersRaw = [
   { address: '0x9C56…11Fa', name: 'Sofia Marchetti', principal: 75000, paidRatio: 0 },
   { address: '0x2E8b…7C40', name: 'Daniel Krause', principal: 30000, paidRatio: 1 },
   { address: '0xB1f7…3D92', name: 'Priya Nair', principal: 200000, paidRatio: 0.45 },
-  { address: '0x6a09…E5Dd', name: 'Marcus Bell', principal: 45000, paidRatio: 0.7 },
+  { address: '0x6a09…E5Dd', name: 'Marcus Bell', principal: 45000, paidRatio: 0.7 }
 ]
 
 function statusFor(paidRatio: number): Status {
@@ -157,19 +214,24 @@ function statusFor(paidRatio: number): Status {
 }
 
 const partners = computed(() =>
-  partnersRaw.map(p => {
+  partnersRaw.map((p) => {
     const expected = p.principal * (1 + props.offering.rate / 100)
     const paid = expected * p.paidRatio
     const status = statusFor(p.paidRatio)
     const pct = expected ? Math.min(100, Math.round((paid / expected) * 100)) : 0
     const barColor = status === 'overdue' ? '#ff5630' : status === 'partial' ? '#ffab00' : '#00bf7a'
     return {
-      name: p.name, address: p.address,
-      principalFmt: moneyFmt(p.principal), rateFmt: props.offering.rate.toFixed(1) + '%',
-      expectedFmt: moneyFmt(expected), paidFmt: moneyFmt(paid),
-      pctLabel: pct + '%', pctWidth: pct + '%', barColor,
+      name: p.name,
+      address: p.address,
+      principalFmt: moneyFmt(p.principal),
+      rateFmt: props.offering.rate.toFixed(1) + '%',
+      expectedFmt: moneyFmt(expected),
+      paidFmt: moneyFmt(paid),
+      pctLabel: pct + '%',
+      pctWidth: pct + '%',
+      barColor,
       maturityFmt: maturityFmt.value,
-      status,
+      status
     }
   })
 )
@@ -190,9 +252,33 @@ const repaymentPct = computed(() =>
 )
 
 const statCards = computed(() => [
-  { label: 'Total principal lent', value: moneyFmt(totalPrincipal.value), icon: 'heroicons:credit-card', iconBg: '#ebf0ff', iconColor: '#3366ff' },
-  { label: 'Total expected return', value: moneyFmt(totalExpected.value), icon: 'heroicons:arrow-trending-up', iconBg: '#e6f8f1', iconColor: '#00a86c' },
-  { label: 'Outstanding balance', value: moneyFmt(totalExpected.value - totalPaid.value), icon: 'heroicons:clock', iconBg: '#fff6e0', iconColor: '#cc8a00' },
-  { label: 'Overdue lenders', value: String(partnersRaw.filter(p => p.paidRatio <= 0).length), icon: 'heroicons:exclamation-triangle', iconBg: '#ffe9e3', iconColor: '#d6431f' },
+  {
+    label: 'Total principal lent',
+    value: moneyFmt(totalPrincipal.value),
+    icon: 'heroicons:credit-card',
+    iconBg: '#ebf0ff',
+    iconColor: '#3366ff'
+  },
+  {
+    label: 'Total expected return',
+    value: moneyFmt(totalExpected.value),
+    icon: 'heroicons:arrow-trending-up',
+    iconBg: '#e6f8f1',
+    iconColor: '#00a86c'
+  },
+  {
+    label: 'Outstanding balance',
+    value: moneyFmt(totalExpected.value - totalPaid.value),
+    icon: 'heroicons:clock',
+    iconBg: '#fff6e0',
+    iconColor: '#cc8a00'
+  },
+  {
+    label: 'Overdue lenders',
+    value: String(partnersRaw.filter((p) => p.paidRatio <= 0).length),
+    icon: 'heroicons:exclamation-triangle',
+    iconBg: '#ffe9e3',
+    iconColor: '#d6431f'
+  }
 ])
 </script>

--- a/app/src/components/sections/FixedReturnView/OfferingSummaryCard.vue
+++ b/app/src/components/sections/FixedReturnView/OfferingSummaryCard.vue
@@ -76,7 +76,7 @@
 </template>
 
 <script setup lang="ts">
-import { moneyShort } from './offeringForm'
+import { moneyShort } from '@/utils'
 
 defineProps<{
   title: string

--- a/app/src/components/sections/FixedReturnView/OfferingTermsStep.vue
+++ b/app/src/components/sections/FixedReturnView/OfferingTermsStep.vue
@@ -126,8 +126,8 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { z } from 'zod'
-import type { OfferingForm, TermUnit } from './offeringForm'
-import { pickerClass } from './offeringForm'
+import type { OfferingForm, TermUnit } from '@/types'
+import { pickerClass } from '@/utils'
 
 const form = defineModel<OfferingForm>('form', { required: true })
 

--- a/app/src/components/sections/FixedReturnView/OfferingsDashboard.vue
+++ b/app/src/components/sections/FixedReturnView/OfferingsDashboard.vue
@@ -11,7 +11,7 @@
 import { ref } from 'vue'
 import OfferingsList from './OfferingsList.vue'
 import OfferingDetail from './OfferingDetail.vue'
-import type { OfferingSummary } from './offeringForm'
+import type { OfferingSummary } from '@/types'
 
 const selectedOffering = ref<OfferingSummary | null>(null)
 </script>

--- a/app/src/components/sections/FixedReturnView/OfferingsList.vue
+++ b/app/src/components/sections/FixedReturnView/OfferingsList.vue
@@ -9,13 +9,40 @@
       <table class="w-full border-collapse" style="min-width: 820px">
         <thead>
           <tr class="bg-[#f7faf8]">
-            <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-5 py-3">Offering</th>
-            <th class="text-right text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Rate</th>
-            <th class="text-right text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Term</th>
-            <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Access</th>
-            <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3" style="min-width: 180px">Raised</th>
-            <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Status</th>
-            <th class="text-right text-xs font-bold text-[#81948a] uppercase tracking-wide px-5 py-3"></th>
+            <th
+              class="px-5 py-3 text-left text-xs font-bold tracking-wide text-[#81948a] uppercase"
+            >
+              Offering
+            </th>
+            <th
+              class="px-4 py-3 text-right text-xs font-bold tracking-wide text-[#81948a] uppercase"
+            >
+              Rate
+            </th>
+            <th
+              class="px-4 py-3 text-right text-xs font-bold tracking-wide text-[#81948a] uppercase"
+            >
+              Term
+            </th>
+            <th
+              class="px-4 py-3 text-left text-xs font-bold tracking-wide text-[#81948a] uppercase"
+            >
+              Access
+            </th>
+            <th
+              class="px-4 py-3 text-left text-xs font-bold tracking-wide text-[#81948a] uppercase"
+              style="min-width: 180px"
+            >
+              Raised
+            </th>
+            <th
+              class="px-4 py-3 text-left text-xs font-bold tracking-wide text-[#81948a] uppercase"
+            >
+              Status
+            </th>
+            <th
+              class="px-5 py-3 text-right text-xs font-bold tracking-wide text-[#81948a] uppercase"
+            ></th>
           </tr>
         </thead>
         <tbody>
@@ -23,23 +50,31 @@
             v-for="o in offerings"
             :key="o.id"
             data-test="offering-row"
-            class="border-t border-[#f0f4f1] hover:bg-[#f7fbf9] transition-colors"
+            class="border-t border-[#f0f4f1] transition-colors hover:bg-[#f7fbf9]"
           >
             <td class="px-5 py-4 text-sm font-bold text-[#0f3d2e]">{{ o.title }}</td>
-            <td class="px-4 py-4 text-right text-sm font-bold text-[#0f3d2e] whitespace-nowrap">{{ o.rate }}%</td>
-            <td class="px-4 py-4 text-right text-sm font-semibold text-[#0f3d2e] whitespace-nowrap">{{ o.term }} mo</td>
+            <td class="px-4 py-4 text-right text-sm font-bold whitespace-nowrap text-[#0f3d2e]">
+              {{ o.rate }}%
+            </td>
+            <td class="px-4 py-4 text-right text-sm font-semibold whitespace-nowrap text-[#0f3d2e]">
+              {{ o.term }} mo
+            </td>
             <td class="px-4 py-4">
-              <UBadge :color="o.access === 'whitelist' ? 'info' : 'success'" variant="soft" size="xs">
+              <UBadge
+                :color="o.access === 'whitelist' ? 'info' : 'success'"
+                variant="soft"
+                size="xs"
+              >
                 {{ o.access === 'whitelist' ? 'Whitelist' : 'Open to all' }}
               </UBadge>
             </td>
             <td class="px-4 py-4">
-              <div class="flex justify-between text-xs font-semibold mb-1.5">
+              <div class="mb-1.5 flex justify-between text-xs font-semibold">
                 <span class="text-[#7d8e84]">{{ moneyShort(o.raised) }}</span>
                 <span class="text-[#9aaba2]">of {{ moneyShort(o.target) }} · {{ pct(o) }}%</span>
               </div>
-              <div class="h-1.5 rounded-full bg-[#eef3f0] overflow-hidden">
-                <div class="h-full rounded-full bg-primary" :style="{ width: pct(o) + '%' }"></div>
+              <div class="h-1.5 overflow-hidden rounded-full bg-[#eef3f0]">
+                <div class="bg-primary h-full rounded-full" :style="{ width: pct(o) + '%' }"></div>
               </div>
             </td>
             <td class="px-4 py-4">
@@ -70,9 +105,39 @@ import { moneyShort, type OfferingSummary } from './offeringForm'
 defineEmits<{ manage: [offering: OfferingSummary] }>()
 
 const offerings: OfferingSummary[] = [
-  { id: 'riverside', title: 'Riverside Expansion Note', rate: 9, term: 12, startDate: '2025-06-15', access: 'general', raised: 520000, target: 500000, status: 'closed' },
-  { id: 'mill-street', title: 'Mill Street Solar Array', rate: 8.5, term: 18, startDate: '2026-01-01', access: 'whitelist', raised: 150000, target: 300000, status: 'open' },
-  { id: 'harbor-logistics', title: 'Harbor Logistics Facility', rate: 10, term: 24, startDate: '2026-03-01', access: 'general', raised: 80000, target: 750000, status: 'open' }
+  {
+    id: 'riverside',
+    title: 'Riverside Expansion Note',
+    rate: 9,
+    term: 12,
+    startDate: '2025-06-15',
+    access: 'general',
+    raised: 520000,
+    target: 500000,
+    status: 'closed'
+  },
+  {
+    id: 'mill-street',
+    title: 'Mill Street Solar Array',
+    rate: 8.5,
+    term: 18,
+    startDate: '2026-01-01',
+    access: 'whitelist',
+    raised: 150000,
+    target: 300000,
+    status: 'open'
+  },
+  {
+    id: 'harbor-logistics',
+    title: 'Harbor Logistics Facility',
+    rate: 10,
+    term: 24,
+    startDate: '2026-03-01',
+    access: 'general',
+    raised: 80000,
+    target: 750000,
+    status: 'open'
+  }
 ]
 
 function pct(o: OfferingSummary): number {

--- a/app/src/components/sections/FixedReturnView/OfferingsList.vue
+++ b/app/src/components/sections/FixedReturnView/OfferingsList.vue
@@ -100,7 +100,8 @@
 
 <script setup lang="ts">
 import StatusBadge from './StatusBadge.vue'
-import { moneyShort, type OfferingSummary } from './offeringForm'
+import { moneyShort, percentOf } from '@/utils'
+import type { OfferingSummary } from '@/types'
 
 defineEmits<{ manage: [offering: OfferingSummary] }>()
 
@@ -141,6 +142,6 @@ const offerings: OfferingSummary[] = [
 ]
 
 function pct(o: OfferingSummary): number {
-  return Math.min(100, Math.round((o.raised / o.target) * 100))
+  return percentOf(o.raised, o.target)
 }
 </script>

--- a/app/src/components/sections/FixedReturnView/OfferingsList.vue
+++ b/app/src/components/sections/FixedReturnView/OfferingsList.vue
@@ -1,0 +1,81 @@
+<template>
+  <UCard :ui="{ body: 'p-0' }">
+    <template #header>
+      <div class="text-base font-extrabold text-[#0f3d2e]">
+        Offerings <span class="text-sm font-semibold text-[#9aaba2]">· {{ offerings.length }}</span>
+      </div>
+    </template>
+    <div class="overflow-x-auto">
+      <table class="w-full border-collapse" style="min-width: 820px">
+        <thead>
+          <tr class="bg-[#f7faf8]">
+            <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-5 py-3">Offering</th>
+            <th class="text-right text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Rate</th>
+            <th class="text-right text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Term</th>
+            <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Access</th>
+            <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3" style="min-width: 180px">Raised</th>
+            <th class="text-left text-xs font-bold text-[#81948a] uppercase tracking-wide px-4 py-3">Status</th>
+            <th class="text-right text-xs font-bold text-[#81948a] uppercase tracking-wide px-5 py-3"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="o in offerings"
+            :key="o.id"
+            data-test="offering-row"
+            class="border-t border-[#f0f4f1] hover:bg-[#f7fbf9] transition-colors"
+          >
+            <td class="px-5 py-4 text-sm font-bold text-[#0f3d2e]">{{ o.title }}</td>
+            <td class="px-4 py-4 text-right text-sm font-bold text-[#0f3d2e] whitespace-nowrap">{{ o.rate }}%</td>
+            <td class="px-4 py-4 text-right text-sm font-semibold text-[#0f3d2e] whitespace-nowrap">{{ o.term }} mo</td>
+            <td class="px-4 py-4">
+              <UBadge :color="o.access === 'whitelist' ? 'info' : 'success'" variant="soft" size="xs">
+                {{ o.access === 'whitelist' ? 'Whitelist' : 'Open to all' }}
+              </UBadge>
+            </td>
+            <td class="px-4 py-4">
+              <div class="flex justify-between text-xs font-semibold mb-1.5">
+                <span class="text-[#7d8e84]">{{ moneyShort(o.raised) }}</span>
+                <span class="text-[#9aaba2]">of {{ moneyShort(o.target) }} · {{ pct(o) }}%</span>
+              </div>
+              <div class="h-1.5 rounded-full bg-[#eef3f0] overflow-hidden">
+                <div class="h-full rounded-full bg-primary" :style="{ width: pct(o) + '%' }"></div>
+              </div>
+            </td>
+            <td class="px-4 py-4">
+              <StatusBadge :status="o.status" />
+            </td>
+            <td class="px-5 py-4 text-right">
+              <UButton
+                size="sm"
+                color="primary"
+                variant="soft"
+                label="Manage"
+                trailing-icon="heroicons:arrow-right"
+                data-test="offering-manage-button"
+                @click="$emit('manage', o)"
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </UCard>
+</template>
+
+<script setup lang="ts">
+import StatusBadge from './StatusBadge.vue'
+import { moneyShort, type OfferingSummary } from './offeringForm'
+
+defineEmits<{ manage: [offering: OfferingSummary] }>()
+
+const offerings: OfferingSummary[] = [
+  { id: 'riverside', title: 'Riverside Expansion Note', rate: 9, term: 12, startDate: '2025-06-15', access: 'general', raised: 520000, target: 500000, status: 'closed' },
+  { id: 'mill-street', title: 'Mill Street Solar Array', rate: 8.5, term: 18, startDate: '2026-01-01', access: 'whitelist', raised: 150000, target: 300000, status: 'open' },
+  { id: 'harbor-logistics', title: 'Harbor Logistics Facility', rate: 10, term: 24, startDate: '2026-03-01', access: 'general', raised: 80000, target: 750000, status: 'open' }
+]
+
+function pct(o: OfferingSummary): number {
+  return Math.min(100, Math.round((o.raised / o.target) * 100))
+}
+</script>

--- a/app/src/components/sections/FixedReturnView/ProgressGauge.vue
+++ b/app/src/components/sections/FixedReturnView/ProgressGauge.vue
@@ -1,8 +1,13 @@
 <template>
   <div :style="ringStyle">
-    <div class="bg-white flex flex-col items-center justify-center" :style="holeStyle">
-      <div class="font-extrabold tracking-tight text-[#0a7a52] leading-none" :style="{ fontSize: `${pctFontSize}px` }">{{ Math.round(clampedPercent) }}%</div>
-      <div class="text-[11px] text-[#9aaba2] mt-1">{{ label }}</div>
+    <div class="flex flex-col items-center justify-center bg-white" :style="holeStyle">
+      <div
+        class="leading-none font-extrabold tracking-tight text-[#0a7a52]"
+        :style="{ fontSize: `${pctFontSize}px` }"
+      >
+        {{ Math.round(clampedPercent) }}%
+      </div>
+      <div class="mt-1 text-[11px] text-[#9aaba2]">{{ label }}</div>
     </div>
   </div>
 </template>

--- a/app/src/components/sections/FixedReturnView/ProgressGauge.vue
+++ b/app/src/components/sections/FixedReturnView/ProgressGauge.vue
@@ -1,0 +1,36 @@
+<template>
+  <div :style="ringStyle">
+    <div class="bg-white flex flex-col items-center justify-center" :style="holeStyle">
+      <div class="font-extrabold tracking-tight text-[#0a7a52] leading-none" :style="{ fontSize: `${pctFontSize}px` }">{{ Math.round(clampedPercent) }}%</div>
+      <div class="text-[11px] text-[#9aaba2] mt-1">{{ label }}</div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<{ percent: number; label: string; size?: number }>(), {
+  size: 152
+})
+
+const clampedPercent = computed(() => Math.min(100, Math.max(0, props.percent)))
+const holeSize = computed(() => Math.round(props.size * 0.8))
+const pctFontSize = computed(() => Math.round(props.size * 0.25))
+
+const ringStyle = computed(() => ({
+  width: `${props.size}px`,
+  height: `${props.size}px`,
+  borderRadius: '999px',
+  background: `conic-gradient(#00bf7a ${clampedPercent.value * 3.6}deg, #eef3f0 0deg)`,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center'
+}))
+
+const holeStyle = computed(() => ({
+  width: `${holeSize.value}px`,
+  height: `${holeSize.value}px`,
+  borderRadius: '999px'
+}))
+</script>

--- a/app/src/components/sections/FixedReturnView/StatusBadge.vue
+++ b/app/src/components/sections/FixedReturnView/StatusBadge.vue
@@ -1,0 +1,32 @@
+<template>
+  <span
+    class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-bold whitespace-nowrap"
+    :style="{ background: meta.bg, color: meta.color }"
+  >
+    <span class="w-1.5 h-1.5 rounded-full" :style="{ background: meta.dot }"></span>
+    {{ meta.label }}
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+type Status = 'on-track' | 'overdue' | 'completed' | 'paid' | 'upcoming' | 'open' | 'funded' | 'closed' | 'partial'
+
+const props = defineProps<{ status: Status }>()
+
+const meta = computed(() => {
+  switch (props.status) {
+    case 'on-track':  return { label: 'On track',  bg: '#e6f8f1', color: '#0a7a52', dot: '#00bf7a' }
+    case 'overdue':   return { label: 'Overdue',   bg: '#ffe9e3', color: '#c2381a', dot: '#ff5630' }
+    case 'completed': return { label: 'Completed', bg: '#e6f8f1', color: '#0a7a52', dot: '#36b37e' }
+    case 'paid':      return { label: 'Paid',      bg: '#e6f8f1', color: '#0a7a52', dot: '#36b37e' }
+    case 'upcoming':  return { label: 'Upcoming',  bg: '#fff6e0', color: '#b07c00', dot: '#ffab00' }
+    case 'open':      return { label: 'Open',      bg: '#e6f8f1', color: '#0a7a52', dot: '#00bf7a' }
+    case 'funded':    return { label: 'Funded',    bg: '#ebf0ff', color: '#2b50c8', dot: '#3366ff' }
+    case 'closed':    return { label: 'Closed',    bg: '#eef1f6', color: '#566377', dot: '#8a99ab' }
+    case 'partial':   return { label: 'In progress', bg: '#fff6e0', color: '#b07c00', dot: '#ffab00' }
+    default:          return { label: props.status, bg: '#eef1f6', color: '#566377', dot: '#8a99ab' }
+  }
+})
+</script>

--- a/app/src/components/sections/FixedReturnView/StatusBadge.vue
+++ b/app/src/components/sections/FixedReturnView/StatusBadge.vue
@@ -1,9 +1,9 @@
 <template>
   <span
-    class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-bold whitespace-nowrap"
+    class="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-bold whitespace-nowrap"
     :style="{ background: meta.bg, color: meta.color }"
   >
-    <span class="w-1.5 h-1.5 rounded-full" :style="{ background: meta.dot }"></span>
+    <span class="h-1.5 w-1.5 rounded-full" :style="{ background: meta.dot }"></span>
     {{ meta.label }}
   </span>
 </template>
@@ -11,22 +11,41 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
-type Status = 'on-track' | 'overdue' | 'completed' | 'paid' | 'upcoming' | 'open' | 'funded' | 'closed' | 'partial'
+type Status =
+  | 'on-track'
+  | 'overdue'
+  | 'completed'
+  | 'paid'
+  | 'upcoming'
+  | 'open'
+  | 'funded'
+  | 'closed'
+  | 'partial'
 
 const props = defineProps<{ status: Status }>()
 
 const meta = computed(() => {
   switch (props.status) {
-    case 'on-track':  return { label: 'On track',  bg: '#e6f8f1', color: '#0a7a52', dot: '#00bf7a' }
-    case 'overdue':   return { label: 'Overdue',   bg: '#ffe9e3', color: '#c2381a', dot: '#ff5630' }
-    case 'completed': return { label: 'Completed', bg: '#e6f8f1', color: '#0a7a52', dot: '#36b37e' }
-    case 'paid':      return { label: 'Paid',      bg: '#e6f8f1', color: '#0a7a52', dot: '#36b37e' }
-    case 'upcoming':  return { label: 'Upcoming',  bg: '#fff6e0', color: '#b07c00', dot: '#ffab00' }
-    case 'open':      return { label: 'Open',      bg: '#e6f8f1', color: '#0a7a52', dot: '#00bf7a' }
-    case 'funded':    return { label: 'Funded',    bg: '#ebf0ff', color: '#2b50c8', dot: '#3366ff' }
-    case 'closed':    return { label: 'Closed',    bg: '#eef1f6', color: '#566377', dot: '#8a99ab' }
-    case 'partial':   return { label: 'In progress', bg: '#fff6e0', color: '#b07c00', dot: '#ffab00' }
-    default:          return { label: props.status, bg: '#eef1f6', color: '#566377', dot: '#8a99ab' }
+    case 'on-track':
+      return { label: 'On track', bg: '#e6f8f1', color: '#0a7a52', dot: '#00bf7a' }
+    case 'overdue':
+      return { label: 'Overdue', bg: '#ffe9e3', color: '#c2381a', dot: '#ff5630' }
+    case 'completed':
+      return { label: 'Completed', bg: '#e6f8f1', color: '#0a7a52', dot: '#36b37e' }
+    case 'paid':
+      return { label: 'Paid', bg: '#e6f8f1', color: '#0a7a52', dot: '#36b37e' }
+    case 'upcoming':
+      return { label: 'Upcoming', bg: '#fff6e0', color: '#b07c00', dot: '#ffab00' }
+    case 'open':
+      return { label: 'Open', bg: '#e6f8f1', color: '#0a7a52', dot: '#00bf7a' }
+    case 'funded':
+      return { label: 'Funded', bg: '#ebf0ff', color: '#2b50c8', dot: '#3366ff' }
+    case 'closed':
+      return { label: 'Closed', bg: '#eef1f6', color: '#566377', dot: '#8a99ab' }
+    case 'partial':
+      return { label: 'In progress', bg: '#fff6e0', color: '#b07c00', dot: '#ffab00' }
+    default:
+      return { label: props.status, bg: '#eef1f6', color: '#566377', dot: '#8a99ab' }
   }
 })
 </script>

--- a/app/src/components/sections/FixedReturnView/WhitelistEditor.vue
+++ b/app/src/components/sections/FixedReturnView/WhitelistEditor.vue
@@ -111,15 +111,14 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { watchDebounced } from '@vueuse/core'
-import type { Member } from '@/types'
+import type { Member, WhitelistEntry } from '@/types'
 import UserComponent from '@/components/UserComponent.vue'
 import SelectMemberResults from '@/components/utils/SelectMemberResults.vue'
 import { useTeamStore } from '@/stores/teamStore'
-import { resolveUser, filter } from '@/utils'
-import { sumWhitelistAmount } from './offeringForm'
+import { resolveUser, filter, sumWhitelistAmount } from '@/utils'
 
 const props = defineProps<{
-  whitelist: { username: string; address: string; amount: number | null }[]
+  whitelist: WhitelistEntry[]
   defaultAmountLabel: string
   defaultAmount: number | null
   principalTarget: number

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './ui'
+export * from './offering'
 export * from './toast-type'
 export * from './member'
 export * from './team'

--- a/app/src/types/offering.ts
+++ b/app/src/types/offering.ts
@@ -1,0 +1,34 @@
+export type TermUnit = 'days' | 'months' | 'years'
+
+export interface OfferingForm {
+  title: string
+  purpose: string
+  principal: number
+  rate: number
+  termValue: number
+  termUnit: TermUnit
+  startDate: string
+  deadline: string
+  access: 'general' | 'whitelist'
+  capOn: boolean
+  cap: number
+  token: string | undefined
+}
+
+export interface WhitelistEntry {
+  username: string
+  address: string
+  amount: number | null
+}
+
+export interface OfferingSummary {
+  id: string
+  title: string
+  rate: number
+  term: number
+  startDate: string
+  access: 'general' | 'whitelist'
+  raised: number
+  target: number
+  status: 'open' | 'funded' | 'closed'
+}

--- a/app/src/utils/__tests__/offeringUtil.spec.ts
+++ b/app/src/utils/__tests__/offeringUtil.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import {
+  moneyShort,
+  pickerClass,
+  sumWhitelistAmount,
+  formatOfferingDate,
+  addTerm,
+  termLabel,
+  maturityLabel,
+  percentOf,
+  expectedReturn
+} from '../offeringUtil'
+
+describe('moneyShort', () => {
+  it('formats a positive amount with a dollar sign and rounds to the nearest whole number', () => {
+    expect(moneyShort(1234.6)).toBe('$1,235')
+  })
+
+  it('formats zero', () => {
+    expect(moneyShort(0)).toBe('$0')
+  })
+})
+
+describe('pickerClass', () => {
+  it('returns the active styling when active is true', () => {
+    expect(pickerClass(true).join(' ')).toContain('border-[#00bf7a]')
+  })
+
+  it('returns the inactive styling when active is false', () => {
+    expect(pickerClass(false).join(' ')).toContain('border-[#e0eae5]')
+  })
+})
+
+describe('sumWhitelistAmount', () => {
+  it('sums the amounts of all entries', () => {
+    expect(sumWhitelistAmount([{ amount: 100 }, { amount: 250 }])).toBe(350)
+  })
+
+  it('treats null amounts as zero', () => {
+    expect(sumWhitelistAmount([{ amount: 100 }, { amount: null }])).toBe(100)
+  })
+
+  it('returns zero for an empty list', () => {
+    expect(sumWhitelistAmount([])).toBe(0)
+  })
+})
+
+describe('formatOfferingDate', () => {
+  it('formats an ISO date as "DD Mon YYYY"', () => {
+    expect(formatOfferingDate('2026-07-01')).toBe('01 Jul 2026')
+  })
+
+  it('returns the original string for an invalid date', () => {
+    expect(formatOfferingDate('not-a-date')).toBe('not-a-date')
+  })
+})
+
+describe('addTerm', () => {
+  const start = new Date('2026-01-15T00:00:00')
+
+  it('adds days', () => {
+    expect(addTerm(start, 10, 'days').toISOString().slice(0, 10)).toBe('2026-01-25')
+  })
+
+  it('adds months', () => {
+    expect(addTerm(start, 3, 'months').toISOString().slice(0, 10)).toBe('2026-04-15')
+  })
+
+  it('adds years', () => {
+    expect(addTerm(start, 2, 'years').toISOString().slice(0, 10)).toBe('2028-01-15')
+  })
+})
+
+describe('termLabel', () => {
+  it('pluralizes when the value is not 1', () => {
+    expect(termLabel(12, 'months')).toBe('12 months')
+  })
+
+  it('keeps the noun singular when the value is 1', () => {
+    expect(termLabel(1, 'years')).toBe('1 year')
+  })
+
+  it('labels a days term', () => {
+    expect(termLabel(90, 'days')).toBe('90 days')
+  })
+})
+
+describe('maturityLabel', () => {
+  it('formats the maturity date as start date plus term', () => {
+    expect(maturityLabel('2026-01-01', 6, 'months')).toBe('01 Jul 2026')
+  })
+
+  it('returns an em dash for an invalid start date', () => {
+    expect(maturityLabel('invalid', 6, 'months')).toBe('—')
+  })
+})
+
+describe('percentOf', () => {
+  it('computes a rounded percentage', () => {
+    expect(percentOf(1, 3)).toBe(33)
+  })
+
+  it('clamps to 100 when the numerator exceeds the denominator', () => {
+    expect(percentOf(150, 100)).toBe(100)
+  })
+
+  it('returns zero when the denominator is zero', () => {
+    expect(percentOf(50, 0)).toBe(0)
+  })
+})
+
+describe('expectedReturn', () => {
+  it('returns principal plus interest at the given rate', () => {
+    expect(expectedReturn(1000, 10)).toBe(1100)
+  })
+
+  it('returns the principal unchanged at a zero rate', () => {
+    expect(expectedReturn(1000, 0)).toBe(1000)
+  })
+})

--- a/app/src/utils/index.ts
+++ b/app/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './offeringUtil'
 export * from './errorUtil'
 export * from './classifyError'
 export * from './generalUtil'

--- a/app/src/utils/offeringUtil.ts
+++ b/app/src/utils/offeringUtil.ts
@@ -1,38 +1,7 @@
-export type TermUnit = 'days' | 'months' | 'years'
-
-export interface OfferingForm {
-  title: string
-  purpose: string
-  principal: number
-  rate: number
-  termValue: number
-  termUnit: TermUnit
-  startDate: string
-  deadline: string
-  access: 'general' | 'whitelist'
-  capOn: boolean
-  cap: number
-  token: string | undefined
-}
-
-export interface OfferingSummary {
-  id: string
-  title: string
-  rate: number
-  term: number
-  startDate: string
-  access: 'general' | 'whitelist'
-  raised: number
-  target: number
-  status: 'open' | 'funded' | 'closed'
-}
+import type { TermUnit } from '@/types'
 
 export function moneyShort(n: number): string {
   return '$' + Math.round(n).toLocaleString('en-US')
-}
-
-export function money(n: number): string {
-  return '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
 }
 
 export function pickerClass(active: boolean) {
@@ -48,7 +17,7 @@ export function sumWhitelistAmount(whitelist: { amount: number | null }[]): numb
   return whitelist.reduce((sum, w) => sum + (w.amount ?? 0), 0)
 }
 
-export function fmtDate(str: string): string {
+export function formatOfferingDate(str: string): string {
   const d = new Date(str + 'T00:00:00')
   if (isNaN(d.getTime())) return str
   const m = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
@@ -66,4 +35,18 @@ export function addTerm(date: Date, value: number, unit: TermUnit): Date {
 export function termLabel(value: number, unit: TermUnit): string {
   const noun = unit === 'days' ? 'day' : unit === 'months' ? 'month' : 'year'
   return `${value} ${noun}${value === 1 ? '' : 's'}`
+}
+
+export function maturityLabel(startDate: string, termValue: number, termUnit: TermUnit): string {
+  const start = new Date(startDate + 'T00:00:00')
+  if (isNaN(start.getTime())) return '—'
+  return formatOfferingDate(addTerm(start, termValue, termUnit).toISOString().slice(0, 10))
+}
+
+export function percentOf(numerator: number, denominator: number): number {
+  return denominator ? Math.min(100, Math.round((numerator / denominator) * 100)) : 0
+}
+
+export function expectedReturn(principal: number, rate: number): number {
+  return principal * (1 + rate / 100)
 }

--- a/app/src/views/team/[id]/FixedReturnView.vue
+++ b/app/src/views/team/[id]/FixedReturnView.vue
@@ -20,16 +20,13 @@
     </div>
 
     <CreateOfferingForm v-if="showCreateForm" @close="showCreateForm = false" />
-    <div v-else class="flex flex-col items-center justify-center gap-2 py-16 text-center">
-      <div class="text-sm font-semibold text-[#7d8e84]">
-        My Offerings management is coming soon.
-      </div>
-    </div>
+    <AdminDashboard v-else />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
+import AdminDashboard from '@/components/sections/FixedReturnView/AdminDashboard.vue'
 import CreateOfferingForm from '@/components/sections/FixedReturnView/CreateOfferingForm.vue'
 
 const showCreateForm = ref(true)

--- a/app/src/views/team/[id]/FixedReturnView.vue
+++ b/app/src/views/team/[id]/FixedReturnView.vue
@@ -20,13 +20,13 @@
     </div>
 
     <CreateOfferingForm v-if="showCreateForm" @close="showCreateForm = false" />
-    <AdminDashboard v-else />
+    <OfferingsDashboard v-else />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import AdminDashboard from '@/components/sections/FixedReturnView/AdminDashboard.vue'
+import OfferingsDashboard from '@/components/sections/FixedReturnView/OfferingsDashboard.vue'
 import CreateOfferingForm from '@/components/sections/FixedReturnView/CreateOfferingForm.vue'
 
 const showCreateForm = ref(true)


### PR DESCRIPTION
# Description

## Intial Issue Description

Once an admin issues a fixed-return offering, there's no way to see how it's performing — how much has been raised, who the lenders are, or how repayment is progressing. The "My Offerings" tab currently just shows a "coming soon" placeholder.

> Link to the issue in the kanban board
> If no issue exists, please create one and link it here.
Fixes #2187 

## Issues introduced and fixed (Optional)

If exit: The description of issues you find and fix in this PR.

## PR Summary Or Solution description

Replaces the "coming soon" placeholder with a real admin dashboard for managing issued offerings.

Two views: an offerings list (rate, term, access type, funding progress, status per offering) and an offering detail view (funding/repayment gauges, summary stats, per-lender repayment breakdown), with drill-in/back navigation between them. Shared status-badge and gauge components keep the visuals consistent across both.

## Contribution

For your PR please add a comment to each file edited to explain the changes you made.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


- **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Contribution checklist

Before submitting the PR, please make sure you have applied the rules in [CONTRIBUTION.md](./../CONTRIBUTION.md)
