### PR TITLE
feat: ✨ ledger engine + statements (buildLedger + GL/trial balance + IS/BS) — step 3/5

### DIFF
--- a/app/src/utils/accounting/__tests__/balanceSheet.spec.ts
+++ b/app/src/utils/accounting/__tests__/balanceSheet.spec.ts
@@ -29,7 +29,8 @@ describe('buildBalanceSheet — catalogue §6.6', () => {
     const claimOnly = catalogueLedger.filter((e) => e.useCase === 'UC-CASH-02')
     const bs = buildBalanceSheet(claimOnly)
     const wagePayable = bs.liabilities.find((l) => l.account === 'Wage Payable')?.amount ?? 0
-    const sharesToIssue = bs.liabilities.find((l) => l.account === 'Shares to be issued')?.amount ?? 0
+    const sharesToIssue =
+      bs.liabilities.find((l) => l.account === 'Shares to be issued')?.amount ?? 0
     expect(wagePayable).toBeCloseTo(40.8, 2)
     expect(sharesToIssue).toBeCloseTo(10, 2)
     // The accrual books Payroll Expense against the liabilities — still balances.

--- a/app/src/utils/accounting/__tests__/balanceSheet.spec.ts
+++ b/app/src/utils/accounting/__tests__/balanceSheet.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { buildBalanceSheet } from '@/utils/accounting/balanceSheet'
+import { catalogueLedger } from './catalogueLedger'
+
+describe('buildBalanceSheet — catalogue §6.6', () => {
+  const bs = buildBalanceSheet(catalogueLedger)
+
+  it('satisfies Assets = Liabilities + Equity', () => {
+    expect(bs.totalAssets).toBeCloseTo(142.2, 2)
+    expect(bs.totalLiabilities).toBeCloseTo(0, 2)
+    expect(bs.totalEquity).toBeCloseTo(142.2, 2)
+    expect(bs.identityGap).toBeCloseTo(0, 2)
+    expect(bs.balanced).toBe(true)
+  })
+
+  it('rolls the cash pockets into one Cash line and closes net income into equity', () => {
+    expect(bs.cash).toBeCloseTo(142.2, 2)
+    expect(bs.investorEquity).toBeCloseTo(138, 2)
+    expect(bs.ownerCapital).toBeCloseTo(0, 2)
+    expect(bs.retainedEarnings).toBeCloseTo(4.2, 2)
+  })
+
+  it('shows no open liabilities once Wage Payable & Shares to be issued settle', () => {
+    expect(bs.liabilities).toHaveLength(0)
+  })
+
+  it('surfaces open liabilities when a claim is accrued without a withdrawal', () => {
+    // Only the accrual legs of transaction #9 (claim), no withdrawal #10.
+    const claimOnly = catalogueLedger.filter((e) => e.useCase === 'UC-CASH-02')
+    const bs = buildBalanceSheet(claimOnly)
+    const wagePayable = bs.liabilities.find((l) => l.account === 'Wage Payable')?.amount ?? 0
+    const sharesToIssue = bs.liabilities.find((l) => l.account === 'Shares to be issued')?.amount ?? 0
+    expect(wagePayable).toBeCloseTo(40.8, 2)
+    expect(sharesToIssue).toBeCloseTo(10, 2)
+    // The accrual books Payroll Expense against the liabilities — still balances.
+    expect(bs.totalLiabilities).toBeCloseTo(50.8, 2)
+    expect(bs.retainedEarnings).toBeCloseTo(-50.8, 2)
+    expect(bs.balanced).toBe(true)
+  })
+})

--- a/app/src/utils/accounting/__tests__/buildLedger.spec.ts
+++ b/app/src/utils/accounting/__tests__/buildLedger.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { buildLedger, dedupeInternalTransfers } from '@/utils/accounting/buildLedger'
+import type { LedgerEntry } from '@/utils/accounting/ledgerEntry'
+import { catalogueLedger } from './catalogueLedger'
+
+describe('buildLedger — summary on the catalogue worked example', () => {
+  const { summary, entries } = buildLedger(catalogueLedger)
+
+  it('rolls up the period totals (cash / income / expense / equity / net)', () => {
+    expect(summary.cash).toBeCloseTo(142.2, 2)
+    expect(summary.income).toBeCloseTo(115, 2)
+    expect(summary.expense).toBeCloseTo(110.8, 2)
+    expect(summary.equity).toBeCloseTo(138, 2)
+    expect(summary.netIncome).toBeCloseTo(4.2, 2)
+  })
+
+  it('counts only monetary postings (memo-only Default-D excluded)', () => {
+    // 25 entries in the fixture, one of which is the memo-only direct mint.
+    expect(entries).toHaveLength(25)
+    expect(summary.entryCount).toBe(24)
+  })
+
+  it('returns entries sorted chronologically', () => {
+    const times = entries.map((e) => e.timestamp)
+    expect(times).toEqual([...times].sort((a, b) => a - b))
+  })
+})
+
+describe('dedupeInternalTransfers', () => {
+  const base: Omit<LedgerEntry, 'id'> = {
+    timestamp: 100,
+    useCase: 'INTERNAL',
+    debit: 'Cash — Bank',
+    credit: 'Cash — Safe',
+    amountUsd: 71.75,
+    token: 'usdc',
+    rawAmount: '71750000',
+    internal: true,
+    memo: 'Safe → Bank',
+    enrichment: 'not-applicable'
+  }
+
+  it('collapses the two contract-side recordings of one internal transfer', () => {
+    const bankSide: LedgerEntry = { ...base, id: 'bank-1' }
+    const safeSide: LedgerEntry = { ...base, id: 'safe-1' }
+    const result = dedupeInternalTransfers([bankSide, safeSide])
+    expect(result).toHaveLength(1)
+    expect(result[0]!.id).toBe('bank-1') // first occurrence wins
+  })
+
+  it('keeps internal moves that differ in amount or token', () => {
+    const usd: LedgerEntry = { ...base, id: 'a', amountUsd: 50, rawAmount: '50000000' }
+    const pol: LedgerEntry = { ...base, id: 'b', amountUsd: 1.72, rawAmount: '22', token: 'native' }
+    expect(dedupeInternalTransfers([usd, pol])).toHaveLength(2)
+  })
+
+  it('never dedupes external postings (unique source events)', () => {
+    const ext: LedgerEntry = { ...base, id: 'x', internal: false, useCase: 'UC-BANK-02' }
+    const twin: LedgerEntry = { ...ext, id: 'y' }
+    expect(dedupeInternalTransfers([ext, twin])).toHaveLength(2)
+  })
+})

--- a/app/src/utils/accounting/__tests__/catalogueLedger.ts
+++ b/app/src/utils/accounting/__tests__/catalogueLedger.ts
@@ -62,31 +62,125 @@ export const catalogueLedger: LedgerEntry[] = [
   // 2 — Geor invests $10 & gets SHER
   post({ day: 1, useCase: 'UC-SDR-01', debit: 'Cash — Safe', credit: 'Investor Equity', usd: 10 }),
   // 3 — Client pays $100 (service)
-  post({ day: 3, useCase: 'UC-BANK-02', debit: 'Cash — Bank', credit: 'Service Revenue', usd: 100 }),
+  post({
+    day: 3,
+    useCase: 'UC-BANK-02',
+    debit: 'Cash — Bank',
+    credit: 'Service Revenue',
+    usd: 100
+  }),
   // 4 — Deploy $30 to trader
   post({ day: 4, useCase: 'CASH-OUT', debit: 'Trading account', credit: 'Cash — Bank', usd: 30 }),
   // 5 — Trader returns $30 capital + $15 profit
   post({ day: 10, useCase: 'CASH-IN', debit: 'Cash — Safe', credit: 'Trading account', usd: 30 }),
   post({ day: 10, useCase: 'CASH-IN', debit: 'Cash — Safe', credit: 'Trading Gain', usd: 15 }),
   // 6 — Transfer $71.75 Safe → Bank (fund operations) — internal
-  post({ day: 11, useCase: 'INTERNAL', debit: 'Cash — Bank', credit: 'Cash — Safe', usd: 71.75, internal: true }),
+  post({
+    day: 11,
+    useCase: 'INTERNAL',
+    debit: 'Cash — Bank',
+    credit: 'Cash — Safe',
+    usd: 71.75,
+    internal: true
+  }),
   // 7 — Ravi funds payroll $50.02 (fee $0.02) — internal
-  post({ day: 12, useCase: 'UC-BANK-03', debit: 'Cash — Payroll', credit: 'Cash — Bank', usd: 50, internal: true }),
-  post({ day: 12, useCase: 'FEE', debit: 'Cash — FeeCollector', credit: 'Cash — Bank', usd: 0.02, internal: true }),
+  post({
+    day: 12,
+    useCase: 'UC-BANK-03',
+    debit: 'Cash — Payroll',
+    credit: 'Cash — Bank',
+    usd: 50,
+    internal: true
+  }),
+  post({
+    day: 12,
+    useCase: 'FEE',
+    debit: 'Cash — FeeCollector',
+    credit: 'Cash — Bank',
+    usd: 0.02,
+    internal: true
+  }),
   // 8 — Ravi funds payroll 22 POL ($1.73, fee $0.01) — internal
-  post({ day: 12, useCase: 'UC-BANK-03', debit: 'Cash — Payroll', credit: 'Cash — Bank', usd: 1.72, internal: true, token: 'native' }),
-  post({ day: 12, useCase: 'FEE', debit: 'Cash — FeeCollector', credit: 'Cash — Bank', usd: 0.01, internal: true, token: 'native' }),
+  post({
+    day: 12,
+    useCase: 'UC-BANK-03',
+    debit: 'Cash — Payroll',
+    credit: 'Cash — Bank',
+    usd: 1.72,
+    internal: true,
+    token: 'native'
+  }),
+  post({
+    day: 12,
+    useCase: 'FEE',
+    debit: 'Cash — FeeCollector',
+    credit: 'Cash — Bank',
+    usd: 0.01,
+    internal: true,
+    token: 'native'
+  }),
   // 9 — Geor claims $40 + 10 POL + 10 SHER (accrual)
-  post({ day: 13, useCase: 'UC-CASH-02', debit: 'Payroll Expense', credit: 'Wage Payable', usd: 40.8, category: 'Payroll' }),
-  post({ day: 13, useCase: 'UC-CASH-02', debit: 'Payroll Expense', credit: 'Shares to be issued', usd: 10, token: 'sher', category: 'Payroll' }),
+  post({
+    day: 13,
+    useCase: 'UC-CASH-02',
+    debit: 'Payroll Expense',
+    credit: 'Wage Payable',
+    usd: 40.8,
+    category: 'Payroll'
+  }),
+  post({
+    day: 13,
+    useCase: 'UC-CASH-02',
+    debit: 'Payroll Expense',
+    credit: 'Shares to be issued',
+    usd: 10,
+    token: 'sher',
+    category: 'Payroll'
+  }),
   // 10 — Geor withdraws the same (settles cash leg + mints SHER)
-  post({ day: 15, useCase: 'UC-CASH-03', debit: 'Wage Payable', credit: 'Cash — Payroll', usd: 40.8, category: 'Payroll' }),
-  post({ day: 15, useCase: 'UC-CASH-03', debit: 'Shares to be issued', credit: 'Investor Equity', usd: 10, token: 'sher', category: 'Payroll' }),
+  post({
+    day: 15,
+    useCase: 'UC-CASH-03',
+    debit: 'Wage Payable',
+    credit: 'Cash — Payroll',
+    usd: 40.8,
+    category: 'Payroll'
+  }),
+  post({
+    day: 15,
+    useCase: 'UC-CASH-03',
+    debit: 'Shares to be issued',
+    credit: 'Investor Equity',
+    usd: 10,
+    token: 'sher',
+    category: 'Payroll'
+  }),
   // 11 — Ravi funds expense $50 (fee $0.20) — internal
-  post({ day: 16, useCase: 'UC-BANK-03', debit: 'Cash — Expense', credit: 'Cash — Bank', usd: 49.8, internal: true }),
-  post({ day: 16, useCase: 'FEE', debit: 'Cash — FeeCollector', credit: 'Cash — Bank', usd: 0.2, internal: true }),
+  post({
+    day: 16,
+    useCase: 'UC-BANK-03',
+    debit: 'Cash — Expense',
+    credit: 'Cash — Bank',
+    usd: 49.8,
+    internal: true
+  }),
+  post({
+    day: 16,
+    useCase: 'FEE',
+    debit: 'Cash — FeeCollector',
+    credit: 'Cash — Bank',
+    usd: 0.2,
+    internal: true
+  }),
   // 12 — Geor withdraws $20 expense
-  post({ day: 17, useCase: 'UC-EXP-01', debit: 'Operating Expense', credit: 'Cash — Expense', usd: 20, category: 'Operating' }),
+  post({
+    day: 17,
+    useCase: 'UC-EXP-01',
+    debit: 'Operating Expense',
+    credit: 'Cash — Expense',
+    usd: 20,
+    category: 'Operating'
+  }),
   // 13 — Redeploy $30 to trader
   post({ day: 18, useCase: 'CASH-OUT', debit: 'Trading account', credit: 'Cash — Bank', usd: 30 }),
   // 14 — Trader returns $10 & loses $20
@@ -97,7 +191,16 @@ export const catalogueLedger: LedgerEntry[] = [
   // 16 — GRG invests $8 & gets SHER
   post({ day: 25, useCase: 'UC-SDR-01', debit: 'Cash — Safe', credit: 'Investor Equity', usd: 8 }),
   // 17 — Ravi mints 30 SHER for himself (Default D) — memo only, value 0
-  post({ day: 26, useCase: 'DEFAULT-D', debit: null, credit: null, usd: 0, token: 'sher', shares: 30, memo: 'Direct mint +30 SHER' }),
+  post({
+    day: 26,
+    useCase: 'DEFAULT-D',
+    debit: null,
+    credit: null,
+    usd: 0,
+    token: 'sher',
+    shares: 30,
+    memo: 'Direct mint +30 SHER'
+  }),
   // 18 — Ravi pays $20 dividend
   post({ day: 28, useCase: 'UC-INV-01', debit: 'Dividend Expense', credit: 'Cash — Bank', usd: 20 })
 ]

--- a/app/src/utils/accounting/__tests__/catalogueLedger.ts
+++ b/app/src/utils/accounting/__tests__/catalogueLedger.ts
@@ -1,0 +1,103 @@
+/**
+ * The money-flow catalogue worked example (§6) as a consolidated
+ * {@link LedgerEntry} feed — the canonical fixture for the statement layer.
+ *
+ * It is the §6.2 general-ledger journal, with every multi-leg transaction split
+ * into balanced debit/credit pairs (the shape the source mappers emit). It
+ * balances at every level: journal total 678.10, trial balance 253, assets 142.20
+ * = equity 142.20 — so any builder that reproduces those numbers is correct.
+ *
+ * Trading lines (UC-TRD) are authored by hand here: their live feed is the
+ * deferred Polymarket / GC:Trader integration (spec §1), so no mapper produces
+ * them, but the catalogue exercises them and the books must still balance.
+ */
+import type { TokenId } from '@/constant'
+import type { AccountName } from '@/utils/accounting/chartOfAccounts'
+import type { LedgerEntry, UseCase } from '@/utils/accounting/ledgerEntry'
+
+/** Unix seconds for a given day in March 2026 (the worked-example period). */
+function march(day: number): number {
+  return Math.floor(Date.UTC(2026, 2, day) / 1000)
+}
+
+let seq = 0
+
+interface PostInput {
+  day: number
+  useCase: UseCase
+  debit: AccountName | null
+  credit: AccountName | null
+  usd: number
+  internal?: boolean
+  token?: TokenId
+  memo?: string
+  shares?: number
+  category?: string
+}
+
+/** Build one balanced posting (or a memo-only entry when debit/credit are null). */
+function post(input: PostInput): LedgerEntry {
+  seq += 1
+  return {
+    id: `cat-${seq}`,
+    timestamp: march(input.day),
+    useCase: input.useCase,
+    debit: input.debit,
+    credit: input.credit,
+    amountUsd: input.usd,
+    token: input.token ?? 'usdc',
+    rawAmount: String(input.usd),
+    internal: input.internal ?? false,
+    memo: input.memo ?? '',
+    enrichment: 'not-applicable',
+    ...(input.shares !== undefined ? { shares: input.shares } : {}),
+    ...(input.category !== undefined ? { category: input.category } : {})
+  }
+}
+
+/** The §6.2 journal, balanced pair by balanced pair (18 transactions, #17 memo). */
+export const catalogueLedger: LedgerEntry[] = [
+  // 1 — Ravi invests $100 & gets SHER
+  post({ day: 1, useCase: 'UC-SDR-01', debit: 'Cash — Safe', credit: 'Investor Equity', usd: 100 }),
+  // 2 — Geor invests $10 & gets SHER
+  post({ day: 1, useCase: 'UC-SDR-01', debit: 'Cash — Safe', credit: 'Investor Equity', usd: 10 }),
+  // 3 — Client pays $100 (service)
+  post({ day: 3, useCase: 'UC-BANK-02', debit: 'Cash — Bank', credit: 'Service Revenue', usd: 100 }),
+  // 4 — Deploy $30 to trader
+  post({ day: 4, useCase: 'CASH-OUT', debit: 'Trading account', credit: 'Cash — Bank', usd: 30 }),
+  // 5 — Trader returns $30 capital + $15 profit
+  post({ day: 10, useCase: 'CASH-IN', debit: 'Cash — Safe', credit: 'Trading account', usd: 30 }),
+  post({ day: 10, useCase: 'CASH-IN', debit: 'Cash — Safe', credit: 'Trading Gain', usd: 15 }),
+  // 6 — Transfer $71.75 Safe → Bank (fund operations) — internal
+  post({ day: 11, useCase: 'INTERNAL', debit: 'Cash — Bank', credit: 'Cash — Safe', usd: 71.75, internal: true }),
+  // 7 — Ravi funds payroll $50.02 (fee $0.02) — internal
+  post({ day: 12, useCase: 'UC-BANK-03', debit: 'Cash — Payroll', credit: 'Cash — Bank', usd: 50, internal: true }),
+  post({ day: 12, useCase: 'FEE', debit: 'Cash — FeeCollector', credit: 'Cash — Bank', usd: 0.02, internal: true }),
+  // 8 — Ravi funds payroll 22 POL ($1.73, fee $0.01) — internal
+  post({ day: 12, useCase: 'UC-BANK-03', debit: 'Cash — Payroll', credit: 'Cash — Bank', usd: 1.72, internal: true, token: 'native' }),
+  post({ day: 12, useCase: 'FEE', debit: 'Cash — FeeCollector', credit: 'Cash — Bank', usd: 0.01, internal: true, token: 'native' }),
+  // 9 — Geor claims $40 + 10 POL + 10 SHER (accrual)
+  post({ day: 13, useCase: 'UC-CASH-02', debit: 'Payroll Expense', credit: 'Wage Payable', usd: 40.8, category: 'Payroll' }),
+  post({ day: 13, useCase: 'UC-CASH-02', debit: 'Payroll Expense', credit: 'Shares to be issued', usd: 10, token: 'sher', category: 'Payroll' }),
+  // 10 — Geor withdraws the same (settles cash leg + mints SHER)
+  post({ day: 15, useCase: 'UC-CASH-03', debit: 'Wage Payable', credit: 'Cash — Payroll', usd: 40.8, category: 'Payroll' }),
+  post({ day: 15, useCase: 'UC-CASH-03', debit: 'Shares to be issued', credit: 'Investor Equity', usd: 10, token: 'sher', category: 'Payroll' }),
+  // 11 — Ravi funds expense $50 (fee $0.20) — internal
+  post({ day: 16, useCase: 'UC-BANK-03', debit: 'Cash — Expense', credit: 'Cash — Bank', usd: 49.8, internal: true }),
+  post({ day: 16, useCase: 'FEE', debit: 'Cash — FeeCollector', credit: 'Cash — Bank', usd: 0.2, internal: true }),
+  // 12 — Geor withdraws $20 expense
+  post({ day: 17, useCase: 'UC-EXP-01', debit: 'Operating Expense', credit: 'Cash — Expense', usd: 20, category: 'Operating' }),
+  // 13 — Redeploy $30 to trader
+  post({ day: 18, useCase: 'CASH-OUT', debit: 'Trading account', credit: 'Cash — Bank', usd: 30 }),
+  // 14 — Trader returns $10 & loses $20
+  post({ day: 24, useCase: 'CASH-IN', debit: 'Cash — Bank', credit: 'Trading account', usd: 10 }),
+  post({ day: 24, useCase: 'CASH-OUT', debit: 'Trading Loss', credit: 'Trading account', usd: 20 }),
+  // 15 — HR invests $10 & gets SHER
+  post({ day: 25, useCase: 'UC-SDR-01', debit: 'Cash — Safe', credit: 'Investor Equity', usd: 10 }),
+  // 16 — GRG invests $8 & gets SHER
+  post({ day: 25, useCase: 'UC-SDR-01', debit: 'Cash — Safe', credit: 'Investor Equity', usd: 8 }),
+  // 17 — Ravi mints 30 SHER for himself (Default D) — memo only, value 0
+  post({ day: 26, useCase: 'DEFAULT-D', debit: null, credit: null, usd: 0, token: 'sher', shares: 30, memo: 'Direct mint +30 SHER' }),
+  // 18 — Ravi pays $20 dividend
+  post({ day: 28, useCase: 'UC-INV-01', debit: 'Dividend Expense', credit: 'Cash — Bank', usd: 20 })
+]

--- a/app/src/utils/accounting/__tests__/generalLedger.spec.ts
+++ b/app/src/utils/accounting/__tests__/generalLedger.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { buildGeneralLedger } from '@/utils/accounting/generalLedger'
+import type { AccountName } from '@/utils/accounting/chartOfAccounts'
+import type { LedgerEntry } from '@/utils/accounting/ledgerEntry'
+import { catalogueLedger } from './catalogueLedger'
+
+describe('buildGeneralLedger — catalogue worked example', () => {
+  const gl = buildGeneralLedger(catalogueLedger)
+  const balanceOf = (account: AccountName): number =>
+    gl.trialBalance.find((r) => r.account === account)?.balance ?? 0
+
+  it('is balanced gross (Σ debit lines = Σ credit lines = journal total)', () => {
+    expect(gl.totalDebit).toBeCloseTo(678.1, 2)
+    expect(gl.totalCredit).toBeCloseTo(678.1, 2)
+  })
+
+  it('is balanced net (Σ debit balances = Σ credit balances = trial balance)', () => {
+    expect(gl.debitBalanceTotal).toBeCloseTo(253, 2)
+    expect(gl.creditBalanceTotal).toBeCloseTo(253, 2)
+    expect(gl.balanced).toBe(true)
+  })
+
+  it('produces the catalogue §6.3 / §6.4 per-account balances', () => {
+    expect(balanceOf('Cash — Safe')).toBeCloseTo(101.25, 2)
+    expect(balanceOf('Cash — Bank')).toBeCloseTo(0, 2)
+    expect(balanceOf('Cash — Payroll')).toBeCloseTo(10.92, 2)
+    expect(balanceOf('Cash — FeeCollector')).toBeCloseTo(0.23, 2)
+    expect(balanceOf('Cash — Expense')).toBeCloseTo(29.8, 2)
+    expect(balanceOf('Trading account')).toBeCloseTo(0, 2)
+    expect(balanceOf('Investor Equity')).toBeCloseTo(138, 2)
+    expect(balanceOf('Payroll Expense')).toBeCloseTo(50.8, 2)
+    expect(balanceOf('Wage Payable')).toBeCloseTo(0, 2)
+  })
+
+  it('emits two journal lines per posting and none for memo-only entries', () => {
+    const memo = gl.entries.find((e) => e.useCase === 'DEFAULT-D')
+    expect(memo?.lines).toHaveLength(0)
+    const dividend = gl.entries.find((e) => e.useCase === 'UC-INV-01')
+    expect(dividend?.lines).toHaveLength(2)
+  })
+
+  it('drops accounts with no activity (e.g. Owner Capital this period)', () => {
+    expect(gl.trialBalance.some((r) => r.account === 'Owner Capital')).toBe(false)
+  })
+
+  it('flags an unbalanced book when a posting is missing a leg', () => {
+    const halfPosting: LedgerEntry = {
+      id: 'broken',
+      timestamp: 1,
+      useCase: 'CASH-IN',
+      debit: 'Cash — Bank',
+      credit: null, // mapper bug: a debit with no matching credit
+      amountUsd: 5,
+      token: 'usdc',
+      rawAmount: '5000000',
+      internal: false,
+      memo: 'half posting',
+      enrichment: 'not-applicable'
+    }
+    const broken = buildGeneralLedger([...catalogueLedger, halfPosting])
+    expect(broken.balanced).toBe(false)
+    expect(broken.totalDebit).not.toBeCloseTo(broken.totalCredit, 2)
+  })
+})

--- a/app/src/utils/accounting/__tests__/incomeStatement.spec.ts
+++ b/app/src/utils/accounting/__tests__/incomeStatement.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { buildIncomeStatement } from '@/utils/accounting/incomeStatement'
+import { catalogueLedger } from './catalogueLedger'
+
+describe('buildIncomeStatement — catalogue §6.5', () => {
+  const is = buildIncomeStatement(catalogueLedger)
+  const lineFor = (account: string): number =>
+    [...is.revenue, ...is.expenses].find((l) => l.account === account)?.amount ?? 0
+
+  it('totals revenue, expenses and net income', () => {
+    expect(is.totalRevenue).toBeCloseTo(115, 2)
+    expect(is.totalExpenses).toBeCloseTo(110.8, 2)
+    expect(is.netIncome).toBeCloseTo(4.2, 2)
+  })
+
+  it('breaks revenue and expenses into their account lines', () => {
+    expect(lineFor('Service Revenue')).toBeCloseTo(100, 2)
+    expect(lineFor('Trading Gain')).toBeCloseTo(15, 2)
+    expect(lineFor('Payroll Expense')).toBeCloseTo(50.8, 2)
+    expect(lineFor('Operating Expense')).toBeCloseTo(20, 2)
+    expect(lineFor('Trading Loss')).toBeCloseTo(20, 2)
+    expect(lineFor('Dividend Expense')).toBeCloseTo(20, 2)
+  })
+
+  it('ignores internal cash-to-cash moves (no income/expense impact)', () => {
+    const internalOnly = catalogueLedger.filter((e) => e.internal)
+    const is = buildIncomeStatement(internalOnly)
+    expect(is.revenue).toHaveLength(0)
+    expect(is.expenses).toHaveLength(0)
+    expect(is.netIncome).toBe(0)
+  })
+})

--- a/app/src/utils/accounting/balanceSheet.ts
+++ b/app/src/utils/accounting/balanceSheet.ts
@@ -1,0 +1,106 @@
+/**
+ * Balance sheet (issue #2117, catalogue §6.6).
+ *
+ * Assets = Liabilities + Equity, as of the end of the period. Built from the
+ * consolidated feed plus the period's net income, which closes into
+ * **Retained Earnings**:
+ *
+ *  - Assets       cash pockets (rolled up) + Trading account + any other asset
+ *  - Liabilities  Wage Payable + Shares to be issued (net; 0 once settled)
+ *  - Equity       Owner Capital + Investor Equity + Retained Earnings (net income)
+ *
+ * The identity holds by construction: every posting is balanced and net income
+ * is exactly Σincome − Σexpense, so contributed-equity + retained-earnings +
+ * liabilities = the asset side. In the worked example: assets 142.20 = equity
+ * 142.20 (Investor Equity 138 + Retained Earnings 4.20), liabilities 0.
+ */
+import { ACCOUNT_NAMES, classOf, type AccountName } from './chartOfAccounts'
+import { netBalanceByAccount } from './generalLedger'
+import { buildIncomeStatement } from './incomeStatement'
+import type { LedgerEntry } from './ledgerEntry'
+import type { StatementLine } from './incomeStatement'
+
+/** The five on-chain cash pockets that roll up into the single Cash line. */
+const CASH_ACCOUNTS: ReadonlySet<AccountName> = new Set<AccountName>([
+  'Cash — Bank',
+  'Cash — Safe',
+  'Cash — Payroll',
+  'Cash — Expense',
+  'Cash — FeeCollector'
+])
+
+export interface BalanceSheet {
+  /** Total cash across every pocket (the single "Cash" asset line). */
+  cash: number
+  /** Per-pocket cash breakdown, for drill-down. */
+  cashByPocket: StatementLine[]
+  /** Non-cash assets (Trading account, …) with non-zero balance. */
+  otherAssets: StatementLine[]
+  totalAssets: number
+  /** Liability accounts with non-zero balance (Wage Payable, Shares to be issued). */
+  liabilities: StatementLine[]
+  totalLiabilities: number
+  ownerCapital: number
+  investorEquity: number
+  /** Period net income closed into equity. */
+  retainedEarnings: number
+  totalEquity: number
+  /** totalAssets − (totalLiabilities + totalEquity); ~0 means it balances. */
+  identityGap: number
+  /** True when |identityGap| ≤ one cent. */
+  balanced: boolean
+}
+
+const CENT = 0.01
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+/** Build the balance sheet as of the end of the supplied feed. */
+export function buildBalanceSheet(entries: readonly LedgerEntry[]): BalanceSheet {
+  const net = netBalanceByAccount(entries)
+  const balanceOf = (account: AccountName): number => net.get(account) ?? 0
+
+  let cash = 0
+  const cashByPocket: StatementLine[] = []
+  const otherAssets: StatementLine[] = []
+  const liabilities: StatementLine[] = []
+
+  for (const account of ACCOUNT_NAMES) {
+    const amount = balanceOf(account)
+    if (CASH_ACCOUNTS.has(account)) {
+      cash += amount
+      if (amount !== 0) cashByPocket.push({ account, amount })
+      continue
+    }
+    const cls = classOf(account)
+    if (cls === 'ASSET' && amount !== 0) otherAssets.push({ account, amount })
+    else if (cls === 'LIABILITY' && amount !== 0) liabilities.push({ account, amount })
+  }
+
+  cash = round2(cash)
+  const totalLiabilities = round2(liabilities.reduce((sum, l) => sum + l.amount, 0))
+  const ownerCapital = balanceOf('Owner Capital')
+  const investorEquity = balanceOf('Investor Equity')
+  const retainedEarnings = buildIncomeStatement(entries).netIncome
+
+  const totalAssets = round2(cash + otherAssets.reduce((sum, a) => sum + a.amount, 0))
+  const totalEquity = round2(ownerCapital + investorEquity + retainedEarnings)
+  const identityGap = round2(totalAssets - (totalLiabilities + totalEquity))
+
+  return {
+    cash,
+    cashByPocket,
+    otherAssets,
+    totalAssets,
+    liabilities,
+    totalLiabilities,
+    ownerCapital,
+    investorEquity,
+    retainedEarnings,
+    totalEquity,
+    identityGap,
+    balanced: Math.abs(identityGap) < CENT
+  }
+}

--- a/app/src/utils/accounting/buildLedger.ts
+++ b/app/src/utils/accounting/buildLedger.ts
@@ -1,0 +1,144 @@
+/**
+ * Ledger consolidation — the entry point of the statement layer (issue #2117).
+ *
+ * The source mappers (issue #2113) already emit a clean feed of **balanced
+ * double-entry postings**: every {@link LedgerEntry} carries one debit account,
+ * one credit account and a single USD amount, and a multi-leg event is split
+ * into several balanced pairs. This module takes that merged, chronologically
+ * sorted feed and:
+ *
+ * 1. **Eliminates the internal-transfer double count.** A move between two of the
+ *    team's own pockets (Safe ⇄ Bank ⇄ payroll/expense, and the fee skim
+ *    Bank → FeeCollector) is indexed twice — once by the sending contract and
+ *    once by the receiving one — so two identical `internal` postings describe
+ *    one economic move. We collapse the twins to a single posting so no internal
+ *    transfer or fee is counted twice (the fee dual-write is already deduped in
+ *    the fee mapper; this is the cross-contract belt-and-suspenders).
+ * 2. **Computes the summary totals** (cash on hand, income, expense, contributed
+ *    equity, net income) the dashboard cards read.
+ *
+ * Internal moves are kept in the feed (they let the general-ledger view show the
+ * funding journal, catalogue §6.2) — they are cash-to-cash, so they net to zero
+ * on total cash and never touch the income statement or equity. What matters is
+ * that each is recorded exactly once.
+ */
+import { classOf, type AccountName } from './chartOfAccounts'
+import type { LedgerEntry } from './ledgerEntry'
+
+/** The five on-chain cash pockets that roll up into total Cash. */
+const CASH_ACCOUNTS: ReadonlySet<AccountName> = new Set<AccountName>([
+  'Cash — Bank',
+  'Cash — Safe',
+  'Cash — Payroll',
+  'Cash — Expense',
+  'Cash — FeeCollector'
+])
+
+/** Equity accounts that hold *contributed* capital (not derived retained earnings). */
+const CONTRIBUTED_EQUITY: ReadonlySet<AccountName> = new Set<AccountName>([
+  'Owner Capital',
+  'Investor Equity'
+])
+
+export interface AccountingSummary {
+  /** Net cash across every pocket (Σ debits − Σ credits to the Cash accounts). */
+  cash: number
+  /** Net income-account total over the period (Service Revenue + Trading Gain …). */
+  income: number
+  /** Net expense-account total over the period (payroll, operating, dividend …). */
+  expense: number
+  /** Contributed equity (Owner Capital + Investor Equity), excluding retained earnings. */
+  equity: number
+  /** income − expense — the period's bottom line (becomes Retained Earnings). */
+  netIncome: number
+  /** Number of monetary postings counted (memo-only Default-D entries excluded). */
+  entryCount: number
+}
+
+export interface BuiltLedger {
+  /** Deduped, chronologically sorted postings — the canonical consolidated feed. */
+  entries: LedgerEntry[]
+  /** Roll-up totals for the summary cards. */
+  summary: AccountingSummary
+}
+
+/** Round to cents — statement figures are USD reporting currency. */
+function round2(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+/** Content key for an internal posting, so the two contract-side twins collapse. */
+function internalKey(entry: LedgerEntry): string {
+  return [entry.debit, entry.credit, entry.rawAmount, entry.token, entry.timestamp].join('|')
+}
+
+/**
+ * Drop the duplicate twin of every internal transfer / fee. Only `internal`
+ * postings are deduped — external entries keep their unique source ids. The
+ * first occurrence wins (mapper order makes the Bank-side row canonical).
+ */
+export function dedupeInternalTransfers(entries: readonly LedgerEntry[]): LedgerEntry[] {
+  const seen = new Set<string>()
+  const out: LedgerEntry[] = []
+  for (const entry of entries) {
+    if (entry.internal) {
+      const key = internalKey(entry)
+      if (seen.has(key)) continue
+      seen.add(key)
+    }
+    out.push(entry)
+  }
+  return out
+}
+
+/** Whether a posting moves real value (memo-only Default-D entries have no legs). */
+function isMonetary(entry: LedgerEntry): boolean {
+  return entry.debit !== null || entry.credit !== null
+}
+
+/** Aggregate the summary totals from the deduped feed. */
+function summarize(entries: readonly LedgerEntry[]): AccountingSummary {
+  let cash = 0
+  let income = 0
+  let expense = 0
+  let equity = 0
+  let entryCount = 0
+
+  for (const entry of entries) {
+    if (!isMonetary(entry)) continue
+    entryCount += 1
+    const amount = entry.amountUsd
+
+    if (entry.debit) {
+      if (CASH_ACCOUNTS.has(entry.debit)) cash += amount
+      else if (classOf(entry.debit) === 'EXPENSE') expense += amount
+      else if (classOf(entry.debit) === 'INCOME') income -= amount
+      else if (CONTRIBUTED_EQUITY.has(entry.debit)) equity -= amount
+    }
+    if (entry.credit) {
+      if (CASH_ACCOUNTS.has(entry.credit)) cash -= amount
+      else if (classOf(entry.credit) === 'INCOME') income += amount
+      else if (classOf(entry.credit) === 'EXPENSE') expense -= amount
+      else if (CONTRIBUTED_EQUITY.has(entry.credit)) equity += amount
+    }
+  }
+
+  return {
+    cash: round2(cash),
+    income: round2(income),
+    expense: round2(expense),
+    equity: round2(equity),
+    netIncome: round2(income - expense),
+    entryCount
+  }
+}
+
+/**
+ * Consolidate a merged, sorted {@link LedgerEntry} feed into the canonical ledger:
+ * collapse internal-transfer twins and compute the summary totals. The result
+ * feeds the general ledger, income statement and balance sheet.
+ */
+export function buildLedger(entries: readonly LedgerEntry[]): BuiltLedger {
+  const deduped = dedupeInternalTransfers(entries).sort((a, b) => a.timestamp - b.timestamp)
+  return { entries: deduped, summary: summarize(deduped) }
+}

--- a/app/src/utils/accounting/generalLedger.ts
+++ b/app/src/utils/accounting/generalLedger.ts
@@ -1,0 +1,189 @@
+/**
+ * General ledger + trial balance (issue #2117).
+ *
+ * Turns the consolidated {@link LedgerEntry} feed into the double-entry journal
+ * (catalogue §6.2) and rolls it up into a trial balance (catalogue §6.4) that
+ * must satisfy two identities:
+ *
+ * - **Gross**: Σ of every journal debit line = Σ of every credit line
+ *   (`totalDebit === totalCredit`) — the journal total, 678.10 in the worked example.
+ * - **Net**: Σ of the debit-normal account balances = Σ of the credit-normal
+ *   balances (`debitBalanceTotal === creditBalanceTotal`) — 253 in the worked example.
+ *
+ * Each {@link LedgerEntry} is already a balanced posting, so a single entry maps
+ * to two journal lines (one debit, one credit). Memo-only Default-D entries
+ * (debit === credit === null) carry no lines — they record a share count only.
+ */
+import {
+  ACCOUNT_NAMES,
+  classOf,
+  isDebitNormal,
+  type AccountClass,
+  type AccountName
+} from './chartOfAccounts'
+import type { LedgerEntry, UseCase } from './ledgerEntry'
+
+export interface JournalLine {
+  account: AccountName
+  debit: number
+  credit: number
+}
+
+export interface JournalEntry {
+  /** Source ledger-entry id. */
+  id: string
+  /** Event time, Unix seconds. */
+  timestamp: number
+  useCase: UseCase
+  memo: string
+  /** True when both legs are CNC-owned pockets (internal move, no IS impact). */
+  internal: boolean
+  /** Off-chain category, when enriched (e.g. "Payroll", "Operating"). */
+  category?: string
+  /** Transaction hash, when known. */
+  txHash?: string
+  /** The balanced journal lines (empty for memo-only entries). */
+  lines: JournalLine[]
+}
+
+export interface TrialBalanceRow {
+  account: AccountName
+  accountClass: AccountClass
+  /** Σ of every debit line posted to this account (gross). */
+  totalDebit: number
+  /** Σ of every credit line posted to this account (gross). */
+  totalCredit: number
+  /** Net balance on the account's normal side (≥ 0 for a clean book). */
+  balance: number
+}
+
+export interface GeneralLedger {
+  /** The journal, chronologically ordered. */
+  entries: JournalEntry[]
+  /** Per-account roll-up; rows with no activity are dropped. */
+  trialBalance: TrialBalanceRow[]
+  /** Σ of all gross debit lines (the journal total). */
+  totalDebit: number
+  /** Σ of all gross credit lines (the journal total). */
+  totalCredit: number
+  /** Σ of the debit-normal account balances (the trial-balance debit column). */
+  debitBalanceTotal: number
+  /** Σ of the credit-normal account balances (the trial-balance credit column). */
+  creditBalanceTotal: number
+  /** True when both the gross and net identities hold to the cent. */
+  balanced: boolean
+}
+
+const CENT = 0.01
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+/**
+ * Net balance of every touched account, signed on its **normal** side
+ * (debit-normal → debit − credit; credit-normal → credit − debit), so a clean
+ * book yields non-negative balances. Shared by the income statement and balance
+ * sheet so all three statements roll up the exact same numbers.
+ */
+export function netBalanceByAccount(entries: readonly LedgerEntry[]): Map<AccountName, number> {
+  const net = new Map<AccountName, number>()
+  const add = (account: AccountName, signed: number): void => {
+    net.set(account, (net.get(account) ?? 0) + signed)
+  }
+  for (const entry of entries) {
+    if (entry.debit) add(entry.debit, isDebitNormal(entry.debit) ? entry.amountUsd : -entry.amountUsd)
+    if (entry.credit) {
+      add(entry.credit, isDebitNormal(entry.credit) ? -entry.amountUsd : entry.amountUsd)
+    }
+  }
+  for (const [account, value] of net) net.set(account, round2(value))
+  return net
+}
+
+/** Convert one balanced posting into its (up to two) journal lines. */
+function linesOf(entry: LedgerEntry): JournalLine[] {
+  const lines: JournalLine[] = []
+  if (entry.debit) lines.push({ account: entry.debit, debit: entry.amountUsd, credit: 0 })
+  if (entry.credit) lines.push({ account: entry.credit, debit: 0, credit: entry.amountUsd })
+  return lines
+}
+
+/** Build the journal entries (the ordered double-entry log). */
+export function buildJournal(entries: readonly LedgerEntry[]): JournalEntry[] {
+  return entries
+    .map((entry) => ({
+      id: entry.id,
+      timestamp: entry.timestamp,
+      useCase: entry.useCase,
+      memo: entry.memo,
+      internal: entry.internal,
+      ...(entry.category ? { category: entry.category } : {}),
+      ...(entry.txHash ? { txHash: entry.txHash } : {}),
+      lines: linesOf(entry)
+    }))
+    .sort((a, b) => a.timestamp - b.timestamp)
+}
+
+/**
+ * Build the double-entry general ledger and its trial balance from the
+ * consolidated feed.
+ */
+export function buildGeneralLedger(entries: readonly LedgerEntry[]): GeneralLedger {
+  const journal = buildJournal(entries)
+
+  const debits = new Map<AccountName, number>()
+  const credits = new Map<AccountName, number>()
+  for (const entry of journal) {
+    for (const line of entry.lines) {
+      debits.set(line.account, (debits.get(line.account) ?? 0) + line.debit)
+      credits.set(line.account, (credits.get(line.account) ?? 0) + line.credit)
+    }
+  }
+
+  let totalDebit = 0
+  let totalCredit = 0
+  let debitBalanceTotal = 0
+  let creditBalanceTotal = 0
+  const trialBalance: TrialBalanceRow[] = []
+
+  // Iterate the chart in declared order so the trial balance reads top-down.
+  for (const account of ACCOUNT_NAMES) {
+    const grossDebit = round2(debits.get(account) ?? 0)
+    const grossCredit = round2(credits.get(account) ?? 0)
+    if (grossDebit === 0 && grossCredit === 0) continue
+
+    totalDebit += grossDebit
+    totalCredit += grossCredit
+    const balance = round2(
+      isDebitNormal(account) ? grossDebit - grossCredit : grossCredit - grossDebit
+    )
+    if (isDebitNormal(account)) debitBalanceTotal += balance
+    else creditBalanceTotal += balance
+
+    trialBalance.push({
+      account,
+      accountClass: classOf(account),
+      totalDebit: grossDebit,
+      totalCredit: grossCredit,
+      balance
+    })
+  }
+
+  totalDebit = round2(totalDebit)
+  totalCredit = round2(totalCredit)
+  debitBalanceTotal = round2(debitBalanceTotal)
+  creditBalanceTotal = round2(creditBalanceTotal)
+
+  return {
+    entries: journal,
+    trialBalance,
+    totalDebit,
+    totalCredit,
+    debitBalanceTotal,
+    creditBalanceTotal,
+    balanced:
+      Math.abs(totalDebit - totalCredit) < CENT &&
+      Math.abs(debitBalanceTotal - creditBalanceTotal) < CENT
+  }
+}

--- a/app/src/utils/accounting/generalLedger.ts
+++ b/app/src/utils/accounting/generalLedger.ts
@@ -92,7 +92,8 @@ export function netBalanceByAccount(entries: readonly LedgerEntry[]): Map<Accoun
     net.set(account, (net.get(account) ?? 0) + signed)
   }
   for (const entry of entries) {
-    if (entry.debit) add(entry.debit, isDebitNormal(entry.debit) ? entry.amountUsd : -entry.amountUsd)
+    if (entry.debit)
+      add(entry.debit, isDebitNormal(entry.debit) ? entry.amountUsd : -entry.amountUsd)
     if (entry.credit) {
       add(entry.credit, isDebitNormal(entry.credit) ? -entry.amountUsd : entry.amountUsd)
     }

--- a/app/src/utils/accounting/incomeStatement.ts
+++ b/app/src/utils/accounting/incomeStatement.ts
@@ -1,0 +1,70 @@
+/**
+ * Income statement (issue #2117, catalogue §6.5).
+ *
+ * Groups the income and expense accounts of the consolidated feed into revenue
+ * and expense lines and derives the net result:
+ *
+ *     Net income = Σ revenue − Σ expenses
+ *
+ * Internal moves (cash-to-cash) and equity / balance-sheet postings never touch
+ * an income or expense account, so they are naturally excluded. In the worked
+ * example: revenue 115 (Service 100 + Trading Gain 15), expenses 110.80
+ * (Payroll 50.80 + Operating 20 + Trading Loss 20 + Dividend 20) → net +4.20.
+ */
+import { ACCOUNT_NAMES, classOf, type AccountName } from './chartOfAccounts'
+import { netBalanceByAccount } from './generalLedger'
+import type { LedgerEntry } from './ledgerEntry'
+
+export interface StatementLine {
+  account: AccountName
+  amount: number
+}
+
+export interface IncomeStatement {
+  /** Income accounts with non-zero activity (revenue + gains). */
+  revenue: StatementLine[]
+  /** Expense accounts with non-zero activity (costs + losses). */
+  expenses: StatementLine[]
+  totalRevenue: number
+  totalExpenses: number
+  /** totalRevenue − totalExpenses. */
+  netIncome: number
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+/** Build the income statement from the consolidated ledger feed. */
+export function buildIncomeStatement(entries: readonly LedgerEntry[]): IncomeStatement {
+  const net = netBalanceByAccount(entries)
+
+  const revenue: StatementLine[] = []
+  const expenses: StatementLine[] = []
+  let totalRevenue = 0
+  let totalExpenses = 0
+
+  // Walk the chart in declared order so lines read top-down and stay stable.
+  for (const account of ACCOUNT_NAMES) {
+    const amount = net.get(account) ?? 0
+    if (amount === 0) continue
+    const cls = classOf(account)
+    if (cls === 'INCOME') {
+      revenue.push({ account, amount })
+      totalRevenue += amount
+    } else if (cls === 'EXPENSE') {
+      expenses.push({ account, amount })
+      totalExpenses += amount
+    }
+  }
+
+  totalRevenue = round2(totalRevenue)
+  totalExpenses = round2(totalExpenses)
+  return {
+    revenue,
+    expenses,
+    totalRevenue,
+    totalExpenses,
+    netIncome: round2(totalRevenue - totalExpenses)
+  }
+}


### PR DESCRIPTION
# Description


## Summary

This PR adds the heart of the pipeline: the layer that turns the normalized double-entry feed from step 2 (#2113) into the three financial statements with double-entry guarantees at every level. It introduces four pure, unit-tested modules in `app/src/utils/accounting/` — `buildLedger` consolidates the merged `LedgerEntry` feed, eliminating the internal-transfer double count (a Safe⇄Bank move, or a Bank→FeeCollector fee skim, is indexed once per contract, so the twin postings are collapsed to one) and rolling up the summary totals (cash, income, expense, equity, net income); `buildGeneralLedger` derives the double-entry journal and trial balance, enforcing both the gross identity (Σ debit lines = Σ credit lines) and the net identity (Σ debit balances = Σ credit balances) and flagging an unbalanced book; `buildIncomeStatement` groups income/expense accounts into revenue and expense lines for the net result; and `buildBalanceSheet` derives Assets vs Liabilities + Equity, closing net income into Retained Earnings and asserting `Assets = Liabilities + Equity`. The unit tests reuse the money-flow catalogue worked example (§6) as the fixture since it balances at every level, and the engine reproduces it to the cent (journal 678.10, trial balance 253, income statement net +4.20, balance sheet 142.20 = 142.20). It is a pure logic layer (not yet wired to the UI — the accounting view is untouched and still renders demo data, which is step 4), ships with 19 new unit tests (92 accounting tests total), and passes lint / type-check / unit tests in `app/`.


Fixes #2117 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Out of scope (step 4)

Wiring the engine into the accounting view — and swapping the fixture feed for the live Ponder source via `buildCncLedgerEntries` — is deferred: it is blocked on the display-granularity mismatch (transaction-level view vs atomic postings) and the live `MapperContext` assembly (founder addresses, SHER token address, FX rate-of-record). Real-money dogfood validation is a known Phase 2 gap per the spec, so this step is validated against the worked example. This PR is 810 insertions, 0 deletions — no existing code or demo data is changed.
