### PR TITLE
feat: ✨ source mappers + off-chain enrichment (all money sources) — step 2/5

### DIFF
--- a/app/src/utils/__tests__/transactionHistoryUtil.spec.ts
+++ b/app/src/utils/__tests__/transactionHistoryUtil.spec.ts
@@ -293,6 +293,7 @@ describe('transactionHistoryUtil', () => {
 
   it('formatDecodedValue handles primitives, arrays, and addresses', () => {
     expect(formatDecodedValue('address', '0x1234')).toEqual({ display: '0x1234', isAddress: true })
+    expect(formatDecodedValue('uint256', 1000n)).toEqual({ display: '1,000', isAddress: false })
     expect(formatDecodedValue('bool', true)).toEqual({ display: 'true', isAddress: false })
     expect(formatDecodedValue('uint256', null)).toEqual({ display: '-', isAddress: false })
     const arr = formatDecodedValue('uint256[]', [100n, 200n])

--- a/app/src/utils/__tests__/transactionHistoryUtil.spec.ts
+++ b/app/src/utils/__tests__/transactionHistoryUtil.spec.ts
@@ -293,7 +293,6 @@ describe('transactionHistoryUtil', () => {
 
   it('formatDecodedValue handles primitives, arrays, and addresses', () => {
     expect(formatDecodedValue('address', '0x1234')).toEqual({ display: '0x1234', isAddress: true })
-    expect(formatDecodedValue('uint256', 1000n)).toEqual({ display: '1,000', isAddress: false })
     expect(formatDecodedValue('bool', true)).toEqual({ display: 'true', isAddress: false })
     expect(formatDecodedValue('uint256', null)).toEqual({ display: '-', isAddress: false })
     const arr = formatDecodedValue('uint256[]', [100n, 200n])

--- a/app/src/utils/accounting/__tests__/bank.spec.ts
+++ b/app/src/utils/accounting/__tests__/bank.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { mapBankEvents } from '@/utils/accounting/mappers/bank'
+import { makeCtx, ADDR } from './fixtures'
+
+const ctx = makeCtx()
+
+describe('mapBankEvents', () => {
+  it('books a founder native deposit as UC-BANK-01 (Owner Capital)', () => {
+    const [entry] = mapBankEvents(
+      {
+        deposits: [
+          {
+            id: 'd1',
+            contractAddress: ADDR.bank,
+            depositor: ADDR.founder,
+            amount: '1000000000000000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'UC-BANK-01',
+      debit: 'Cash — Bank',
+      credit: 'Owner Capital',
+      amountUsd: 2, // 1 native * $2
+      token: 'native',
+      internal: false
+    })
+  })
+
+  it('books a non-founder (client) deposit as UC-BANK-02 (Service Revenue)', () => {
+    const [entry] = mapBankEvents(
+      {
+        tokenDeposits: [
+          {
+            id: 'd2',
+            contractAddress: ADDR.bank,
+            depositor: ADDR.client,
+            token: ADDR.usdcToken,
+            amount: '5000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'UC-BANK-02',
+      debit: 'Cash — Bank',
+      credit: 'Service Revenue',
+      amountUsd: 5, // 5 usdc * $1
+      token: 'usdc'
+    })
+  })
+
+  it('treats a deposit from an internal pocket as an internal funding move', () => {
+    const [entry] = mapBankEvents(
+      {
+        deposits: [
+          {
+            id: 'd3',
+            contractAddress: ADDR.bank,
+            depositor: ADDR.safe,
+            amount: '1000000000000000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'INTERNAL',
+      debit: 'Cash — Bank',
+      credit: 'Cash — Safe',
+      internal: true
+    })
+  })
+
+  it('books a transfer to an internal pocket as UC-BANK-03 funding', () => {
+    const [entry] = mapBankEvents(
+      {
+        transfers: [
+          { id: 't1', sender: ADDR.bank, to: ADDR.payroll, amount: '2000000', timestamp: 100 }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'UC-BANK-03',
+      debit: 'Cash — Payroll',
+      credit: 'Cash — Bank',
+      internal: true
+    })
+  })
+
+  it('flags an external transfer out for off-chain reclassification', () => {
+    const [entry] = mapBankEvents(
+      {
+        transfers: [
+          { id: 't2', sender: ADDR.bank, to: ADDR.client, amount: '2000000', timestamp: 100 }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'CASH-OUT',
+      credit: 'Cash — Bank',
+      enrichment: 'needs-off-chain-data'
+    })
+  })
+
+  it('checksum-normalizes the counterparty', () => {
+    const [entry] = mapBankEvents(
+      {
+        deposits: [
+          {
+            id: 'd4',
+            contractAddress: ADDR.bank,
+            depositor: ADDR.founder,
+            amount: '1',
+            timestamp: 1
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry?.counterparty).toBe('0x6666666666666666666666666666666666666666')
+  })
+})

--- a/app/src/utils/accounting/__tests__/cashRemuneration.spec.ts
+++ b/app/src/utils/accounting/__tests__/cashRemuneration.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import { mapCashRemunerationEvents } from '@/utils/accounting/mappers/cashRemuneration'
+import { makeCtx, ADDR } from './fixtures'
+
+const ctx = makeCtx()
+
+describe('mapCashRemunerationEvents', () => {
+  it('settles a native wage withdrawal against Wage Payable (UC-CASH-03)', () => {
+    const [entry] = mapCashRemunerationEvents(
+      {
+        withdraws: [
+          {
+            id: 'w1',
+            contractAddress: ADDR.payroll,
+            withdrawer: ADDR.member,
+            amount: '1000000000000000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'UC-CASH-03',
+      debit: 'Wage Payable',
+      credit: 'Cash — Payroll',
+      amountUsd: 2,
+      enrichment: 'needs-off-chain-data'
+    })
+  })
+
+  it('books a SHER WithdrawToken as the equity leg (Shares to be issued → Investor Equity)', () => {
+    const [entry] = mapCashRemunerationEvents(
+      {
+        withdrawTokens: [
+          {
+            id: 'w2',
+            contractAddress: ADDR.payroll,
+            withdrawer: ADDR.member,
+            tokenAddress: ADDR.sherToken,
+            amount: '10000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'UC-CASH-03',
+      debit: 'Shares to be issued',
+      credit: 'Investor Equity',
+      token: 'sher',
+      shares: 10,
+      amountUsd: 5 // 10 sher * $0.50
+    })
+  })
+
+  it('books a USDC WithdrawToken as a cash settlement', () => {
+    const [entry] = mapCashRemunerationEvents(
+      {
+        withdrawTokens: [
+          {
+            id: 'w3',
+            contractAddress: ADDR.payroll,
+            withdrawer: ADDR.member,
+            tokenAddress: ADDR.usdcToken,
+            amount: '3000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({ debit: 'Wage Payable', credit: 'Cash — Payroll', token: 'usdc' })
+  })
+
+  it('books a deposit as internal funding from its source pocket', () => {
+    const [entry] = mapCashRemunerationEvents(
+      {
+        deposits: [
+          {
+            id: 'dep',
+            contractAddress: ADDR.payroll,
+            depositor: ADDR.bank,
+            amount: '1000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'INTERNAL',
+      debit: 'Cash — Payroll',
+      credit: 'Cash — Bank',
+      internal: true
+    })
+  })
+
+  it('books an owner sweep back to Bank as an internal move', () => {
+    const [entry] = mapCashRemunerationEvents(
+      {
+        ownerTreasuryWithdrawNatives: [
+          {
+            id: 's1',
+            contractAddress: ADDR.payroll,
+            ownerAddress: ADDR.founder,
+            amount: '1000000000000000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'INTERNAL',
+      debit: 'Cash — Bank',
+      credit: 'Cash — Payroll',
+      internal: true
+    })
+  })
+})

--- a/app/src/utils/accounting/__tests__/context.spec.ts
+++ b/app/src/utils/accounting/__tests__/context.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { buildMapperContext } from '@/utils/accounting/mappers/context'
+import type { TeamContract } from '@/types/teamContract'
+import { ADDR } from './fixtures'
+
+const contracts = [
+  { address: ADDR.bank, type: 'Bank' },
+  { address: ADDR.safe, type: 'Safe' },
+  { address: ADDR.payroll, type: 'CashRemunerationEIP712' },
+  { address: ADDR.expense, type: 'ExpenseAccountEIP712' }
+] as unknown as TeamContract[]
+
+describe('buildMapperContext', () => {
+  const ctx = buildMapperContext({
+    contracts,
+    internalAddresses: new Set(),
+    founderAddresses: [ADDR.founder],
+    feeCollectorAddress: ADDR.feeCollector,
+    sherTokenAddress: ADDR.sherToken,
+    rateOfRecord: () => 3 // $3 for every non-pegged token
+  })
+
+  it('maps each contract type to its Cash pocket account', () => {
+    expect(ctx.pocketOf(ADDR.bank)).toBe('Cash — Bank')
+    expect(ctx.pocketOf(ADDR.safe)).toBe('Cash — Safe')
+    expect(ctx.pocketOf(ADDR.payroll)).toBe('Cash — Payroll')
+    expect(ctx.pocketOf(ADDR.expense)).toBe('Cash — Expense')
+    expect(ctx.pocketOf(ADDR.feeCollector)).toBe('Cash — FeeCollector')
+    expect(ctx.pocketOf(ADDR.client)).toBeNull()
+  })
+
+  it('resolves token ids (zero/empty = native, SHER override, peg)', () => {
+    expect(ctx.tokenIdOf(null)).toBe('native')
+    expect(ctx.tokenIdOf('')).toBe('native')
+    expect(ctx.tokenIdOf(ADDR.sherToken)).toBe('sher')
+  })
+
+  it('values pegged stablecoins at $1 and uses the resolver for native', () => {
+    // SHER is not pegged → resolver ($3) × 1 whole token (6 decimals).
+    expect(ctx.toUsd(1_000_000n, 'sher', new Date(0))).toBe(3)
+    // native is not pegged → resolver ($3) × 1 whole token (18 decimals).
+    expect(ctx.toUsd(10n ** 18n, 'native', new Date(0))).toBe(3)
+  })
+
+  it('checksum-normalizes founder addresses', () => {
+    expect(ctx.founderAddresses.has('0x6666666666666666666666666666666666666666')).toBe(true)
+  })
+})

--- a/app/src/utils/accounting/__tests__/enrichment.spec.ts
+++ b/app/src/utils/accounting/__tests__/enrichment.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { enrichEntries } from '@/utils/accounting/enrichment'
+import { makeEntry, type LedgerEntry } from '@/utils/accounting/ledgerEntry'
+import type { WeeklyClaim } from '@/types/cash-remuneration'
+import type { ExpenseResponse } from '@/types/expense-account'
+import { ADDR } from './fixtures'
+
+const payrollEntry = (): LedgerEntry =>
+  makeEntry({
+    id: 'p1',
+    timestamp: 1_700_000_100,
+    useCase: 'UC-CASH-03',
+    debit: 'Wage Payable',
+    credit: 'Cash — Payroll',
+    amountUsd: 2,
+    token: 'native',
+    rawAmount: '1',
+    counterparty: ADDR.member,
+    memo: 'Wage withdrawal — cash settlement',
+    enrichment: 'needs-off-chain-data'
+  })
+
+const expenseEntry = (): LedgerEntry =>
+  makeEntry({
+    id: 'e1',
+    timestamp: 1_700_000_100,
+    useCase: 'UC-EXP-01',
+    debit: 'Operating Expense',
+    credit: 'Cash — Expense',
+    amountUsd: 4,
+    token: 'usdc',
+    rawAmount: '4000000',
+    counterparty: ADDR.member,
+    memo: 'Approved expense payout',
+    enrichment: 'needs-off-chain-data'
+  })
+
+const weeklyClaim = (): WeeklyClaim =>
+  ({
+    memberAddress: ADDR.member,
+    weekStart: new Date(1_700_000_000 * 1000).toISOString(),
+    minutesWorked: 120,
+    wage: { ratePerHour: [{ type: 'usdc', amount: 15 }] },
+    claims: [{ memo: 'Fixed the build' }]
+  }) as unknown as WeeklyClaim
+
+const expenseRecord = (): ExpenseResponse =>
+  ({
+    id: 42,
+    userAddress: ADDR.member,
+    createdAt: new Date(1_700_000_000 * 1000)
+  }) as unknown as ExpenseResponse
+
+describe('enrichEntries', () => {
+  it('attaches the Payroll category and rate/minutes/memo to a payroll entry', () => {
+    const [entry] = enrichEntries([payrollEntry()], { weeklyClaims: [weeklyClaim()] })
+    expect(entry.category).toBe('Payroll')
+    expect(entry.enrichment).toBe('enriched')
+    expect(entry.memo).toContain('15 usdc/h')
+    expect(entry.memo).toContain('120 min')
+    expect(entry.memo).toContain('Fixed the build')
+  })
+
+  it('attaches the Operating category to an expense entry', () => {
+    const [entry] = enrichEntries([expenseEntry()], { expenses: [expenseRecord()] })
+    expect(entry).toMatchObject({ category: 'Operating', enrichment: 'enriched' })
+    expect(entry.memo).toContain('#42')
+  })
+
+  it('keeps the needs-off-chain-data flag when no portal record matches', () => {
+    const [entry] = enrichEntries([payrollEntry()], { weeklyClaims: [] })
+    expect(entry.enrichment).toBe('needs-off-chain-data')
+    expect(entry.category).toBeUndefined()
+  })
+
+  it('leaves entries that need no off-chain data untouched', () => {
+    const internal = makeEntry({
+      id: 'i1',
+      timestamp: 1,
+      useCase: 'INTERNAL',
+      debit: 'Cash — Bank',
+      credit: 'Cash — Safe',
+      amountUsd: 1,
+      token: 'native',
+      rawAmount: '1',
+      internal: true,
+      memo: 'move'
+    })
+    const [entry] = enrichEntries([internal], { weeklyClaims: [weeklyClaim()] })
+    expect(entry).toEqual(internal)
+  })
+})

--- a/app/src/utils/accounting/__tests__/expenseAccount.spec.ts
+++ b/app/src/utils/accounting/__tests__/expenseAccount.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import { mapExpenseAccountEvents } from '@/utils/accounting/mappers/expenseAccount'
+import { makeCtx, ADDR } from './fixtures'
+
+const ctx = makeCtx()
+
+describe('mapExpenseAccountEvents', () => {
+  it('books an approved payout to an external member as UC-EXP-01', () => {
+    const [entry] = mapExpenseAccountEvents(
+      {
+        transfers: [
+          {
+            id: 'x1',
+            contractAddress: ADDR.expense,
+            withdrawer: ADDR.expense,
+            to: ADDR.member,
+            amount: '4000000000000000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'UC-EXP-01',
+      debit: 'Operating Expense',
+      credit: 'Cash — Expense',
+      amountUsd: 8, // 4 native * $2 (native: token null)
+      enrichment: 'needs-off-chain-data'
+    })
+  })
+
+  it('books a token payout with the right token and value', () => {
+    const [entry] = mapExpenseAccountEvents(
+      {
+        tokenTransfers: [
+          {
+            id: 'x2',
+            contractAddress: ADDR.expense,
+            withdrawer: ADDR.expense,
+            to: ADDR.member,
+            token: ADDR.usdcToken,
+            amount: '4000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({ useCase: 'UC-EXP-01', token: 'usdc', amountUsd: 4 })
+  })
+
+  it('treats a transfer to an internal pocket as an internal move', () => {
+    const [entry] = mapExpenseAccountEvents(
+      {
+        transfers: [
+          {
+            id: 'x3',
+            contractAddress: ADDR.expense,
+            withdrawer: ADDR.expense,
+            to: ADDR.bank,
+            amount: '1000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'INTERNAL',
+      debit: 'Cash — Bank',
+      credit: 'Cash — Expense',
+      internal: true
+    })
+  })
+
+  it('books deposits as internal funding into the expense pocket', () => {
+    const [entry] = mapExpenseAccountEvents(
+      {
+        deposits: [
+          {
+            id: 'x4',
+            contractAddress: ADDR.expense,
+            depositor: ADDR.bank,
+            amount: '1000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'INTERNAL',
+      debit: 'Cash — Expense',
+      credit: 'Cash — Bank',
+      internal: true
+    })
+  })
+
+  it('books an owner sweep back to Bank as an internal move', () => {
+    const [entry] = mapExpenseAccountEvents(
+      {
+        ownerTreasuryWithdrawTokens: [
+          {
+            id: 'x5',
+            contractAddress: ADDR.expense,
+            ownerAddress: ADDR.founder,
+            token: ADDR.usdcToken,
+            amount: '1000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'INTERNAL',
+      debit: 'Cash — Bank',
+      credit: 'Cash — Expense',
+      internal: true
+    })
+  })
+})

--- a/app/src/utils/accounting/__tests__/fees.spec.ts
+++ b/app/src/utils/accounting/__tests__/fees.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { mapFees } from '@/utils/accounting/mappers/fees'
+import { makeCtx, ADDR } from './fixtures'
+
+const ctx = makeCtx()
+
+describe('mapFees', () => {
+  it('books a fee as an internal Bank → FeeCollector move (not an expense)', () => {
+    const [entry] = mapFees(
+      {
+        bankFeePaids: [
+          {
+            id: 'f1',
+            contractAddress: ADDR.bank,
+            feeCollector: ADDR.feeCollector,
+            token: ADDR.usdcToken,
+            amount: '1000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'FEE',
+      debit: 'Cash — FeeCollector',
+      credit: 'Cash — Bank',
+      amountUsd: 1,
+      internal: true
+    })
+  })
+
+  it('dedups the Bank/FeeCollector dual-write of the same fee', () => {
+    const entries = mapFees(
+      {
+        bankFeePaids: [
+          {
+            id: 'f1',
+            contractAddress: ADDR.bank,
+            feeCollector: ADDR.feeCollector,
+            token: ADDR.usdcToken,
+            amount: '1000000',
+            timestamp: 100
+          }
+        ],
+        feeCollectorFeePaids: [
+          {
+            id: 'f2',
+            contractAddress: ADDR.feeCollector,
+            payer: ADDR.bank,
+            token: ADDR.usdcToken,
+            amount: '1000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entries).toHaveLength(1)
+    expect(entries[0].id).toBe('f1') // the Bank row is canonical
+  })
+
+  it('keeps distinct fees (different amount or timestamp) separate', () => {
+    const entries = mapFees(
+      {
+        bankFeePaids: [
+          {
+            id: 'f1',
+            contractAddress: ADDR.bank,
+            feeCollector: ADDR.feeCollector,
+            token: ADDR.usdcToken,
+            amount: '1000000',
+            timestamp: 100
+          },
+          {
+            id: 'f2',
+            contractAddress: ADDR.bank,
+            feeCollector: ADDR.feeCollector,
+            token: ADDR.usdcToken,
+            amount: '2000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entries).toHaveLength(2)
+  })
+
+  it('handles a native fee (null token)', () => {
+    const [entry] = mapFees(
+      {
+        bankFeePaids: [
+          {
+            id: 'f1',
+            contractAddress: ADDR.bank,
+            feeCollector: ADDR.feeCollector,
+            token: null,
+            amount: '1000000000000000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({ token: 'native', amountUsd: 2 })
+  })
+})

--- a/app/src/utils/accounting/__tests__/fixtures.ts
+++ b/app/src/utils/accounting/__tests__/fixtures.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared test fixtures for the accounting source mappers — a deterministic
+ * {@link MapperContext} with hand-picked addresses and a stub FX rate, so each
+ * mapper spec can exercise pure logic without Vue, the chain, or a price oracle.
+ */
+import { formatUnits, type Address } from 'viem'
+import type { TokenId } from '@/constant'
+import type { AccountName } from '@/utils/accounting/chartOfAccounts'
+import type { MapperContext } from '@/utils/accounting/mappers/context'
+
+/** Lowercase addresses are always valid (no checksum to fail) — safe for tests. */
+export const ADDR = {
+  bank: '0x1111111111111111111111111111111111111111',
+  safe: '0x2222222222222222222222222222222222222222',
+  payroll: '0x3333333333333333333333333333333333333333',
+  expense: '0x4444444444444444444444444444444444444444',
+  feeCollector: '0x5555555555555555555555555555555555555555',
+  founder: '0x6666666666666666666666666666666666666666',
+  client: '0x7777777777777777777777777777777777777777',
+  member: '0x8888888888888888888888888888888888888888',
+  usdcToken: '0x9999999999999999999999999999999999999999',
+  sherToken: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+} as const
+
+const POCKETS: Record<string, AccountName> = {
+  [ADDR.bank]: 'Cash — Bank',
+  [ADDR.safe]: 'Cash — Safe',
+  [ADDR.payroll]: 'Cash — Payroll',
+  [ADDR.expense]: 'Cash — Expense',
+  [ADDR.feeCollector]: 'Cash — FeeCollector'
+}
+
+const DECIMALS: Record<TokenId, number> = { native: 18, usdc: 6, 'usdc.e': 6, usdt: 6, sher: 6 }
+/** Stub rate of record: native $2, stablecoins $1, SHER $0.50. */
+const RATE: Record<TokenId, number> = { native: 2, usdc: 1, 'usdc.e': 1, usdt: 1, sher: 0.5 }
+
+/** Build a deterministic {@link MapperContext}; override any field per test. */
+export function makeCtx(overrides: Partial<MapperContext> = {}): MapperContext {
+  const tokenIdOf = (token: string | null | undefined): TokenId => {
+    if (!token) return 'native'
+    const lower = token.toLowerCase()
+    if (lower === ADDR.usdcToken) return 'usdc'
+    if (lower === ADDR.sherToken) return 'sher'
+    return 'native'
+  }
+  return {
+    internalAddresses: new Set(Object.keys(POCKETS) as Address[]),
+    founderAddresses: new Set([ADDR.founder as Address]),
+    toUsd: (amount, token) => Number(formatUnits(amount, DECIMALS[token])) * RATE[token],
+    tokenIdOf,
+    pocketOf: (address) => (address ? (POCKETS[address.toLowerCase()] ?? null) : null),
+    ...overrides
+  }
+}

--- a/app/src/utils/accounting/__tests__/investor.spec.ts
+++ b/app/src/utils/accounting/__tests__/investor.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import { mapInvestorEvents } from '@/utils/accounting/mappers/investor'
+import { makeCtx, ADDR } from './fixtures'
+
+const ctx = makeCtx()
+
+describe('mapInvestorEvents', () => {
+  it('drops a mint backed by a SafeDepositRouter deposit (equity booked there)', () => {
+    const entries = mapInvestorEvents(
+      {
+        mints: [
+          {
+            id: 'm1',
+            contractAddress: ADDR.safe,
+            shareholder: ADDR.founder,
+            amount: '10000000',
+            timestamp: 100
+          }
+        ],
+        safeDepositRouterDeposits: [
+          {
+            id: 'sd1',
+            contractAddress: ADDR.safe,
+            depositor: ADDR.founder,
+            token: ADDR.usdcToken,
+            tokenAmount: '5000000',
+            sherAmount: '10000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entries).toHaveLength(0)
+  })
+
+  it('drops a mint backed by a SHER wage withdrawal', () => {
+    const entries = mapInvestorEvents(
+      {
+        mints: [
+          {
+            id: 'm2',
+            contractAddress: ADDR.safe,
+            shareholder: ADDR.member,
+            amount: '7000000',
+            timestamp: 100
+          }
+        ],
+        cashRemunerationWithdrawTokens: [
+          {
+            id: 'w1',
+            contractAddress: ADDR.payroll,
+            withdrawer: ADDR.member,
+            tokenAddress: ADDR.sherToken,
+            amount: '7000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entries).toHaveLength(0)
+  })
+
+  it('books an unbacked mint as a Default-D memo (value 0, no posting)', () => {
+    const [entry] = mapInvestorEvents(
+      {
+        mints: [
+          {
+            id: 'm3',
+            contractAddress: ADDR.safe,
+            shareholder: ADDR.client,
+            amount: '3000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'DEFAULT-D',
+      debit: null,
+      credit: null,
+      amountUsd: 0,
+      shares: 3
+    })
+  })
+
+  it('books a DividendPaid as UC-INV-01 (Dividend Expense → Cash — Bank)', () => {
+    const [entry] = mapInvestorEvents(
+      {
+        dividendPaids: [
+          {
+            id: 'dp1',
+            contractAddress: ADDR.safe,
+            shareholder: ADDR.member,
+            token: ADDR.usdcToken,
+            amount: '2000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'UC-INV-01',
+      debit: 'Dividend Expense',
+      credit: 'Cash — Bank',
+      amountUsd: 2
+    })
+  })
+
+  it('only consumes one backing per matching mint', () => {
+    const entries = mapInvestorEvents(
+      {
+        mints: [
+          {
+            id: 'm1',
+            contractAddress: ADDR.safe,
+            shareholder: ADDR.founder,
+            amount: '10000000',
+            timestamp: 100
+          },
+          {
+            id: 'm2',
+            contractAddress: ADDR.safe,
+            shareholder: ADDR.founder,
+            amount: '10000000',
+            timestamp: 200
+          }
+        ],
+        safeDepositRouterDeposits: [
+          {
+            id: 'sd1',
+            contractAddress: ADDR.safe,
+            depositor: ADDR.founder,
+            token: ADDR.usdcToken,
+            tokenAmount: '5000000',
+            sherAmount: '10000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    // First mint is backed and dropped; the second has no backing left → Default-D.
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ id: 'm2', useCase: 'DEFAULT-D' })
+  })
+})

--- a/app/src/utils/accounting/__tests__/ledgerEntry.spec.ts
+++ b/app/src/utils/accounting/__tests__/ledgerEntry.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { makeEntry, normalizeCounterparty } from '@/utils/accounting/ledgerEntry'
+
+describe('normalizeCounterparty', () => {
+  it('checksum-normalizes a valid address', () => {
+    expect(normalizeCounterparty('0x6666666666666666666666666666666666666666')).toBe(
+      '0x6666666666666666666666666666666666666666'
+    )
+  })
+
+  it('returns undefined for invalid / missing input', () => {
+    expect(normalizeCounterparty(null)).toBeUndefined()
+    expect(normalizeCounterparty(undefined)).toBeUndefined()
+    expect(normalizeCounterparty('not-an-address')).toBeUndefined()
+  })
+})
+
+describe('makeEntry', () => {
+  it('fills the common defaults (internal=false, enrichment=not-applicable)', () => {
+    const entry = makeEntry({
+      id: '1',
+      timestamp: 1,
+      useCase: 'UC-BANK-01',
+      debit: 'Cash — Bank',
+      credit: 'Owner Capital',
+      amountUsd: 1,
+      token: 'native',
+      rawAmount: '1',
+      memo: 'x'
+    })
+    expect(entry.internal).toBe(false)
+    expect(entry.enrichment).toBe('not-applicable')
+    expect(entry.counterparty).toBeUndefined()
+  })
+
+  it('drops an invalid counterparty rather than storing it', () => {
+    const entry = makeEntry({
+      id: '1',
+      timestamp: 1,
+      useCase: 'UC-BANK-01',
+      debit: 'Cash — Bank',
+      credit: 'Owner Capital',
+      amountUsd: 1,
+      token: 'native',
+      rawAmount: '1',
+      memo: 'x',
+      counterparty: 'bad'
+    })
+    expect(entry.counterparty).toBeUndefined()
+  })
+})

--- a/app/src/utils/accounting/__tests__/orchestrator.spec.ts
+++ b/app/src/utils/accounting/__tests__/orchestrator.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { buildCncLedgerEntries, type LedgerSources } from '@/utils/accounting/mappers'
+import { makeCtx, ADDR } from './fixtures'
+
+const ctx = makeCtx()
+
+const sources: LedgerSources = {
+  bank: {
+    deposits: [
+      {
+        id: 'b1',
+        contractAddress: ADDR.bank,
+        depositor: ADDR.founder,
+        amount: '1000000000000000000',
+        timestamp: 300
+      }
+    ],
+    transfers: [
+      { id: 'b2', sender: ADDR.bank, to: ADDR.payroll, amount: '2000000', timestamp: 100 }
+    ]
+  },
+  fees: {
+    bankFeePaids: [
+      {
+        id: 'f1',
+        contractAddress: ADDR.bank,
+        feeCollector: ADDR.feeCollector,
+        token: ADDR.usdcToken,
+        amount: '1000000',
+        timestamp: 200
+      }
+    ]
+  },
+  cashRemuneration: {
+    withdraws: [
+      {
+        id: 'c1',
+        contractAddress: ADDR.payroll,
+        withdrawer: ADDR.member,
+        amount: '1000000000000000000',
+        timestamp: 400
+      }
+    ]
+  },
+  safeDepositRouter: {
+    deposits: [
+      {
+        id: 's1',
+        contractAddress: ADDR.safe,
+        depositor: ADDR.client,
+        token: ADDR.usdcToken,
+        tokenAmount: '5000000',
+        sherAmount: '10000000',
+        timestamp: 500
+      }
+    ]
+  }
+}
+
+describe('buildCncLedgerEntries', () => {
+  const entries = buildCncLedgerEntries(sources, ctx)
+
+  it('runs every source and returns entries sorted by timestamp', () => {
+    expect(entries.map((e) => e.timestamp)).toEqual([100, 200, 300, 400, 500])
+  })
+
+  it('produces a balanced ledger (every posting has equal debit and credit legs)', () => {
+    let debits = 0
+    let credits = 0
+    for (const e of entries) {
+      if (e.debit) debits += e.amountUsd
+      if (e.credit) credits += e.amountUsd
+    }
+    expect(debits).toBeCloseTo(credits)
+  })
+
+  it('enriches payroll entries when off-chain data is supplied', () => {
+    const enriched = buildCncLedgerEntries(sources, ctx, {
+      weeklyClaims: [
+        {
+          memberAddress: ADDR.member,
+          weekStart: new Date(400 * 1000).toISOString(),
+          minutesWorked: 60,
+          wage: { ratePerHour: [{ type: 'native', amount: 1 }] },
+          claims: []
+        } as never
+      ]
+    })
+    const payroll = enriched.find((e) => e.useCase === 'UC-CASH-03')
+    expect(payroll?.enrichment).toBe('enriched')
+    expect(payroll?.category).toBe('Payroll')
+  })
+})

--- a/app/src/utils/accounting/__tests__/safe.spec.ts
+++ b/app/src/utils/accounting/__tests__/safe.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { mapSafeTransfers } from '@/utils/accounting/mappers/safe'
+import { makeCtx, ADDR } from './fixtures'
+
+const ctx = makeCtx()
+const base = { token: null as string | null, amount: '1000000000000000000', timestamp: 100 }
+
+describe('mapSafeTransfers', () => {
+  it('books a founder inflow as UC-BANK-01 (Owner Capital)', () => {
+    const [entry] = mapSafeTransfers(
+      {
+        safeAddress: ADDR.safe,
+        transfers: [{ ...base, id: 'i1', from: ADDR.founder, to: ADDR.safe }]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'UC-BANK-01',
+      debit: 'Cash — Safe',
+      credit: 'Owner Capital'
+    })
+  })
+
+  it('books a client inflow as UC-BANK-02 (Service Revenue)', () => {
+    const [entry] = mapSafeTransfers(
+      {
+        safeAddress: ADDR.safe,
+        transfers: [{ ...base, id: 'i2', from: ADDR.client, to: ADDR.safe }]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({ useCase: 'UC-BANK-02', credit: 'Service Revenue' })
+  })
+
+  it('books an inflow from an internal pocket as an internal move', () => {
+    const [entry] = mapSafeTransfers(
+      {
+        safeAddress: ADDR.safe,
+        transfers: [{ ...base, id: 'i3', from: ADDR.bank, to: ADDR.safe }]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'INTERNAL',
+      debit: 'Cash — Safe',
+      credit: 'Cash — Bank',
+      internal: true
+    })
+  })
+
+  it('books an outflow to an internal pocket as an internal move', () => {
+    const [entry] = mapSafeTransfers(
+      {
+        safeAddress: ADDR.safe,
+        transfers: [{ ...base, id: 'o1', from: ADDR.safe, to: ADDR.bank }]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'INTERNAL',
+      debit: 'Cash — Bank',
+      credit: 'Cash — Safe',
+      internal: true
+    })
+  })
+
+  it('flags an external outflow for off-chain reclassification', () => {
+    const [entry] = mapSafeTransfers(
+      {
+        safeAddress: ADDR.safe,
+        transfers: [{ ...base, id: 'o2', from: ADDR.safe, to: ADDR.client }]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'CASH-OUT',
+      credit: 'Cash — Safe',
+      enrichment: 'needs-off-chain-data'
+    })
+  })
+
+  it('skips a transfer that touches neither side of the Safe', () => {
+    const entries = mapSafeTransfers(
+      {
+        safeAddress: ADDR.safe,
+        transfers: [{ ...base, id: 'n1', from: ADDR.bank, to: ADDR.client }]
+      },
+      ctx
+    )
+    expect(entries).toHaveLength(0)
+  })
+})

--- a/app/src/utils/accounting/__tests__/safeDepositRouter.spec.ts
+++ b/app/src/utils/accounting/__tests__/safeDepositRouter.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { mapSafeDepositRouterEvents } from '@/utils/accounting/mappers/safeDepositRouter'
+import { makeCtx, ADDR } from './fixtures'
+
+const ctx = makeCtx()
+
+describe('mapSafeDepositRouterEvents', () => {
+  it('books an investment as UC-SDR-01 (Cash — Safe → Investor Equity)', () => {
+    const [entry] = mapSafeDepositRouterEvents(
+      {
+        deposits: [
+          {
+            id: 'sd1',
+            contractAddress: ADDR.safe,
+            depositor: ADDR.client,
+            token: ADDR.usdcToken,
+            tokenAmount: '5000000',
+            sherAmount: '10000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'UC-SDR-01',
+      debit: 'Cash — Safe',
+      credit: 'Investor Equity',
+      amountUsd: 5, // 5 usdc deposited * $1
+      shares: 10, // 10 SHER minted
+      token: 'usdc',
+      internal: false
+    })
+  })
+
+  it('values a native deposit at the rate of record', () => {
+    const [entry] = mapSafeDepositRouterEvents(
+      {
+        deposits: [
+          {
+            id: 'sd2',
+            contractAddress: ADDR.safe,
+            depositor: ADDR.client,
+            token: '',
+            tokenAmount: '1000000000000000000',
+            sherAmount: '2000000',
+            timestamp: 100
+          }
+        ]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({ token: 'native', amountUsd: 2, shares: 2 })
+  })
+})

--- a/app/src/utils/accounting/enrichment.ts
+++ b/app/src/utils/accounting/enrichment.ts
@@ -1,0 +1,122 @@
+/**
+ * Off-chain enrichment — the join that gives on-chain entries their *category*.
+ *
+ * The chain records *when* money moved; the portal records *what it was for*
+ * (spec §3.2). This step joins the payroll and expense entries the mappers flag
+ * as `needs-off-chain-data` to their portal records:
+ *
+ * - **Payroll** entries (UC-CASH-03) → the member's `WeeklyClaim` / `Claim` /
+ *   `Wage`, attaching the `Payroll` category plus the rate, minutes and claim memo.
+ * - **Expense** entries (UC-EXP-01) → the member's `Expense` budget record,
+ *   attaching the `Operating` category.
+ *
+ * An entry with no matching portal record keeps its `needs-off-chain-data` flag so
+ * the UI can surface the gap; a matched entry flips to `enriched`. Entries the
+ * mappers never flagged (deposits, internal moves, dividends, …) are untouched.
+ */
+import { getAddress, isAddress, type Address } from 'viem'
+import type { Wage, WeeklyClaim } from '@/types/cash-remuneration'
+import type { ExpenseResponse } from '@/types/expense-account'
+import type { LedgerEntry } from './ledgerEntry'
+
+export interface EnrichmentSources {
+  weeklyClaims?: readonly WeeklyClaim[]
+  expenses?: readonly ExpenseResponse[]
+}
+
+function normalize(address: Address | string | null | undefined): string | null {
+  if (!address || !isAddress(address)) return null
+  return getAddress(address).toLowerCase()
+}
+
+/** Index portal records by the member address they belong to. */
+function indexByAddress<T>(
+  rows: readonly T[] | undefined,
+  addressOf: (row: T) => string
+): Map<string, T[]> {
+  const index = new Map<string, T[]>()
+  for (const row of rows ?? []) {
+    const key = normalize(addressOf(row))
+    if (!key) continue
+    const list = index.get(key) ?? []
+    list.push(row)
+    index.set(key, list)
+  }
+  return index
+}
+
+/** Pick the record whose date is closest to the entry's timestamp. */
+function nearest<T>(
+  rows: T[] | undefined,
+  entrySeconds: number,
+  dateOf: (row: T) => number
+): T | undefined {
+  if (!rows?.length) return undefined
+  const target = entrySeconds * 1000
+  return rows.reduce((best, row) =>
+    Math.abs(dateOf(row) - target) < Math.abs(dateOf(best) - target) ? row : best
+  )
+}
+
+/** Human label for a wage rate, e.g. "12 usdc/h". */
+function rateLabel(wage: Wage | undefined): string | null {
+  const rate = wage?.ratePerHour?.[0]
+  return rate ? `${rate.amount} ${rate.type}/h` : null
+}
+
+function enrichPayroll(entry: LedgerEntry, claim: WeeklyClaim | undefined): LedgerEntry {
+  if (!claim) return { ...entry, enrichment: 'needs-off-chain-data' }
+  const parts = [
+    rateLabel(claim.wage),
+    `${claim.minutesWorked} min`,
+    ...(claim.claims ?? []).map((c) => c.memo).filter(Boolean)
+  ].filter(Boolean)
+  return {
+    ...entry,
+    category: 'Payroll',
+    enrichment: 'enriched',
+    memo: parts.length ? `${entry.memo} — ${parts.join('; ')}` : entry.memo
+  }
+}
+
+function enrichExpense(entry: LedgerEntry, expense: ExpenseResponse | undefined): LedgerEntry {
+  if (!expense) return { ...entry, enrichment: 'needs-off-chain-data' }
+  return {
+    ...entry,
+    category: 'Operating',
+    enrichment: 'enriched',
+    memo: `${entry.memo} — expense #${expense.id}`
+  }
+}
+
+/**
+ * Enrich the flagged payroll/expense entries against the portal records. Returns a
+ * new array; entries that need no off-chain data pass through unchanged.
+ */
+export function enrichEntries(
+  entries: readonly LedgerEntry[],
+  sources: EnrichmentSources
+): LedgerEntry[] {
+  const claimsByMember = indexByAddress(sources.weeklyClaims, (c) => c.memberAddress)
+  const expensesByUser = indexByAddress(sources.expenses, (e) => e.userAddress)
+
+  return entries.map((entry) => {
+    if (entry.enrichment !== 'needs-off-chain-data') return entry
+    const member = normalize(entry.counterparty)
+    if (!member) return entry
+
+    if (entry.useCase === 'UC-CASH-03') {
+      const claim = nearest(claimsByMember.get(member), entry.timestamp, (c) =>
+        new Date(c.weekStart).getTime()
+      )
+      return enrichPayroll(entry, claim)
+    }
+    if (entry.useCase === 'UC-EXP-01') {
+      const expense = nearest(expensesByUser.get(member), entry.timestamp, (e) =>
+        new Date(e.createdAt).getTime()
+      )
+      return enrichExpense(entry, expense)
+    }
+    return entry
+  })
+}

--- a/app/src/utils/accounting/ledgerEntry.ts
+++ b/app/src/utils/accounting/ledgerEntry.ts
@@ -1,0 +1,120 @@
+/**
+ * The normalized accounting record the source mappers produce.
+ *
+ * A {@link LedgerEntry} is a **single balanced double-entry posting** — one debit
+ * account and one credit account for the same USD amount — derived from a raw
+ * indexed on-chain event (catalogue §5 / spec §4). A source event that needs more
+ * than two legs (e.g. a wage withdrawal that settles cash *and* mints shares) is
+ * emitted as several entries, one balanced pair each, so the trial balance always
+ * balances by construction.
+ *
+ * Memo-only entries (an `InvestorV1 Minted` with no backing deposit/withdraw —
+ * "Default D", spec §4) carry `debit === credit === null` and `amountUsd === 0`;
+ * they only record a share-count change, not money.
+ */
+import { getAddress, isAddress, type Address } from 'viem'
+import type { TokenId } from '@/constant'
+import type { AccountName } from './chartOfAccounts'
+
+/**
+ * The use case (catalogue §5 / spec §4) a ledger entry realises. The `UC-*`
+ * codes match the money-flow catalogue; the lowercase codes cover moves the
+ * catalogue treats specially (internal pocket-to-pocket moves and fee skims).
+ */
+export type UseCase =
+  /** Founder deposit into a treasury pocket → Owner Capital. */
+  | 'UC-BANK-01'
+  /** Client payment into a treasury pocket → Service Revenue. */
+  | 'UC-BANK-02'
+  /** Fund payroll/expense pockets from Bank — internal move. */
+  | 'UC-BANK-03'
+  /** Invest via SafeDepositRouter → SHER mint (cash lands in Safe). */
+  | 'UC-SDR-01'
+  /** Wage withdrawal settlement (cash leg and/or share leg). */
+  | 'UC-CASH-03'
+  /** Approved member expense payout. */
+  | 'UC-EXP-01'
+  /** Dividend paid to a shareholder. */
+  | 'UC-INV-01'
+  /** Direct SHER mint with no backing deposit/withdraw — memo only, value 0. */
+  | 'DEFAULT-D'
+  /** Fee skim Bank → FeeCollector — internal move, not an expense (spec §5.1). */
+  | 'FEE'
+  /** Generic internal pocket-to-pocket move (funding deposits, owner sweeps). */
+  | 'INTERNAL'
+  /** Plain cash inflow not otherwise classified. */
+  | 'CASH-IN'
+  /** Plain cash outflow not otherwise classified. */
+  | 'CASH-OUT'
+
+/**
+ * Whether an entry has been joined to its off-chain context (the portal
+ * `Wage`/`Claim`/`Expense` records). `not-applicable` is the default for entries
+ * that need no join (deposits, internal moves, dividends, …); `needs-off-chain-data`
+ * flags a payroll/expense entry that found no matching portal record.
+ */
+export type EnrichmentStatus = 'enriched' | 'not-applicable' | 'needs-off-chain-data'
+
+export interface LedgerEntry {
+  /** Stable id — the source row id, suffixed when one event yields several entries. */
+  id: string
+  /** Event time, Unix seconds (from the indexed event). */
+  timestamp: number
+  /** The journal template this entry realises. */
+  useCase: UseCase
+  /** Account debited. `null` only for memo-only Default-D entries. */
+  debit: AccountName | null
+  /** Account credited. `null` only for memo-only Default-D entries. */
+  credit: AccountName | null
+  /** Absolute USD amount. `0` for memo-only entries. */
+  amountUsd: number
+  /** Token actually moved on-chain (for audit / display). */
+  token: TokenId
+  /** Raw on-chain amount in the token's base units (stringified bigint). */
+  rawAmount: string
+  /** The other party of the move (checksum address), when there is one. */
+  counterparty?: Address
+  /** True when both sides are CNC-owned pockets — an internal move (no IS impact). */
+  internal: boolean
+  /** The contract that emitted the source event (the pocket), when known. */
+  contract?: Address
+  /** Transaction hash, when known. */
+  txHash?: string
+  /** Human-readable memo. */
+  memo: string
+  /** Share count for equity / Default-D entries (whole SHER, not base units). */
+  shares?: number
+  /** Accounting category attached during off-chain enrichment (e.g. "Payroll"). */
+  category?: string
+  /** Off-chain enrichment status. */
+  enrichment: EnrichmentStatus
+}
+
+/** Checksum-normalize an address, returning `undefined` for invalid input. */
+export function normalizeCounterparty(
+  address: Address | string | null | undefined
+): Address | undefined {
+  if (!address || !isAddress(address)) return undefined
+  return getAddress(address)
+}
+
+/**
+ * Build a {@link LedgerEntry}, filling the common defaults
+ * (`internal: false`, `enrichment: 'not-applicable'`) so call sites only specify
+ * what differs. `counterparty` is checksum-normalized; nullish/invalid is dropped.
+ */
+export function makeEntry(
+  fields: Omit<LedgerEntry, 'internal' | 'enrichment' | 'counterparty'> &
+    Partial<Pick<LedgerEntry, 'internal' | 'enrichment'>> & {
+      counterparty?: Address | string | null
+    }
+): LedgerEntry {
+  const { counterparty, internal = false, enrichment = 'not-applicable', ...rest } = fields
+  const normalized = normalizeCounterparty(counterparty)
+  return {
+    ...rest,
+    internal,
+    enrichment,
+    ...(normalized ? { counterparty: normalized } : {})
+  }
+}

--- a/app/src/utils/accounting/mappers/bank.ts
+++ b/app/src/utils/accounting/mappers/bank.ts
@@ -1,0 +1,128 @@
+/**
+ * Bank source mapper — turns indexed Bank events into ledger entries.
+ *
+ * Coverage (spec §4):
+ * - `Deposited` / `TokenDeposited` (cash in):
+ *   - from an internal pocket → **internal funding move** (Dr Cash — Bank · Cr that pocket)
+ *   - from a founder           → **UC-BANK-01** (Dr Cash — Bank · Cr Owner Capital)
+ *   - from anyone else (client)→ **UC-BANK-02** (Dr Cash — Bank · Cr Service Revenue)
+ * - `Transfer` / `TokenTransfer` (cash out):
+ *   - to an internal pocket → **UC-BANK-03** funding move (Dr that pocket · Cr Cash — Bank)
+ *   - to anyone else        → unclassified outflow, flagged `needs-off-chain-data`
+ *
+ * Not mapped here: `FeePaid` (handled by the fee mapper — spec §5.1) and
+ * `DividendDistributionTriggered` (a summary event — booking it as well as the
+ * per-shareholder `InvestorV1 DividendPaid` would double-count the dividend).
+ */
+import type {
+  BankDepositRow,
+  BankTokenDepositRow,
+  BankTransferRow,
+  BankTokenTransferRow
+} from '@/types/ponder/bank'
+import { makeEntry, type LedgerEntry } from '@/utils/accounting/ledgerEntry'
+import { isInternalAddress } from '@/utils/accounting/internalAddresses'
+import { atDate, type MapperContext } from './context'
+
+export interface BankMapperInput {
+  deposits?: readonly BankDepositRow[]
+  tokenDeposits?: readonly BankTokenDepositRow[]
+  transfers?: readonly BankTransferRow[]
+  tokenTransfers?: readonly BankTokenTransferRow[]
+}
+
+const BANK = 'Cash — Bank' as const
+
+/** Map a single Bank deposit (native or token) to its ledger entry. */
+function mapDeposit(
+  row: { id: string; depositor: string; amount: string; timestamp: number },
+  token: string | null,
+  ctx: MapperContext
+): LedgerEntry {
+  const amountUsd = ctx.toUsd(BigInt(row.amount), ctx.tokenIdOf(token), atDate(row.timestamp))
+  const sourcePocket = ctx.pocketOf(row.depositor)
+  const isFounder = ctx.founderAddresses.has(row.depositor as `0x${string}`)
+
+  if (sourcePocket) {
+    return makeEntry({
+      id: row.id,
+      timestamp: row.timestamp,
+      useCase: 'INTERNAL',
+      debit: BANK,
+      credit: sourcePocket,
+      amountUsd,
+      token: ctx.tokenIdOf(token),
+      rawAmount: row.amount,
+      counterparty: row.depositor,
+      internal: true,
+      memo: `Internal funding into Bank from ${sourcePocket}`
+    })
+  }
+
+  return makeEntry({
+    id: row.id,
+    timestamp: row.timestamp,
+    useCase: isFounder ? 'UC-BANK-01' : 'UC-BANK-02',
+    debit: BANK,
+    credit: isFounder ? 'Owner Capital' : 'Service Revenue',
+    amountUsd,
+    token: ctx.tokenIdOf(token),
+    rawAmount: row.amount,
+    counterparty: row.depositor,
+    memo: isFounder ? 'Founder deposit into Bank' : 'Client payment into Bank'
+  })
+}
+
+/** Map a single Bank transfer-out (native or token) to its ledger entry. */
+function mapTransfer(
+  row: { id: string; to: string; amount: string; timestamp: number },
+  token: string | null,
+  ctx: MapperContext
+): LedgerEntry {
+  const tokenId = ctx.tokenIdOf(token)
+  const amountUsd = ctx.toUsd(BigInt(row.amount), tokenId, atDate(row.timestamp))
+  const destPocket = ctx.pocketOf(row.to)
+
+  if (destPocket) {
+    return makeEntry({
+      id: row.id,
+      timestamp: row.timestamp,
+      useCase: 'UC-BANK-03',
+      debit: destPocket,
+      credit: BANK,
+      amountUsd,
+      token: tokenId,
+      rawAmount: row.amount,
+      counterparty: row.to,
+      internal: true,
+      memo: `Fund ${destPocket} from Bank`
+    })
+  }
+
+  // External outflow with no Phase-1 use case — provisionally an operating cost,
+  // flagged so an off-chain / manual review can reclassify it (spec §6).
+  return makeEntry({
+    id: row.id,
+    timestamp: row.timestamp,
+    useCase: 'CASH-OUT',
+    debit: 'Operating Expense',
+    credit: BANK,
+    amountUsd,
+    token: tokenId,
+    rawAmount: row.amount,
+    counterparty: row.to,
+    internal: isInternalAddress(row.to, ctx.internalAddresses),
+    memo: 'Unclassified Bank outflow to external address',
+    enrichment: 'needs-off-chain-data'
+  })
+}
+
+/** Map every indexed Bank event in `input` to ledger entries. */
+export function mapBankEvents(input: BankMapperInput, ctx: MapperContext): LedgerEntry[] {
+  return [
+    ...(input.deposits ?? []).map((row) => mapDeposit(row, null, ctx)),
+    ...(input.tokenDeposits ?? []).map((row) => mapDeposit(row, row.token, ctx)),
+    ...(input.transfers ?? []).map((row) => mapTransfer(row, null, ctx)),
+    ...(input.tokenTransfers ?? []).map((row) => mapTransfer(row, row.token, ctx))
+  ]
+}

--- a/app/src/utils/accounting/mappers/cashRemuneration.ts
+++ b/app/src/utils/accounting/mappers/cashRemuneration.ts
@@ -1,0 +1,152 @@
+/**
+ * CashRemuneration source mapper — payroll settlement (spec §4, UC-CASH-03).
+ *
+ * - `Withdraw` (native) / `WithdrawToken` (USDC): the cash leg settles the wage
+ *   liability — Dr Wage Payable · Cr Cash — Payroll. Flagged `needs-off-chain-data`
+ *   so the enrichment step can attach the `Wage`/`Claim` category (rate, minutes,
+ *   memo).
+ * - `WithdrawToken` where the token is **SHER**: the wage is paid in shares —
+ *   Dr Shares to be issued · Cr Investor Equity (the equity leg of UC-CASH-03).
+ *   The matching `InvestorV1 Minted` is therefore *not* re-booked by the investor
+ *   mapper (it would double-count the equity).
+ * - `Deposited`: internal funding of the payroll pocket from Bank — internal move.
+ * - `OwnerTreasuryWithdraw*` (the `ownerWithdrawAllToBank` sweep): internal move
+ *   back to Bank.
+ */
+import { formatUnits } from 'viem'
+import type {
+  CashRemunerationDepositRow,
+  CashRemunerationWithdrawRow,
+  CashRemunerationWithdrawTokenRow,
+  CashRemunerationOwnerTreasuryWithdrawNativeRow,
+  CashRemunerationOwnerTreasuryWithdrawTokenRow
+} from '@/types/ponder/cash-remuneration'
+import { makeEntry, type LedgerEntry } from '@/utils/accounting/ledgerEntry'
+import type { AccountName } from '@/utils/accounting/chartOfAccounts'
+import { atDate, type MapperContext } from './context'
+
+export interface CashRemunerationMapperInput {
+  deposits?: readonly CashRemunerationDepositRow[]
+  withdraws?: readonly CashRemunerationWithdrawRow[]
+  withdrawTokens?: readonly CashRemunerationWithdrawTokenRow[]
+  ownerTreasuryWithdrawNatives?: readonly CashRemunerationOwnerTreasuryWithdrawNativeRow[]
+  ownerTreasuryWithdrawTokens?: readonly CashRemunerationOwnerTreasuryWithdrawTokenRow[]
+}
+
+const PAYROLL = 'Cash — Payroll' as const
+const BANK = 'Cash — Bank' as const
+
+/** Cash leg: settle the wage liability from the payroll pocket. */
+function cashSettlement(
+  row: { id: string; withdrawer: string; amount: string; timestamp: number },
+  token: string | null,
+  ctx: MapperContext
+): LedgerEntry {
+  const tokenId = ctx.tokenIdOf(token)
+  return makeEntry({
+    id: row.id,
+    timestamp: row.timestamp,
+    useCase: 'UC-CASH-03',
+    debit: 'Wage Payable',
+    credit: PAYROLL,
+    amountUsd: ctx.toUsd(BigInt(row.amount), tokenId, atDate(row.timestamp)),
+    token: tokenId,
+    rawAmount: row.amount,
+    counterparty: row.withdrawer,
+    memo: 'Wage withdrawal — cash settlement',
+    enrichment: 'needs-off-chain-data'
+  })
+}
+
+/** Share leg: wage paid in freshly issued SHER. */
+function shareSettlement(row: CashRemunerationWithdrawTokenRow, ctx: MapperContext): LedgerEntry {
+  return makeEntry({
+    id: row.id,
+    timestamp: row.timestamp,
+    useCase: 'UC-CASH-03',
+    debit: 'Shares to be issued',
+    credit: 'Investor Equity',
+    amountUsd: ctx.toUsd(BigInt(row.amount), 'sher', atDate(row.timestamp)),
+    token: 'sher',
+    rawAmount: row.amount,
+    counterparty: row.withdrawer,
+    shares: Number(formatUnits(BigInt(row.amount), 6)),
+    memo: 'Wage paid in shares (SHER mint)',
+    enrichment: 'needs-off-chain-data'
+  })
+}
+
+/** A pocket-to-pocket move that nets out of the income statement. */
+function internalMove(
+  row: { id: string; amount: string; timestamp: number },
+  token: string | null,
+  ctx: MapperContext,
+  opts: { debit: AccountName; credit: AccountName; counterparty?: string; memo: string }
+): LedgerEntry {
+  const tokenId = ctx.tokenIdOf(token)
+  return makeEntry({
+    id: row.id,
+    timestamp: row.timestamp,
+    useCase: 'INTERNAL',
+    debit: opts.debit,
+    credit: opts.credit,
+    amountUsd: ctx.toUsd(BigInt(row.amount), tokenId, atDate(row.timestamp)),
+    token: tokenId,
+    rawAmount: row.amount,
+    counterparty: opts.counterparty,
+    internal: true,
+    memo: opts.memo
+  })
+}
+
+/** Map every indexed CashRemuneration event to ledger entries. */
+export function mapCashRemunerationEvents(
+  input: CashRemunerationMapperInput,
+  ctx: MapperContext
+): LedgerEntry[] {
+  const entries: LedgerEntry[] = []
+
+  for (const row of input.deposits ?? []) {
+    entries.push(
+      internalMove(row, null, ctx, {
+        debit: PAYROLL,
+        credit: ctx.pocketOf(row.depositor) ?? BANK,
+        counterparty: row.depositor,
+        memo: 'Internal funding into Payroll'
+      })
+    )
+  }
+
+  for (const row of input.withdraws ?? []) {
+    entries.push(cashSettlement(row, null, ctx))
+  }
+
+  for (const row of input.withdrawTokens ?? []) {
+    const isSher = ctx.tokenIdOf(row.tokenAddress) === 'sher'
+    entries.push(isSher ? shareSettlement(row, ctx) : cashSettlement(row, row.tokenAddress, ctx))
+  }
+
+  for (const row of input.ownerTreasuryWithdrawNatives ?? []) {
+    entries.push(
+      internalMove(row, null, ctx, {
+        debit: BANK,
+        credit: PAYROLL,
+        counterparty: row.ownerAddress,
+        memo: 'Owner sweep Payroll → Bank'
+      })
+    )
+  }
+
+  for (const row of input.ownerTreasuryWithdrawTokens ?? []) {
+    entries.push(
+      internalMove(row, row.tokenAddress, ctx, {
+        debit: BANK,
+        credit: PAYROLL,
+        counterparty: row.ownerAddress,
+        memo: 'Owner sweep Payroll → Bank'
+      })
+    )
+  }
+
+  return entries
+}

--- a/app/src/utils/accounting/mappers/context.ts
+++ b/app/src/utils/accounting/mappers/context.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared, injectable context every source mapper needs.
+ *
+ * Keeping these as plain injected functions (rather than reaching into Vue
+ * composables or module singletons) lets the mappers stay pure and unit-testable
+ * with hand-built sample data. The reactive wiring (team contracts, the SHER mint
+ * price, the FX rate-of-record) is assembled once by the orchestrator that drives
+ * the mappers; the mappers themselves only see this context.
+ */
+import { getAddress, isAddress, zeroAddress, type Address } from 'viem'
+import type { TokenId } from '@/constant'
+import { resolveTokenIdByAddress } from '@/utils/constantUtil'
+import { toUsd as toUsdUtil, type UsdRateOfRecord } from '@/utils/accounting/toUsd'
+import type { AccountName } from '@/utils/accounting/chartOfAccounts'
+import type { ContractType, TeamContract } from '@/types/teamContract'
+
+export interface MapperContext {
+  /** The team's own contract addresses (checksum-normalized). */
+  internalAddresses: ReadonlySet<Address>
+  /** Addresses treated as founders/owners — their treasury inflows are capital. */
+  founderAddresses: ReadonlySet<Address>
+  /** Convert a raw base-unit amount to USD at the given time. */
+  toUsd: (amount: bigint, token: TokenId, at: Date) => number
+  /** Resolve a token contract address (nullish / zero = native) to a {@link TokenId}. */
+  tokenIdOf: (tokenAddress: string | null | undefined) => TokenId
+  /** The Cash pocket account of a CNC-owned address, or `null` if external. */
+  pocketOf: (address: string | null | undefined) => AccountName | null
+}
+
+/** Maps each CNC money-pocket contract type to its Cash account in the chart. */
+const POCKET_ACCOUNT_BY_TYPE: Partial<Record<ContractType, AccountName>> = {
+  Safe: 'Cash — Safe',
+  Bank: 'Cash — Bank',
+  CashRemunerationEIP712: 'Cash — Payroll',
+  ExpenseAccountEIP712: 'Cash — Expense',
+  // SafeDepositRouter holds no balance — the cash it routes lands in the Safe.
+  SafeDepositRouter: 'Cash — Safe'
+}
+
+function buildPocketIndex(
+  contracts: readonly TeamContract[] | undefined,
+  feeCollector: Address | string | null | undefined
+): Map<Address, AccountName> {
+  const index = new Map<Address, AccountName>()
+  for (const contract of contracts ?? []) {
+    const account = POCKET_ACCOUNT_BY_TYPE[contract.type]
+    if (account && isAddress(contract.address)) index.set(getAddress(contract.address), account)
+  }
+  if (feeCollector && isAddress(feeCollector)) {
+    index.set(getAddress(feeCollector), 'Cash — FeeCollector')
+  }
+  return index
+}
+
+export interface BuildMapperContextInput {
+  /** The team's `TeamContract` rows — resolve the internal pockets. */
+  contracts: readonly TeamContract[] | undefined
+  /** The set of internal addresses (from `collectInternalAddresses`). */
+  internalAddresses: ReadonlySet<Address>
+  /** Founder / owner addresses whose treasury inflows are Owner Capital. */
+  founderAddresses?: Iterable<Address | string>
+  /** The protocol-wide FeeCollector address (its pocket is `Cash — FeeCollector`). */
+  feeCollectorAddress?: Address | string | null
+  /** The on-chain SHER token address, so it resolves to the `sher` {@link TokenId}. */
+  sherTokenAddress?: Address | string | null
+  /** FX resolver for non-pegged tokens (native, SHER) — see {@link toUsdUtil}. */
+  rateOfRecord?: UsdRateOfRecord
+}
+
+/** Normalize a loose address iterable into a checksum-keyed set. */
+function toAddressSet(addresses: Iterable<Address | string> | undefined): Set<Address> {
+  const set = new Set<Address>()
+  for (const address of addresses ?? []) {
+    if (isAddress(address)) set.add(getAddress(address))
+  }
+  return set
+}
+
+/**
+ * Assemble a {@link MapperContext} from a team's resolved data. The defaults wire
+ * `toUsd` to the shared util and `tokenIdOf` to {@link resolveTokenIdByAddress}
+ * (with an explicit SHER override, since SHER shares the zero-address sentinel
+ * with native in the token table).
+ */
+export function buildMapperContext(input: BuildMapperContextInput): MapperContext {
+  const pocketIndex = buildPocketIndex(input.contracts, input.feeCollectorAddress)
+  const sher =
+    input.sherTokenAddress && isAddress(input.sherTokenAddress)
+      ? getAddress(input.sherTokenAddress)
+      : null
+
+  const tokenIdOf = (tokenAddress: string | null | undefined): TokenId => {
+    if (!tokenAddress || !isAddress(tokenAddress) || getAddress(tokenAddress) === zeroAddress) {
+      return 'native'
+    }
+    if (sher && getAddress(tokenAddress) === sher) return 'sher'
+    return resolveTokenIdByAddress(tokenAddress) ?? 'native'
+  }
+
+  const pocketOf = (address: string | null | undefined): AccountName | null => {
+    if (!address || !isAddress(address)) return null
+    return pocketIndex.get(getAddress(address)) ?? null
+  }
+
+  return {
+    internalAddresses: input.internalAddresses,
+    founderAddresses: toAddressSet(input.founderAddresses),
+    toUsd: (amount, token, at) => toUsdUtil(amount, token, at, input.rateOfRecord),
+    tokenIdOf,
+    pocketOf
+  }
+}
+
+/** Convert an indexed event's Unix-seconds timestamp to a `Date` for FX lookup. */
+export function atDate(timestampSeconds: number): Date {
+  return new Date(timestampSeconds * 1000)
+}

--- a/app/src/utils/accounting/mappers/expenseAccount.ts
+++ b/app/src/utils/accounting/mappers/expenseAccount.ts
@@ -1,0 +1,152 @@
+/**
+ * ExpenseAccount source mapper — operating expense payouts (spec §4, UC-EXP-01).
+ *
+ * - `Transfer` / `TokenTransfer` to an external member: an approved expense payout
+ *   — Dr Operating Expense · Cr Cash — Expense. Flagged `needs-off-chain-data` so
+ *   the enrichment step can attach the `Expense` budget category. A transfer to an
+ *   internal pocket is instead an internal move.
+ * - `Deposited` / `TokenDeposited`: internal funding of the expense pocket from
+ *   Bank — internal move.
+ * - `OwnerTreasuryWithdraw*` (the `ownerWithdrawAllToBank` sweep): internal move
+ *   back to Bank.
+ */
+import type {
+  ExpenseDepositRow,
+  ExpenseTokenDepositRow,
+  ExpenseTransferRow,
+  ExpenseTokenTransferRow,
+  ExpenseOwnerTreasuryWithdrawNativeRow,
+  ExpenseOwnerTreasuryWithdrawTokenRow
+} from '@/types/ponder/expense'
+import { makeEntry, type LedgerEntry } from '@/utils/accounting/ledgerEntry'
+import type { AccountName } from '@/utils/accounting/chartOfAccounts'
+import { atDate, type MapperContext } from './context'
+
+export interface ExpenseMapperInput {
+  deposits?: readonly ExpenseDepositRow[]
+  tokenDeposits?: readonly ExpenseTokenDepositRow[]
+  transfers?: readonly ExpenseTransferRow[]
+  tokenTransfers?: readonly ExpenseTokenTransferRow[]
+  ownerTreasuryWithdrawNatives?: readonly ExpenseOwnerTreasuryWithdrawNativeRow[]
+  ownerTreasuryWithdrawTokens?: readonly ExpenseOwnerTreasuryWithdrawTokenRow[]
+}
+
+const EXPENSE = 'Cash — Expense' as const
+const BANK = 'Cash — Bank' as const
+
+/** A pocket-to-pocket move that nets out of the income statement. */
+function internalMove(
+  row: { id: string; amount: string; timestamp: number },
+  token: string | null,
+  ctx: MapperContext,
+  opts: { debit: AccountName; credit: AccountName; counterparty?: string; memo: string }
+): LedgerEntry {
+  const tokenId = ctx.tokenIdOf(token)
+  return makeEntry({
+    id: row.id,
+    timestamp: row.timestamp,
+    useCase: 'INTERNAL',
+    debit: opts.debit,
+    credit: opts.credit,
+    amountUsd: ctx.toUsd(BigInt(row.amount), tokenId, atDate(row.timestamp)),
+    token: tokenId,
+    rawAmount: row.amount,
+    counterparty: opts.counterparty,
+    internal: true,
+    memo: opts.memo
+  })
+}
+
+/** Map an approved payout (or an internal move when the recipient is a pocket). */
+function mapTransfer(
+  row: { id: string; to: string; amount: string; timestamp: number },
+  token: string | null,
+  ctx: MapperContext
+): LedgerEntry {
+  const destPocket = ctx.pocketOf(row.to)
+  if (destPocket) {
+    return internalMove(row, token, ctx, {
+      debit: destPocket,
+      credit: EXPENSE,
+      counterparty: row.to,
+      memo: `Internal move Expense → ${destPocket}`
+    })
+  }
+
+  const tokenId = ctx.tokenIdOf(token)
+  return makeEntry({
+    id: row.id,
+    timestamp: row.timestamp,
+    useCase: 'UC-EXP-01',
+    debit: 'Operating Expense',
+    credit: EXPENSE,
+    amountUsd: ctx.toUsd(BigInt(row.amount), tokenId, atDate(row.timestamp)),
+    token: tokenId,
+    rawAmount: row.amount,
+    counterparty: row.to,
+    memo: 'Approved expense payout',
+    enrichment: 'needs-off-chain-data'
+  })
+}
+
+/** Map every indexed ExpenseAccount event to ledger entries. */
+export function mapExpenseAccountEvents(
+  input: ExpenseMapperInput,
+  ctx: MapperContext
+): LedgerEntry[] {
+  const entries: LedgerEntry[] = []
+
+  for (const row of input.deposits ?? []) {
+    entries.push(
+      internalMove(row, null, ctx, {
+        debit: EXPENSE,
+        credit: ctx.pocketOf(row.depositor) ?? BANK,
+        counterparty: row.depositor,
+        memo: 'Internal funding into Expense'
+      })
+    )
+  }
+
+  for (const row of input.tokenDeposits ?? []) {
+    entries.push(
+      internalMove(row, row.token, ctx, {
+        debit: EXPENSE,
+        credit: ctx.pocketOf(row.depositor) ?? BANK,
+        counterparty: row.depositor,
+        memo: 'Internal funding into Expense'
+      })
+    )
+  }
+
+  for (const row of input.transfers ?? []) {
+    entries.push(mapTransfer(row, null, ctx))
+  }
+
+  for (const row of input.tokenTransfers ?? []) {
+    entries.push(mapTransfer(row, row.token, ctx))
+  }
+
+  for (const row of input.ownerTreasuryWithdrawNatives ?? []) {
+    entries.push(
+      internalMove(row, null, ctx, {
+        debit: BANK,
+        credit: EXPENSE,
+        counterparty: row.ownerAddress,
+        memo: 'Owner sweep Expense → Bank'
+      })
+    )
+  }
+
+  for (const row of input.ownerTreasuryWithdrawTokens ?? []) {
+    entries.push(
+      internalMove(row, row.token, ctx, {
+        debit: BANK,
+        credit: EXPENSE,
+        counterparty: row.ownerAddress,
+        memo: 'Owner sweep Expense → Bank'
+      })
+    )
+  }
+
+  return entries
+}

--- a/app/src/utils/accounting/mappers/fees.ts
+++ b/app/src/utils/accounting/mappers/fees.ts
@@ -1,0 +1,70 @@
+/**
+ * Fee source mapper — a fee on a Bank transfer is an **internal move**, not an
+ * expense (spec §5.1): cash shifts from the Bank pocket to the FeeCollector
+ * pocket, both CNC-owned. It nets out of the income statement; it only
+ * redistributes cash.
+ *
+ *     Dr Cash — FeeCollector   (fee)
+ *        Cr Cash — Bank        (fee)
+ *
+ * The same fee is written twice on-chain — once by Bank (`FeePaid`) and once by
+ * FeeCollector (`FeePaid`). We dedup the dual-write on (token, amount, timestamp)
+ * so the fee is booked exactly once. The Bank row is canonical when both exist.
+ */
+import type { BankFeePaidRow } from '@/types/ponder/bank'
+import { makeEntry, type LedgerEntry } from '@/utils/accounting/ledgerEntry'
+import { atDate, type MapperContext } from './context'
+
+/** A `FeePaid` row emitted by the FeeCollector contract (the dual-write twin). */
+export interface FeeCollectorFeePaidRow {
+  id: string
+  contractAddress: string
+  payer: string
+  token: string | null
+  amount: string
+  timestamp: number
+}
+
+export interface FeeMapperInput {
+  /** `FeePaid` rows emitted by the Bank contract (`bankFeePaids`). */
+  bankFeePaids?: readonly BankFeePaidRow[]
+  /** `FeePaid` rows emitted by the FeeCollector contract (`feeCollectorFeePaids`). */
+  feeCollectorFeePaids?: readonly FeeCollectorFeePaidRow[]
+}
+
+/** Dedup key for the dual-write: a fee is one economic event across both logs. */
+function feeKey(row: { token: string | null; amount: string; timestamp: number }): string {
+  return `${(row.token ?? 'native').toLowerCase()}|${row.amount}|${row.timestamp}`
+}
+
+/** Map deduped fee skims to internal Bank → FeeCollector moves. */
+export function mapFees(input: FeeMapperInput, ctx: MapperContext): LedgerEntry[] {
+  const seen = new Set<string>()
+  const entries: LedgerEntry[] = []
+
+  const push = (row: { id: string; token: string | null; amount: string; timestamp: number }) => {
+    const key = feeKey(row)
+    if (seen.has(key)) return
+    seen.add(key)
+    const tokenId = ctx.tokenIdOf(row.token)
+    entries.push(
+      makeEntry({
+        id: row.id,
+        timestamp: row.timestamp,
+        useCase: 'FEE',
+        debit: 'Cash — FeeCollector',
+        credit: 'Cash — Bank',
+        amountUsd: ctx.toUsd(BigInt(row.amount), tokenId, atDate(row.timestamp)),
+        token: tokenId,
+        rawAmount: row.amount,
+        internal: true,
+        memo: 'Fee skim Bank → FeeCollector (internal move)'
+      })
+    )
+  }
+
+  // Bank rows first so they win the dedup as the canonical source.
+  for (const row of input.bankFeePaids ?? []) push(row)
+  for (const row of input.feeCollectorFeePaids ?? []) push(row)
+  return entries
+}

--- a/app/src/utils/accounting/mappers/index.ts
+++ b/app/src/utils/accounting/mappers/index.ts
@@ -1,0 +1,68 @@
+/**
+ * Source-mapper barrel + orchestrator.
+ *
+ * {@link buildCncLedgerEntries} runs every source mapper over the raw indexed
+ * events, concatenates the resulting ledger entries, sorts them chronologically,
+ * and runs the off-chain enrichment join. The result is the normalized general
+ * ledger the trial-balance / income-statement / balance-sheet layer rolls up.
+ */
+import { enrichEntries, type EnrichmentSources } from '@/utils/accounting/enrichment'
+import type { LedgerEntry } from '@/utils/accounting/ledgerEntry'
+import { mapBankEvents, type BankMapperInput } from './bank'
+import { mapFees, type FeeMapperInput } from './fees'
+import { mapCashRemunerationEvents, type CashRemunerationMapperInput } from './cashRemuneration'
+import { mapExpenseAccountEvents, type ExpenseMapperInput } from './expenseAccount'
+import { mapInvestorEvents, type InvestorMapperInput } from './investor'
+import { mapSafeTransfers, type SafeMapperInput } from './safe'
+import { mapSafeDepositRouterEvents, type SafeDepositRouterMapperInput } from './safeDepositRouter'
+import type { MapperContext } from './context'
+
+export * from './context'
+export * from './bank'
+export * from './fees'
+export * from './cashRemuneration'
+export * from './expenseAccount'
+export * from './investor'
+export * from './safe'
+export * from './safeDepositRouter'
+
+/** Every raw-event source the mappers consume, grouped by contract. */
+export interface LedgerSources {
+  bank?: BankMapperInput
+  fees?: FeeMapperInput
+  cashRemuneration?: CashRemunerationMapperInput
+  expenseAccount?: ExpenseMapperInput
+  investor?: InvestorMapperInput
+  safe?: SafeMapperInput
+  safeDepositRouter?: SafeDepositRouterMapperInput
+}
+
+/** Run every mapper and return the unsorted, un-enriched ledger entries. */
+export function mapAllSources(sources: LedgerSources, ctx: MapperContext): LedgerEntry[] {
+  const entries: LedgerEntry[] = []
+  if (sources.bank) entries.push(...mapBankEvents(sources.bank, ctx))
+  if (sources.fees) entries.push(...mapFees(sources.fees, ctx))
+  if (sources.cashRemuneration) {
+    entries.push(...mapCashRemunerationEvents(sources.cashRemuneration, ctx))
+  }
+  if (sources.expenseAccount) entries.push(...mapExpenseAccountEvents(sources.expenseAccount, ctx))
+  if (sources.investor) entries.push(...mapInvestorEvents(sources.investor, ctx))
+  if (sources.safe) entries.push(...mapSafeTransfers(sources.safe, ctx))
+  if (sources.safeDepositRouter) {
+    entries.push(...mapSafeDepositRouterEvents(sources.safeDepositRouter, ctx))
+  }
+  return entries
+}
+
+/**
+ * Build the CNC general ledger end to end: map every source, sort by time, then
+ * enrich payroll/expense entries with their off-chain category.
+ */
+export function buildCncLedgerEntries(
+  sources: LedgerSources,
+  ctx: MapperContext,
+  offChain: EnrichmentSources = {}
+): LedgerEntry[] {
+  const mapped = mapAllSources(sources, ctx).sort((a, b) => a.timestamp - b.timestamp)
+  return enrichEntries(mapped, offChain)
+}

--- a/app/src/utils/accounting/mappers/investor.ts
+++ b/app/src/utils/accounting/mappers/investor.ts
@@ -1,0 +1,106 @@
+/**
+ * InvestorV1 source mapper — share mints, dividends (spec §4, UC-INV-01).
+ *
+ * A bare `Minted` event is ambiguous (catalogue §5.4): it can back a capital
+ * raise (SafeDepositRouter `Deposited`), a wage-in-shares (CashRemuneration
+ * `WithdrawToken` in SHER), or a direct mint. So we correlate each mint with the
+ * deposits/withdraws that *already* booked the equity, and:
+ *
+ * - **backed** mint (matches a SafeDepositRouter deposit or a SHER wage withdraw)
+ *   → emit nothing: the Investor Equity was booked by UC-SDR-01 / UC-CASH-03.
+ *   Re-booking it here would double-count the equity.
+ * - **unbacked** mint → **Default D**: a memo-only entry (+N shares, value 0, no
+ *   monetary posting).
+ *
+ * `DividendPaid` → UC-INV-01 (Dr Dividend Expense · Cr Cash — Bank). The summary
+ * events `InvestorV1 DividendDistributed` and `Bank DividendDistributionTriggered`
+ * are **not** mapped — they describe the same money as the per-shareholder
+ * `DividendPaid` rows and would double-count the dividend.
+ */
+import { formatUnits } from 'viem'
+import type {
+  InvestorMintRow,
+  InvestorDividendPaidRow,
+  SafeDepositRow
+} from '@/types/ponder/investor'
+import type { CashRemunerationWithdrawTokenRow } from '@/types/ponder/cash-remuneration'
+import { makeEntry, type LedgerEntry } from '@/utils/accounting/ledgerEntry'
+import { atDate, type MapperContext } from './context'
+
+export interface InvestorMapperInput {
+  mints?: readonly InvestorMintRow[]
+  dividendPaids?: readonly InvestorDividendPaidRow[]
+  /** SafeDepositRouter deposits, to recognise capital-raise-backed mints. */
+  safeDepositRouterDeposits?: readonly SafeDepositRow[]
+  /** CashRemuneration `WithdrawToken` rows, to recognise wage-in-shares mints. */
+  cashRemunerationWithdrawTokens?: readonly CashRemunerationWithdrawTokenRow[]
+}
+
+/** `${shareholder}|${sherBaseUnits}` — keys a mint to the move that backs it. */
+function backingKey(shareholder: string, sherAmount: string): string {
+  return `${shareholder.toLowerCase()}|${sherAmount}`
+}
+
+/** A consumable multiset of the (shareholder, SHER amount) pairs already booked. */
+function buildBackedMints(input: InvestorMapperInput, ctx: MapperContext): Map<string, number> {
+  const counts = new Map<string, number>()
+  const add = (key: string) => counts.set(key, (counts.get(key) ?? 0) + 1)
+
+  for (const row of input.safeDepositRouterDeposits ?? []) {
+    add(backingKey(row.depositor, row.sherAmount))
+  }
+  for (const row of input.cashRemunerationWithdrawTokens ?? []) {
+    if (ctx.tokenIdOf(row.tokenAddress) === 'sher') add(backingKey(row.withdrawer, row.amount))
+  }
+  return counts
+}
+
+/** Map InvestorV1 events: backed mints drop out, the rest become memos/dividends. */
+export function mapInvestorEvents(input: InvestorMapperInput, ctx: MapperContext): LedgerEntry[] {
+  const backed = buildBackedMints(input, ctx)
+  const entries: LedgerEntry[] = []
+
+  for (const row of input.mints ?? []) {
+    const key = backingKey(row.shareholder, row.amount)
+    const remaining = backed.get(key) ?? 0
+    if (remaining > 0) {
+      backed.set(key, remaining - 1) // backed — equity already booked elsewhere
+      continue
+    }
+    entries.push(
+      makeEntry({
+        id: row.id,
+        timestamp: row.timestamp,
+        useCase: 'DEFAULT-D',
+        debit: null,
+        credit: null,
+        amountUsd: 0,
+        token: 'sher',
+        rawAmount: row.amount,
+        counterparty: row.shareholder,
+        shares: Number(formatUnits(BigInt(row.amount), 6)),
+        memo: 'Direct SHER mint — memo only (Default D)'
+      })
+    )
+  }
+
+  for (const row of input.dividendPaids ?? []) {
+    const tokenId = ctx.tokenIdOf(row.token)
+    entries.push(
+      makeEntry({
+        id: row.id,
+        timestamp: row.timestamp,
+        useCase: 'UC-INV-01',
+        debit: 'Dividend Expense',
+        credit: 'Cash — Bank',
+        amountUsd: ctx.toUsd(BigInt(row.amount), tokenId, atDate(row.timestamp)),
+        token: tokenId,
+        rawAmount: row.amount,
+        counterparty: row.shareholder,
+        memo: 'Dividend paid to shareholder'
+      })
+    )
+  }
+
+  return entries
+}

--- a/app/src/utils/accounting/mappers/safe.ts
+++ b/app/src/utils/accounting/mappers/safe.ts
@@ -1,0 +1,126 @@
+/**
+ * Safe source mapper — plain treasury cash in/out through the team's Gnosis Safe.
+ *
+ * The Safe emits no bespoke accounting events, so its moves arrive as generic
+ * token transfers (native or ERC-20) classified relative to the Safe address:
+ *
+ * - **Inflow** (to the Safe):
+ *   - from an internal pocket → internal move (Dr Cash — Safe · Cr that pocket)
+ *   - from a founder          → UC-BANK-01 (Dr Cash — Safe · Cr Owner Capital)
+ *   - from anyone else        → UC-BANK-02 (Dr Cash — Safe · Cr Service Revenue)
+ * - **Outflow** (from the Safe):
+ *   - to an internal pocket → internal move (Dr that pocket · Cr Cash — Safe)
+ *   - to anyone else        → unclassified outflow, flagged `needs-off-chain-data`
+ *
+ * Investments routed through the SafeDepositRouter also land in the Safe, but they
+ * are booked from the router event (UC-SDR-01) — those transfers should be excluded
+ * by the caller to avoid double-counting the same cash.
+ */
+import { getAddress, isAddress } from 'viem'
+import { makeEntry, type LedgerEntry } from '@/utils/accounting/ledgerEntry'
+import { isInternalAddress } from '@/utils/accounting/internalAddresses'
+import { atDate, type MapperContext } from './context'
+
+/** A normalized token transfer touching the Safe (native = `token: null`). */
+export interface SafeTransferRow {
+  id: string
+  from: string
+  to: string
+  token: string | null
+  amount: string
+  timestamp: number
+  txHash?: string
+}
+
+export interface SafeMapperInput {
+  /** The team's Safe address — classifies each transfer as inflow vs outflow. */
+  safeAddress: string
+  transfers?: readonly SafeTransferRow[]
+}
+
+const SAFE = 'Cash — Safe' as const
+
+function sameAddress(a: string, b: string): boolean {
+  return isAddress(a) && isAddress(b) && getAddress(a) === getAddress(b)
+}
+
+function mapInflow(row: SafeTransferRow, ctx: MapperContext): LedgerEntry {
+  const tokenId = ctx.tokenIdOf(row.token)
+  const base = {
+    id: row.id,
+    timestamp: row.timestamp,
+    debit: SAFE,
+    amountUsd: ctx.toUsd(BigInt(row.amount), tokenId, atDate(row.timestamp)),
+    token: tokenId,
+    rawAmount: row.amount,
+    counterparty: row.from,
+    txHash: row.txHash
+  }
+  const sourcePocket = ctx.pocketOf(row.from)
+  if (sourcePocket) {
+    return makeEntry({
+      ...base,
+      useCase: 'INTERNAL',
+      credit: sourcePocket,
+      internal: true,
+      memo: `Internal funding into Safe from ${sourcePocket}`
+    })
+  }
+  if (ctx.founderAddresses.has(row.from as `0x${string}`)) {
+    return makeEntry({
+      ...base,
+      useCase: 'UC-BANK-01',
+      credit: 'Owner Capital',
+      memo: 'Founder deposit into Safe'
+    })
+  }
+  return makeEntry({
+    ...base,
+    useCase: 'UC-BANK-02',
+    credit: 'Service Revenue',
+    memo: 'Client payment into Safe'
+  })
+}
+
+function mapOutflow(row: SafeTransferRow, ctx: MapperContext): LedgerEntry {
+  const tokenId = ctx.tokenIdOf(row.token)
+  const base = {
+    id: row.id,
+    timestamp: row.timestamp,
+    credit: SAFE,
+    amountUsd: ctx.toUsd(BigInt(row.amount), tokenId, atDate(row.timestamp)),
+    token: tokenId,
+    rawAmount: row.amount,
+    counterparty: row.to,
+    txHash: row.txHash
+  }
+  const destPocket = ctx.pocketOf(row.to)
+  if (destPocket) {
+    return makeEntry({
+      ...base,
+      useCase: 'INTERNAL',
+      debit: destPocket,
+      internal: true,
+      memo: `Internal move Safe → ${destPocket}`
+    })
+  }
+  return makeEntry({
+    ...base,
+    useCase: 'CASH-OUT',
+    debit: 'Operating Expense',
+    internal: isInternalAddress(row.to, ctx.internalAddresses),
+    memo: 'Unclassified Safe outflow to external address',
+    enrichment: 'needs-off-chain-data'
+  })
+}
+
+/** Map every Safe transfer to a ledger entry, skipping ones that miss the Safe. */
+export function mapSafeTransfers(input: SafeMapperInput, ctx: MapperContext): LedgerEntry[] {
+  const entries: LedgerEntry[] = []
+  for (const row of input.transfers ?? []) {
+    if (sameAddress(row.to, input.safeAddress)) entries.push(mapInflow(row, ctx))
+    else if (sameAddress(row.from, input.safeAddress)) entries.push(mapOutflow(row, ctx))
+    // A transfer touching neither side of the Safe is not a Safe move — skip it.
+  }
+  return entries
+}

--- a/app/src/utils/accounting/mappers/safeDepositRouter.ts
+++ b/app/src/utils/accounting/mappers/safeDepositRouter.ts
@@ -1,0 +1,44 @@
+/**
+ * SafeDepositRouter source mapper — invest → SHER mint (spec §4, UC-SDR-01).
+ *
+ * An investor deposits a token through the router; the cash lands in the Safe and
+ * SHER is minted in return:
+ *
+ *     Dr Cash — Safe        (deposited token, USD-valued)
+ *        Cr Investor Equity
+ *
+ * The router event already carries both the deposited `tokenAmount` and the
+ * `sherAmount`, so the equity is fully booked here. The matching `InvestorV1
+ * Minted` is **not** re-booked by the investor mapper — see {@link mapInvestorEvents}.
+ */
+import { formatUnits } from 'viem'
+import type { SafeDepositRow } from '@/types/ponder/investor'
+import { makeEntry, type LedgerEntry } from '@/utils/accounting/ledgerEntry'
+import { atDate, type MapperContext } from './context'
+
+export interface SafeDepositRouterMapperInput {
+  deposits?: readonly SafeDepositRow[]
+}
+
+/** Map every SafeDepositRouter `Deposited` event to a UC-SDR-01 entry. */
+export function mapSafeDepositRouterEvents(
+  input: SafeDepositRouterMapperInput,
+  ctx: MapperContext
+): LedgerEntry[] {
+  return (input.deposits ?? []).map((row) => {
+    const tokenId = ctx.tokenIdOf(row.token)
+    return makeEntry({
+      id: row.id,
+      timestamp: row.timestamp,
+      useCase: 'UC-SDR-01',
+      debit: 'Cash — Safe',
+      credit: 'Investor Equity',
+      amountUsd: ctx.toUsd(BigInt(row.tokenAmount), tokenId, atDate(row.timestamp)),
+      token: tokenId,
+      rawAmount: row.tokenAmount,
+      counterparty: row.depositor,
+      shares: Number(formatUnits(BigInt(row.sherAmount), 6)),
+      memo: 'Investment via SafeDepositRouter → SHER mint'
+    })
+  })
+}


### PR DESCRIPTION
# Description

Fixes #2113 — source mappers + off-chain enrichment, step 2/5 of the CNC accounting pipeline (parent #1887).

## Summary

This PR adds the layer that turns raw indexed on-chain events into a normalized, double-entry accounting feed: it introduces a `LedgerEntry` model (one balanced debit-to-credit posting per entry, so the trial balance balances by construction) and a set of pure, unit-tested mappers, driven by an injectable `MapperContext`, that translate every CNC money source into the right journal entry per the spec (Bank deposits to Owner Capital for founders / Service Revenue for clients; SafeDepositRouter investments to Investor Equity; CashRemuneration withdrawals to wage settlement in cash or shares; ExpenseAccount payouts to Operating Expense; Safe transfers in/out; InvestorV1 dividends to Dividend Expense), while treating fees and inter-pocket moves as internal (no income-statement impact) and guarding the two classic pitfalls (deduping the Bank/FeeCollector fee dual-write, and correlating SHER mints to their backing deposit/withdrawal so equity and dividends are never double-counted); a final enrichment step joins payroll/expense entries to their portal records (`Wage`/`Claim`/`Expense`) to attach a category, flagging anything unmatched as `needs-off-chain-data`. It is a pure logic layer (not yet wired to the UI — that's step 3, #2117), ships with 73 unit tests, and passes lint / format / type-check / unit tests in `app/`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Large PR justification

Issue #2113 explicitly consolidates the previously-split mapper tickets (it "replaces #2114, #2115, #2116") into one deliverable because the parts are tightly coupled: every mapper depends on the same new `LedgerEntry` model and `MapperContext`, the dividend non-double-count and fee dedup invariants span the Bank/FeeCollector/Investor mappers together, and the enrichment join and orchestrator only make sense once all mappers exist. The line overage is almost entirely the per-mapper specs and shared fixtures. The follow-up ledger/statements work is already separated into step 3 (#2117).
