### PR TITLE
fix: 🐛 Company Payroll total ignores overtime pay

### DIFF
--- a/app/src/components/sections/ClaimHistoryView/WeeklyRecap.vue
+++ b/app/src/components/sections/ClaimHistoryView/WeeklyRecap.vue
@@ -112,7 +112,11 @@ import { computed } from 'vue'
 import { useCurrencyStore } from '@/stores'
 import type { RatePerHour, Wage, WeeklyClaim } from '@/types/cash-remuneration'
 import RateDotList from '@/components/RateDotList.vue'
-import { computeClaimTokenAmounts, formatMinutesAsDuration, splitClaimMinutes } from '@/utils/wageUtil'
+import {
+  computeClaimTokenAmounts,
+  formatMinutesAsDuration,
+  splitClaimMinutes
+} from '@/utils/wageUtil'
 
 const props = defineProps<{
   weeklyClaim?: WeeklyClaim

--- a/app/src/components/sections/ClaimHistoryView/WeeklyRecap.vue
+++ b/app/src/components/sections/ClaimHistoryView/WeeklyRecap.vue
@@ -112,7 +112,7 @@ import { computed } from 'vue'
 import { useCurrencyStore } from '@/stores'
 import type { RatePerHour, Wage, WeeklyClaim } from '@/types/cash-remuneration'
 import RateDotList from '@/components/RateDotList.vue'
-import { formatMinutesAsDuration } from '@/utils/wageUtil'
+import { computeClaimTokenAmounts, formatMinutesAsDuration, splitClaimMinutes } from '@/utils/wageUtil'
 
 const props = defineProps<{
   weeklyClaim?: WeeklyClaim
@@ -133,17 +133,11 @@ const isSignedClaim = computed(
   () => props.weeklyClaim?.status === 'signed' || props.weeklyClaim?.status === 'withdrawn'
 )
 
-const regularMinutesWorked = computed(() => {
-  if (!hasOvertimeWage.value) return submittedTime.value
-  const maxRegularMinutes = (effectiveWage.value?.maximumHoursPerWeek ?? Infinity) * 60
-  return Math.min(submittedTime.value, maxRegularMinutes)
-})
+const claimMinutes = computed(() => splitClaimMinutes(submittedTime.value, effectiveWage.value))
 
-const overtimeMinutesWorked = computed(() => {
-  if (!hasOvertimeWage.value) return 0
-  const maxRegularMinutes = (effectiveWage.value?.maximumHoursPerWeek ?? Infinity) * 60
-  return Math.max(0, submittedTime.value - maxRegularMinutes)
-})
+const regularMinutesWorked = computed(() => claimMinutes.value.regularMinutes)
+
+const overtimeMinutesWorked = computed(() => claimMinutes.value.overtimeMinutes)
 
 function getHourlyRateInUserCurrency(
   ratePerHour: RatePerHour[],
@@ -168,23 +162,9 @@ const overtimeHourlyRateInUserCurrency = computed(() =>
     : 0
 )
 
-const combinedTokenAmounts = computed(() => {
-  const result = new Map<string, number>()
-  const regMinutes = regularMinutesWorked.value
-
-  for (const rate of effectiveWage.value?.ratePerHour ?? []) {
-    result.set(rate.type, (result.get(rate.type) ?? 0) + (rate.amount * regMinutes) / 60)
-  }
-
-  if (hasOvertimeWage.value) {
-    const otMinutes = overtimeMinutesWorked.value
-    for (const rate of (effectiveWage.value?.overtimeRatePerHour as RatePerHour[]) ?? []) {
-      result.set(rate.type, (result.get(rate.type) ?? 0) + (rate.amount * otMinutes) / 60)
-    }
-  }
-
-  return Array.from(result.entries()).map(([type, amount]) => ({ type, amount }))
-})
+const combinedTokenAmounts = computed(() =>
+  computeClaimTokenAmounts(submittedTime.value, effectiveWage.value)
+)
 
 const totalAmount = computed(() => {
   const regularTotal = (regularMinutesWorked.value / 60) * hourlyRateInUserCurrency.value

--- a/app/src/components/sections/WeeklyClaimView/WeeklyClaim.vue
+++ b/app/src/components/sections/WeeklyClaimView/WeeklyClaim.vue
@@ -32,10 +32,14 @@
 
       <template #minutesWorked-cell="{ row: { original: row } }">
         <span class="font-bold">
-          {{ formatMinutesAsDuration(getTotalTimeWorked(row.claims)) }}
+          {{ formatMinutesAsDuration(row.derived.totalMinutes) }}
         </span>
         <br />
-        <span>of {{ row.wage.maximumHoursPerWeek ?? '-' }} hrs weekly limit</span>
+        <span v-if="row.derived.hasOvertime">
+          of {{ row.wage.maximumHoursPerWeek ?? '-' }} hrs weekly limit &amp;
+          {{ row.wage.maximumOvertimeHoursPerWeek ?? '-' }} overtime hrs
+        </span>
+        <span v-else>of {{ row.wage.maximumHoursPerWeek ?? '-' }} hrs weekly limit</span>
       </template>
 
       <template #hourlyRate-cell="{ row: { original: row } }">
@@ -46,27 +50,34 @@
             :class="'font-bold'"
           />
           <span class="">
-            ≃ ${{ getHoulyRateInUserCurrency(row.wage.ratePerHour).toFixed(2) }}
+            ≃ ${{ row.derived.hourlyRateInUserCurrency.toFixed(2) }}
             {{ currencyStore.localCurrency.code }} / Hour
           </span>
+          <template v-if="row.derived.hasOvertime">
+            <div class="mt-2 text-xs font-semibold text-gray-500 uppercase">Overtime</div>
+            <RatePerHourList
+              :rate-per-hour="row.wage.overtimeRatePerHour ?? []"
+              :currency-symbol="NETWORK.currencySymbol"
+              :class="'font-bold'"
+            />
+            <span class="">
+              ≃ ${{ row.derived.overtimeHourlyRateInUserCurrency.toFixed(2) }}
+              {{ currencyStore.localCurrency.code }} / Hour
+            </span>
+          </template>
         </div>
       </template>
 
       <template #totalAmount-cell="{ row: { original: row } }">
         <div>
           <RatePerHourTotalList
-            :rate-per-hour="row.wage.ratePerHour"
+            :rate-per-hour="row.derived.tokenAmounts"
             :currency-symbol="NETWORK.currencySymbol"
-            :total-hours="getTotalTimeWorked(row.claims) / 60"
+            :total-hours="1"
             :class="'font-bold'"
           />
           <span class="">
-            ≃ ${{
-              (
-                (getTotalTimeWorked(row.claims) / 60) *
-                getHoulyRateInUserCurrency(row.wage.ratePerHour)
-              ).toFixed(2)
-            }}
+            ≃ ${{ row.derived.totalInUserCurrency.toFixed(2) }}
             {{ currencyStore.localCurrency.code }}
           </span>
         </div>
@@ -135,7 +146,7 @@ import UserComponent from '@/components/UserComponent.vue'
 import type { TokenId } from '@/constant'
 import { NETWORK } from '@/constant'
 import { useCurrencyStore, useTeamStore /*, useUserDataStore*/ } from '@/stores'
-import type { RatePerHour, WeeklyClaim } from '@/types/cash-remuneration'
+import type { SupportedTokens, WeeklyClaim } from '@/types/cash-remuneration'
 import { formatIsoWeekRange } from '@/utils/dayUtils'
 import dayjs from 'dayjs'
 import isoWeek from 'dayjs/plugin/isoWeek'
@@ -150,7 +161,7 @@ import WeeklyClaimActionDropdown from './WeeklyClaimActionDropdown.vue'
 import TablePagination from '@/components/TablePagination.vue'
 import { usePagination } from '@/composables/usePagination'
 import type { Address } from 'viem'
-import { formatMinutesAsDuration } from '@/utils/wageUtil'
+import { computeClaimTokenAmounts, formatMinutesAsDuration } from '@/utils/wageUtil'
 
 dayjs.extend(utc)
 dayjs.extend(isoWeek)
@@ -204,7 +215,44 @@ const { data: fetchedData, error } = useGetTeamWeeklyClaimsQuery({
   }
 })
 
-const rows = computed(() => fetchedData.value?.data ?? null)
+type TokenAmount = { type: SupportedTokens; amount: number }
+
+type EnrichedWeeklyClaim = WeeklyClaim & {
+  derived: {
+    totalMinutes: number
+    hasOvertime: boolean
+    tokenAmounts: TokenAmount[]
+    totalInUserCurrency: number
+    hourlyRateInUserCurrency: number
+    overtimeHourlyRateInUserCurrency: number
+  }
+}
+
+// Every per-row derived value (split hours, combined regular+overtime payout,
+// local-currency totals) is computed once here so the cells just read it back
+// instead of recomputing on each render.
+const rows = computed<EnrichedWeeklyClaim[] | null>(() => {
+  const data = fetchedData.value?.data
+  if (!data) return null
+
+  return data.map((row) => {
+    const totalMinutes = getTotalTimeWorked(row.claims)
+    const overtimeRates = row.wage.overtimeRatePerHour ?? []
+    const tokenAmounts = computeClaimTokenAmounts(totalMinutes, row.wage)
+
+    return {
+      ...row,
+      derived: {
+        totalMinutes,
+        hasOvertime: overtimeRates.length > 0,
+        tokenAmounts,
+        totalInUserCurrency: sumInUserCurrency(tokenAmounts),
+        hourlyRateInUserCurrency: sumInUserCurrency(row.wage.ratePerHour),
+        overtimeHourlyRateInUserCurrency: sumInUserCurrency(overtimeRates)
+      }
+    }
+  })
+})
 const total = computed(() => fetchedData.value?.total ?? 0)
 
 // Switching between the team-wide table and a single member's view changes the
@@ -215,14 +263,16 @@ const isTeamClaimDataFetching = computed(() => !fetchedData.value && !error.valu
 
 const currencyStore = useCurrencyStore()
 
-function getHoulyRateInUserCurrency(
-  ratePerHour: RatePerHour[],
+// Converts a list of token amounts (rates or payouts) into the user's local
+// currency. Reused for hourly rate, overtime rate and the weekly total.
+function sumInUserCurrency(
+  amounts: Array<{ type: SupportedTokens; amount: number }>,
   tokenStore = currencyStore
 ): number {
-  return ratePerHour.reduce((total: number, rate: { type: TokenId; amount: number }) => {
-    const tokenInfo = tokenStore.getTokenInfo(rate.type as TokenId)
+  return amounts.reduce((total, { type, amount }) => {
+    const tokenInfo = tokenStore.getTokenInfo(type as TokenId)
     const localPrice = tokenInfo?.prices.find((p) => p.id === 'local')?.price ?? 0
-    return total + rate.amount * localPrice
+    return total + amount * localPrice
   }, 0)
 }
 
@@ -262,5 +312,5 @@ const columns = [
     header: 'Action',
     enableSorting: false
   }
-] as TableColumn<WeeklyClaim>[]
+] as TableColumn<EnrichedWeeklyClaim>[]
 </script>

--- a/app/src/utils/wageUtil.ts
+++ b/app/src/utils/wageUtil.ts
@@ -1,4 +1,10 @@
-import type { RatePerHour, RatePerHourWithEnabled, SupportedTokens, Wage, WeeklyClaim } from '@/types'
+import type {
+  RatePerHour,
+  RatePerHourWithEnabled,
+  SupportedTokens,
+  Wage,
+  WeeklyClaim
+} from '@/types'
 import { parseEther, parseUnits, type Address } from 'viem'
 
 const requiredRateTypes: RatePerHour['type'][] = ['native', 'usdc', 'sher']

--- a/app/src/utils/wageUtil.ts
+++ b/app/src/utils/wageUtil.ts
@@ -1,4 +1,4 @@
-import type { RatePerHour, RatePerHourWithEnabled, WeeklyClaim } from '@/types'
+import type { RatePerHour, RatePerHourWithEnabled, SupportedTokens, Wage, WeeklyClaim } from '@/types'
 import { parseEther, parseUnits, type Address } from 'viem'
 
 const requiredRateTypes: RatePerHour['type'][] = ['native', 'usdc', 'sher']
@@ -111,6 +111,52 @@ const buildClaimRatesWithOvertime = ({
       totalAmount
     }
   })
+}
+
+/**
+ * Splits total minutes worked into regular vs overtime minutes for a given wage.
+ * Overtime only applies when the wage actually defines an overtime rate; otherwise
+ * every minute is treated as regular time.
+ */
+export const splitClaimMinutes = (
+  totalMinutesWorked: number,
+  wage?: Pick<Wage, 'overtimeRatePerHour' | 'maximumHoursPerWeek'> | null
+) => {
+  const hasOvertime =
+    Array.isArray(wage?.overtimeRatePerHour) && (wage?.overtimeRatePerHour.length ?? 0) > 0
+  return getRegularAndOvertimeHours(
+    totalMinutesWorked,
+    hasOvertime ? wage?.maximumHoursPerWeek : null
+  )
+}
+
+/**
+ * Computes the per-token payout for a claim, combining regular and overtime pay:
+ * regularRate * regularHours + overtimeRate * overtimeHours.
+ *
+ * Shared by the company payroll table and the member payroll recap so both views
+ * agree on the total (see issue: company payroll ignored overtime).
+ */
+export const computeClaimTokenAmounts = (
+  totalMinutesWorked: number,
+  wage?: Pick<Wage, 'ratePerHour' | 'overtimeRatePerHour' | 'maximumHoursPerWeek'> | null
+): Array<{ type: SupportedTokens; amount: number }> => {
+  if (!wage) return []
+
+  const { regularMinutes, overtimeMinutes } = splitClaimMinutes(totalMinutesWorked, wage)
+  const result = new Map<SupportedTokens, number>()
+
+  for (const rate of wage.ratePerHour ?? []) {
+    result.set(rate.type, (result.get(rate.type) ?? 0) + (rate.amount * regularMinutes) / 60)
+  }
+
+  if (Array.isArray(wage.overtimeRatePerHour) && wage.overtimeRatePerHour.length > 0) {
+    for (const rate of wage.overtimeRatePerHour) {
+      result.set(rate.type, (result.get(rate.type) ?? 0) + (rate.amount * overtimeMinutes) / 60)
+    }
+  }
+
+  return Array.from(result.entries()).map(([type, amount]) => ({ type, amount }))
 }
 
 export const buildWageClaimPayload = ({


### PR DESCRIPTION
Fixes #2204

The Company Payroll table was computing each week's total as `hoursWorked × regularRate`, which ignored overtime — so a week could show a different total than the member's own Payroll History view (e.g. 11h with a 10h limit and a 5 SHER/h overtime rate showed 11 SHER instead of the correct 15 SHER). This PR fixes that by moving the overtime calculation into two shared, pure helpers in `wageUtil.ts` (`splitClaimMinutes` to split worked time into regular vs overtime, and `computeClaimTokenAmounts` to compute regularHours × regularRate + overtimeHours × overtimeRate), and making both Company Payroll and My Payroll History use them so the two screens can no longer disagree. While there, the Company Payroll rows now also show the overtime allowance under "Hour Worked" and the overtime rate under "Hourly Rate", and each row's derived values are computed once instead of being recalculated in every cell.