### PR TITLE
fix: 🐛 Dashboard login error display & SIWE refactor

### DIFF
--- a/dashboard/app/composables/useSiwe.ts
+++ b/dashboard/app/composables/useSiwe.ts
@@ -1,4 +1,5 @@
 import { SiweMessage } from 'siwe'
+import { useMutation } from '@tanstack/vue-query'
 import {
   useConnection,
   useSignMessage,
@@ -10,14 +11,23 @@ import {
 } from '@wagmi/vue'
 import { useAuthStore } from '~/stores/useAuthStore'
 import { getUserNonce } from '~/api/user'
-import { authenticateWithSiwe as authWithSiwe, validateToken as validateAuthToken } from '~/api/auth'
+import { authenticateWithSiwe, validateToken as validateAuthToken } from '~/api/auth'
+import { parseLoginError } from '~/utils/loginError'
 
+/**
+ * Owns the SIWE (Sign-In With Ethereum) session for the dashboard: wallet
+ * connection, message signature, backend authentication, sign-out, and token
+ * validation.
+ *
+ * The connect and sign-in steps are modelled as TanStack Query mutations so the
+ * page consumes ready-made `isPending` / `error` reactive state instead of
+ * hand-rolling `try/catch` + loading flags. Every failure path is funnelled
+ * through `parseLoginError`, so `error` is always a user-facing string (or
+ * `null`) — never a raw wallet/HTTP error.
+ */
 export function useSiwe() {
   const runtimeConfig = useRuntimeConfig()
-  const configChainId = runtimeConfig.public.chainId
-
-  const isProcessing = ref(false)
-  const error = ref<string | null>(null)
+  const networkChainId = parseInt((runtimeConfig.public.chainId as string) || '31337')
 
   const authStore = useAuthStore()
   const connection = useConnection()
@@ -27,120 +37,113 @@ export function useSiwe() {
   const { disconnect } = useDisconnect()
   const { switchChainAsync } = useSwitchChain()
 
-  /**
-   * Main SIWE sign-in flow
-   */
-  const signIn = async () => {
-    isProcessing.value = true
-    error.value = null
-    // Use chainId from runtime config, fallback to hardhat local network
-    const networkChainId = configChainId ? parseInt(configChainId as string) : 31337
+  const isConnected = computed(() => connection.isConnected.value)
+  const address = computed(() => connection.address.value)
 
-    try {
-      // Ensure wallet is connected
-      if (!connection.isConnected.value || !connection.address.value) {
-        await connectAsync({ connector: injected(), chainId: networkChainId })
+  /** Connect an injected wallet (if needed) and switch it to the target chain. */
+  const ensureWalletReady = async () => {
+    if (!connection.isConnected.value || !connection.address.value) {
+      await connectAsync({ connector: injected(), chainId: networkChainId })
+    }
+    if (chainId.value !== networkChainId) {
+      await switchChainAsync({ chainId: networkChainId })
+    }
+  }
 
-        // check if the current chainId matches the required network
-        if (chainId.value !== networkChainId) {
-          await switchChainAsync({ chainId: networkChainId })
-        }
+  const connectMutation = useMutation({ mutationFn: ensureWalletReady })
+
+  const loginMutation = useMutation({
+    mutationFn: async (): Promise<string> => {
+      await ensureWalletReady()
+
+      const account = connection.address.value
+      if (!account) {
+        throw new Error('No wallet account available. Please connect your wallet and try again.')
       }
 
-      // Step 1: Fetch nonce from backend
-      if (!connection.address.value) {
-        error.value = 'Please connect your wallet first'
-        isProcessing.value = false
-        return false
+      const { nonce } = await getUserNonce(account)
+      if (!nonce) {
+        throw new Error('Could not retrieve a login nonce from the server. Please try again.')
       }
 
-      const nonceResponse = await getUserNonce(connection.address.value)
-      if (!nonceResponse?.nonce) {
-        error.value = 'Failed to get nonce from server'
-        isProcessing.value = false
-        return false
-      }
-
-      // Step 2: Create SIWE message
-      const siweMessage = new SiweMessage({
-        address: connection.address.value,
+      const message = new SiweMessage({
+        address: account,
         statement: 'Sign in to CNC Portal Admin Dashboard with Ethereum.',
-        nonce: nonceResponse.nonce,
+        nonce,
         chainId: chainId.value,
         uri: window.location.origin,
         domain: window.location.host,
         version: '1'
-      })
-      const messageToSign = siweMessage.prepareMessage()
+      }).prepareMessage()
 
-      // Step 3: Sign the message
-      let signature: string
-      try {
-        signature = await signMessageAsync({ message: messageToSign })
-      } catch (e: unknown) {
-        const signError = e as { name?: string }
-        if (signError.name === 'UserRejectedRequestError') {
-          error.value = 'You rejected the signature request. Please sign to authenticate.'
-        } else {
-          error.value = 'Failed to sign message'
-        }
-        isProcessing.value = false
-        return false
+      const signature = await signMessageAsync({ message })
+
+      const { accessToken } = await authenticateWithSiwe(message, signature)
+      if (!accessToken) {
+        throw new Error('Authentication failed. Please try again.')
       }
 
-      // Step 4: Send to backend for verification and get JWT
-      const authResponse = await authWithSiwe(messageToSign, signature)
-      if (!authResponse?.accessToken) {
-        error.value = 'Authentication failed. Please try again.'
-        isProcessing.value = false
-        return false
-      }
+      authStore.setAuth(accessToken, account)
+      return accessToken
+    }
+  })
 
-      // Step 5: Store authentication data
-      authStore.setAuth(authResponse.accessToken, connection.address.value)
+  const isConnecting = computed(() => connectMutation.isPending.value)
+  const isSigningIn = computed(() => loginMutation.isPending.value)
+  const isProcessing = computed(() => isConnecting.value || isSigningIn.value)
 
-      isProcessing.value = false
+  // Surface whichever step last failed, classified into a user-facing message.
+  const error = computed<string | null>(() => {
+    const err = loginMutation.error.value ?? connectMutation.error.value
+    return err ? parseLoginError(err).message : null
+  })
+
+  const connectWallet = async (): Promise<boolean> => {
+    loginMutation.reset()
+    try {
+      await connectMutation.mutateAsync()
       return true
-    } catch (e) {
-      console.error('SIWE sign-in error:', e)
-      error.value = 'An unexpected error occurred'
-      isProcessing.value = false
+    } catch {
       return false
     }
   }
 
-  /**
-   * Sign out and clear authentication data
-   */
+  const signIn = async (): Promise<boolean> => {
+    connectMutation.reset()
+    try {
+      await loginMutation.mutateAsync()
+      return true
+    } catch {
+      return false
+    }
+  }
+
   const signOut = () => {
     authStore.clearAuth()
     disconnect()
   }
 
-  /**
-   * Validate current token with backend
-   */
   const validateToken = async (): Promise<boolean> => {
     const token = authStore.getToken()
-    if (!token) {
-      console.warn('No token found for validation')
-      return false
-    }
+    if (!token) return false
 
     try {
       await validateAuthToken(token)
       return true
-    } catch (e) {
-      console.warn('Token validation failed:', e)
-      // Clear invalid token
+    } catch {
       authStore.clearAuth()
       return false
     }
   }
 
   return {
+    isConnected,
+    address,
+    isConnecting,
+    isSigningIn,
     isProcessing,
     error,
+    connectWallet,
     signIn,
     signOut,
     validateToken

--- a/dashboard/app/pages/login.vue
+++ b/dashboard/app/pages/login.vue
@@ -1,108 +1,25 @@
 <script setup lang="ts">
-import { injected, useConnection, useChainId, useConnect, useSwitchChain } from '@wagmi/vue'
+import { useSiwe } from '~/composables/useSiwe'
 
 definePageMeta({
-  layout: 'auth',
-  ssr: false
+  layout: 'auth'
 })
 
 const router = useRouter()
-const runtimeConfig = useRuntimeConfig()
-const networkChainId = parseInt((runtimeConfig.public.chainId as string) || '31337')
 
-// State for SSR compatibility
-const isProcessing = ref(false)
-const error = ref<string | null>(null)
-const isConnected = ref(false)
-const address = ref<string | undefined>(undefined)
+// The dashboard is a client-only SPA (`ssr: false`), so the SIWE composable —
+// which owns wallet connection, signature, error classification, and loading
+// state — can be consumed directly here.
+const { isConnected, address, isProcessing, error, connectWallet, signIn } = useSiwe()
 
-// SIWE composable and Wagmi composables - initialized on client
-let siweInstance: ReturnType<typeof useSiwe> | null = null
-let connection: ReturnType<typeof useConnection> | null = null
-let chainId: ReturnType<typeof useChainId> | null = null
-let connectAsync: ReturnType<typeof useConnect>['connectAsync'] | null = null
-let switchChainAsync: ReturnType<typeof useSwitchChain>['switchChainAsync'] | null = null
-
-// Initialize on client side only after mount
-onMounted(() => {
-  // Initialize Wagmi composables
-  connection = useConnection()
-  chainId = useChainId()
-  const connectComposable = useConnect()
-  connectAsync = connectComposable.connectAsync
-  const switchComposable = useSwitchChain()
-  switchChainAsync = switchComposable.switchChainAsync
-
-  // Initialize SIWE
-  siweInstance = useSiwe()
-
-  // Sync all reactive state
-  watch(
-    () => siweInstance?.isProcessing.value,
-    (val) => {
-      isProcessing.value = val ?? false
-    },
-    { immediate: true }
-  )
-
-  // watch(
-  //   () => siweInerrorstance?.error.value,
-  //   (val) => {
-  //     error.value = val ?? null
-  //   },
-  //   { immediate: true }
-  // )
-
-  watch(
-    () => connection?.isConnected.value,
-    (val) => {
-      isConnected.value = val ?? false
-    },
-    { immediate: true }
-  )
-
-  watch(
-    () => connection?.address.value,
-    (val) => {
-      address.value = val
-    },
-    { immediate: true }
-  )
-})
-
-const handleSignIn = async () => {
-  if (siweInstance) {
-    const success = await siweInstance.signIn()
-    if (success) {
-      await router.push('/')
-    }
-  }
+const handleConnectWallet = () => {
+  connectWallet()
 }
 
-const handleConnectWallet = async () => {
-  if (!connection || !connectAsync || !switchChainAsync || !chainId) {
-    error.value = 'Wallet connection not initialized'
-    return
-  }
-
-  try {
-    error.value = null
-    isProcessing.value = true
-
-    // Ensure wallet is connected
-    if (!connection.isConnected.value || !connection.address.value) {
-      await connectAsync({ connector: injected(), chainId: networkChainId })
-
-      // check if the current chainId matches the required network
-      if (chainId.value !== networkChainId) {
-        await switchChainAsync({ chainId: networkChainId })
-      }
-    }
-  } catch (e: unknown) {
-    console.error('Failed to connect wallet:', e)
-    error.value = e instanceof Error ? e.message : 'Failed to connect wallet'
-  } finally {
-    isProcessing.value = false
+const handleSignIn = async () => {
+  const success = await signIn()
+  if (success) {
+    await router.push('/')
   }
 }
 

--- a/dashboard/app/utils/loginError.ts
+++ b/dashboard/app/utils/loginError.ts
@@ -1,0 +1,143 @@
+import {
+  BaseError,
+  ChainMismatchError,
+  HttpRequestError,
+  SwitchChainError,
+  TimeoutError,
+  UserRejectedRequestError
+} from 'viem'
+import type { FetchError } from 'ofetch'
+
+export type LoginErrorCategory
+  = | 'user_rejected'
+    | 'chain'
+    | 'backend'
+    | 'network'
+    | 'unknown'
+
+export interface ParsedLoginError {
+  category: LoginErrorCategory
+  message: string
+}
+
+const NETWORK_MESSAGE = 'Network error. Check your connection and try again.'
+
+/**
+ * Translate any error thrown during the SIWE login flow into a single
+ * user-facing message plus a semantic category.
+ *
+ * The flow can fail at four different layers — wallet connection, network
+ * switch, message signature, or the backend auth call — each throwing its own
+ * error shape (viem `BaseError`, an EIP-1193 `{ code: 4001 }`, or an ofetch
+ * `FetchError`). Callers branch on `category` (e.g. to decide whether to retry
+ * or stay quiet) and show `message` in a `UAlert` / toast. Never surface the
+ * raw error to the user: it leaks RPC noise and stack traces.
+ */
+export function parseLoginError(error: unknown): ParsedLoginError {
+  // Order matters: the user-rejection and chain checks must run before the
+  // generic fall-throughs, since wallets wrap rejections inside other types.
+  if (isUserRejection(error)) {
+    return {
+      category: 'user_rejected',
+      message: 'Request cancelled. You declined the wallet prompt — approve it to continue.'
+    }
+  }
+
+  if (isChainError(error)) {
+    return {
+      category: 'chain',
+      message: 'Wrong network. Switch your wallet to the required network and try again.'
+    }
+  }
+
+  if (isFetchError(error)) {
+    return parseBackendError(error)
+  }
+
+  if (isViemNetworkError(error)) {
+    return { category: 'network', message: NETWORK_MESSAGE }
+  }
+
+  return { category: 'unknown', message: extractMessage(error) }
+}
+
+function isUserRejection(error: unknown): boolean {
+  if (error instanceof BaseError && error.walk(e => e instanceof UserRejectedRequestError)) {
+    return true
+  }
+  // Some injected wallets throw a raw EIP-1193 rejection that viem never wraps.
+  if (getErrorCode(error) === 4001) return true
+  return getErrorName(error) === 'UserRejectedRequestError'
+}
+
+function isChainError(error: unknown): boolean {
+  if (
+    error instanceof BaseError
+    && error.walk(e => e instanceof SwitchChainError || e instanceof ChainMismatchError)
+  ) {
+    return true
+  }
+  const name = getErrorName(error)
+  return name === 'SwitchChainError' || name === 'ChainMismatchError'
+}
+
+function isViemNetworkError(error: unknown): boolean {
+  return (
+    error instanceof BaseError
+    && !!error.walk(e => e instanceof HttpRequestError || e instanceof TimeoutError)
+  )
+}
+
+function isFetchError(error: unknown): error is FetchError {
+  return getErrorName(error) === 'FetchError'
+}
+
+function parseBackendError(error: FetchError): ParsedLoginError {
+  const status = error.statusCode ?? error.response?.status
+  const data = error.data as { message?: string, error?: string } | undefined
+  const backendMessage = data?.message || data?.error
+
+  // No status means the request never reached the server (DNS, CORS, offline).
+  if (status === undefined) {
+    return { category: 'network', message: NETWORK_MESSAGE }
+  }
+  if (status >= 500) {
+    return { category: 'backend', message: 'Server error. Please try again in a moment.' }
+  }
+  if (status === 401) {
+    return {
+      category: 'backend',
+      message: backendMessage
+        ? `Authentication failed: ${backendMessage}.`
+        : 'Authentication failed. Please sign in again.'
+    }
+  }
+  return {
+    category: 'backend',
+    message: backendMessage || `Request failed (status ${status}). Please try again.`
+  }
+}
+
+function extractMessage(error: unknown): string {
+  if (error instanceof BaseError) return error.shortMessage || error.message
+  if (error instanceof Error && error.message) return error.message
+  return 'An unexpected error occurred. Please try again.'
+}
+
+function getErrorName(error: unknown): string | undefined {
+  if (error && typeof error === 'object' && 'name' in error) {
+    return String((error as { name?: unknown }).name)
+  }
+  return undefined
+}
+
+function getErrorCode(error: unknown): number | undefined {
+  let current: unknown = error
+  // Walk a short cause chain — injected wallets nest the EIP-1193 code.
+  for (let depth = 0; depth < 5 && current && typeof current === 'object'; depth++) {
+    const code = (current as { code?: unknown }).code
+    if (typeof code === 'number') return code
+    current = (current as { cause?: unknown }).cause
+  }
+  return undefined
+}


### PR DESCRIPTION
## What & why

Closes #1618.

Login errors in the admin **dashboard** were silently swallowed: `useSiwe` set an internal `error` ref that the page never read (the `watch` syncing it was commented out), and `login.vue` carried a heavy `onMounted` lazy-init dance left over from an SSR assumption that no longer holds — the dashboard is a client-only SPA (`ssr: false` globally).

This makes every login failure visible and refactors the flow on TanStack Query, as the issue asked.

## Changes

- **`utils/loginError.ts` (new)** — `parseLoginError()` classifies any failure from the SIWE flow into a semantic `category` + a single user-facing `message`:
  - **User rejection** of the wallet-connect *or* signature prompt (viem `UserRejectedRequestError`, with an EIP-1193 `code: 4001` fallback for raw injected-wallet errors)
  - **Wrong network** (`SwitchChainError` / `ChainMismatchError`)
  - **Backend errors** — pulls the message out of the ofetch `FetchError` body, with dedicated 401 / 5xx wording
  - **Network/offline** failures
- **`composables/useSiwe.ts`** — connect and sign-in are now TanStack Query `useMutation`s. The composable exposes reactive `isProcessing` / `error` (always a classified, user-facing string) so the page no longer hand-rolls loading flags or `try/catch`. `signOut` / `validateToken` unchanged in behaviour.
- **`pages/login.vue`** — drops the `onMounted` lazy init, the manual wagmi watches, and the duplicated connect logic; consumes `useSiwe` directly and renders the classified error in the existing `UAlert`.

## Acceptance criteria

- [x] Better error handling — backend, wallet connection, and user-rejection (connect **and** signature) paths all produce a clear message
- [x] Login refactor — flow rebuilt on a TanStack Query composable; page reduced from ~110 to ~30 lines of script

## Testing

- `npm run lint` ✅ (dashboard's CI gate)
- `npx nuxi typecheck` ✅ for the three touched files (pre-existing errors elsewhere in the dashboard are untouched)

> Note: the `dashboard/` subproject has no unit-test runner yet, so `parseLoginError` ships without specs. Worth a follow-up to add Vitest + cover the classifier, which is pure and trivially testable.