### PR TITLE
feat: ✨ Move breadcrumb into the navbar and refine the team picker

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -27,8 +27,7 @@
                     <NavBreadcrumb />
                   </template>
                   <template #trailing>
-                    <!-- Team picker only makes sense inside a team — hidden on the Companies list -->
-                    <TeamSelectMenu v-if="route.name && route.name !== 'teams'" />
+                    <TeamSelectMenu />
                   </template>
                   <template #right>
                     <NavBar />

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -26,10 +26,9 @@
                   <template #title>
                     <NavBreadcrumb />
                   </template>
-                  <template #trailing>
-                    <TeamSelectMenu />
-                  </template>
                   <template #right>
+                    <!-- Team picker sits on the right, before the theme/notifications/avatar cluster -->
+                    <TeamSelectMenu />
                     <NavBar />
                   </template>
                 </UDashboardNavbar>

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -14,7 +14,7 @@
               }"
             >
               <template #header>
-                <UDashboardNavbar :title="pageTitle" :ui="{ right: 'gap-3' }" class="bg-default">
+                <UDashboardNavbar :ui="{ right: 'gap-3' }" class="bg-default">
                   <template #leading>
                     <UDashboardSidebarCollapse
                       icon="heroicons:arrow-left-start-on-rectangle"
@@ -22,6 +22,9 @@
                       trailing-icon="heroicons:arrow-right-start-on-rectangle"
                       v-if="route.name && route.name !== 'teams'"
                     />
+                  </template>
+                  <template #title>
+                    <NavBreadcrumb />
                   </template>
                   <template #trailing>
                     <TeamSelectMenu />
@@ -55,6 +58,7 @@ import { RouterView, useRoute } from 'vue-router'
 
 import LockScreen from '@/components/LockScreen.vue'
 import NavBar from '@/components/NavBar.vue'
+import NavBreadcrumb from '@/components/NavBreadcrumb.vue'
 import TeamSelectMenu from '@/components/TeamSelectMenu.vue'
 import SidebarLayout from '@/components/ui/SidebarLayout.vue'
 
@@ -65,8 +69,6 @@ import { NETWORK } from '@/constant/index'
 import { useUserDataStore } from '@/stores/index'
 
 const route = useRoute()
-
-const pageTitle = computed<string>(() => (route.meta.name as string) || 'CNC-Portal')
 
 const connection = useConnection()
 const switchChain = useSwitchChain()

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -27,7 +27,8 @@
                     <NavBreadcrumb />
                   </template>
                   <template #trailing>
-                    <TeamSelectMenu />
+                    <!-- Team picker only makes sense inside a team — hidden on the Companies list -->
+                    <TeamSelectMenu v-if="route.name && route.name !== 'teams'" />
                   </template>
                   <template #right>
                     <NavBar />

--- a/app/src/components/NavBreadcrumb.vue
+++ b/app/src/components/NavBreadcrumb.vue
@@ -1,0 +1,46 @@
+<template>
+  <UBreadcrumb :items="breadcrumbItems">
+    <template #loader>
+      <USkeleton class="h-4 w-20" data-test="loader" />
+    </template>
+  </UBreadcrumb>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useTeamStore } from '@/stores/teamStore'
+
+const route = useRoute()
+const teamStore = useTeamStore()
+
+/**
+ * Breadcrumb rendered in the dashboard navbar.
+ *
+ * - Companies list (no team in the route): a single `[Page]` crumb.
+ * - Inside a team: `[Team name] > [Page]`.
+ * - While the team is loading: a skeleton stands in for its name.
+ * - If the team fails to load: fall back to the `[Page]` crumb only.
+ */
+const breadcrumbItems = computed(() => {
+  const pageLabel = route.meta.name as string
+  const teamId = route.params.id as string | undefined
+
+  // Companies list and other team-less pages: just the page label.
+  if (!teamId) {
+    return [{ label: pageLabel }]
+  }
+
+  const teamMeta = teamStore.currentTeamMeta
+
+  if (teamMeta?.isPending) {
+    return [{ slot: 'loader' as const }, { label: pageLabel }]
+  }
+
+  if (teamMeta?.data) {
+    return [{ label: teamMeta.data.name }, { label: pageLabel }]
+  }
+
+  return [{ label: pageLabel }]
+})
+</script>

--- a/app/src/components/NavBreadcrumb.vue
+++ b/app/src/components/NavBreadcrumb.vue
@@ -1,7 +1,20 @@
 <template>
   <UBreadcrumb :items="breadcrumbItems">
+    <template #separator>
+      <span class="text-dimmed">/</span>
+    </template>
+    <template #item-trailing="{ item }">
+      <UBadge
+        v-if="(item as Crumb).role"
+        :color="(item as Crumb).role === 'Owner' ? 'primary' : 'secondary'"
+        variant="solid"
+        size="sm"
+        class="ml-0.5"
+        >{{ (item as Crumb).role }}</UBadge
+      >
+    </template>
     <template #loader>
-      <USkeleton class="h-4 w-20" data-test="loader" />
+      <USkeleton class="h-4 w-24" data-test="loader" />
     </template>
   </UBreadcrumb>
 </template>
@@ -9,20 +22,29 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
-import { useTeamStore } from '@/stores/teamStore'
+import { useUserDataStore, useTeamStore } from '@/stores'
 
 const route = useRoute()
+const userStore = useUserDataStore()
 const teamStore = useTeamStore()
+
+type Crumb = {
+  label?: string
+  to?: string
+  role?: 'Owner' | 'Employee'
+  slot?: 'loader'
+}
 
 /**
  * Breadcrumb rendered in the dashboard navbar.
  *
- * - Companies list (no team in the route): a single `[Page]` crumb.
- * - Inside a team: `[Team name] > [Page]`.
+ * - Companies list (no team in the route): a single `Companies` crumb.
+ * - Inside a team: `Companies / Team [role] / Page`, where `Companies` and the
+ *   team name are links, and a role badge (Owner/Employee) sits by the team name.
  * - While the team is loading: a skeleton stands in for its name.
- * - If the team fails to load: fall back to the `[Page]` crumb only.
+ * - If the team fails to load: fall back to `Companies / Page`.
  */
-const breadcrumbItems = computed(() => {
+const breadcrumbItems = computed<Crumb[]>(() => {
   const pageLabel = route.meta.name as string
   const teamId = route.params.id as string | undefined
 
@@ -31,16 +53,25 @@ const breadcrumbItems = computed(() => {
     return [{ label: pageLabel }]
   }
 
+  const companies: Crumb = { label: 'Companies', to: '/teams' }
   const teamMeta = teamStore.currentTeamMeta
 
   if (teamMeta?.isPending) {
-    return [{ slot: 'loader' as const }, { label: pageLabel }]
+    return [companies, { slot: 'loader' }, { label: pageLabel }]
   }
 
   if (teamMeta?.data) {
-    return [{ label: teamMeta.data.name }, { label: pageLabel }]
+    const owner =
+      !!teamMeta.data.ownerAddress &&
+      !!userStore.address &&
+      teamMeta.data.ownerAddress.toLowerCase() === userStore.address.toLowerCase()
+    return [
+      companies,
+      { label: teamMeta.data.name, to: `/teams/${teamId}`, role: owner ? 'Owner' : 'Employee' },
+      { label: pageLabel }
+    ]
   }
 
-  return [{ label: pageLabel }]
+  return [companies, { label: pageLabel }]
 })
 </script>

--- a/app/src/components/TeamSelectMenu.vue
+++ b/app/src/components/TeamSelectMenu.vue
@@ -1,35 +1,185 @@
 <template>
-  <USelectMenu
-    v-model="selectedTeam"
-    :items="teamItems"
-    :loading="teamsLoading"
-    placeholder="Select Company"
-    by="id"
-    class="w-50"
-    :avatar="selectedTeam?.avatar"
-    :search-input="{ placeholder: 'Search company...' }"
-  />
+  <UPopover
+    v-model:open="open"
+    :content="{ align: 'end', sideOffset: 8 }"
+    :ui="{ content: 'w-[19.25rem]' }"
+  >
+    <!-- Trigger: soft primary pill with a gradient initials chip -->
+    <UButton
+      color="primary"
+      variant="soft"
+      class="h-9 gap-1.5 rounded-lg px-3 text-[13px] font-semibold"
+      data-test="team-picker"
+    >
+      <span
+        v-if="!teamsLoading"
+        class="flex size-[18px] shrink-0 items-center justify-center rounded-[5px] text-[8px] font-bold text-white"
+        :style="gradientStyle"
+        >{{ teamMark }}</span
+      >
+      <UIcon v-else name="i-lucide-loader-circle" class="size-4 animate-spin" data-test="loader" />
+      <span class="max-w-[10rem] truncate">{{ teamLabel }}</span>
+      <UIcon name="i-heroicons-chevron-up-down" class="size-4 shrink-0" />
+    </UButton>
+
+    <template #content>
+      <div class="flex max-h-[80vh] flex-col" data-test="team-menu">
+        <!-- Header -->
+        <div class="flex items-center justify-between px-3.5 pt-3 pb-2">
+          <span class="text-dimmed text-[11px] font-bold tracking-wider uppercase"
+            >Switch team</span
+          >
+          <span class="text-muted text-[11px]">{{ teamCountLabel }}</span>
+        </div>
+
+        <!-- Search -->
+        <div class="px-2.5 pb-2">
+          <UInput
+            v-model="query"
+            icon="i-heroicons-magnifying-glass"
+            placeholder="Search teams"
+            size="sm"
+            class="w-full"
+            :ui="{ root: 'w-full' }"
+          >
+            <template v-if="query" #trailing>
+              <UButton
+                color="neutral"
+                variant="link"
+                size="xs"
+                icon="i-heroicons-x-mark"
+                aria-label="Clear search"
+                data-test="clear-search"
+                @click="query = ''"
+              />
+            </template>
+          </UInput>
+        </div>
+
+        <!-- All companies (hidden while searching) -->
+        <template v-if="!query">
+          <button
+            type="button"
+            :class="[menuItemClass, isAllCompaniesActive ? 'bg-primary/10' : '']"
+            data-test="all-companies"
+            @click="goAllCompanies"
+          >
+            <span
+              class="bg-muted text-muted border-default flex size-[30px] shrink-0 items-center justify-center rounded-lg border"
+            >
+              <UIcon name="i-heroicons-squares-2x2" class="size-4" />
+            </span>
+            <span class="min-w-0 flex-1">
+              <span class="text-highlighted block text-[13px] font-semibold">All companies</span>
+              <span class="text-muted block text-[11px]"
+                >Portfolio overview · {{ teamCountLabel }}</span
+              >
+            </span>
+            <UIcon
+              v-if="isAllCompaniesActive"
+              name="i-heroicons-check"
+              class="text-primary size-4 shrink-0"
+            />
+          </button>
+          <div class="bg-border-muted mx-1.5 my-1 h-px" />
+        </template>
+
+        <!-- Team list -->
+        <div class="overflow-y-auto px-1.5 pb-1.5">
+          <button
+            v-for="t in filteredTeams"
+            :key="t.id"
+            type="button"
+            :class="[menuItemClass, isTeamActive(t) ? 'bg-primary/10' : '']"
+            :data-test="`team-option-${t.id}`"
+            @click="selectTeam(t)"
+          >
+            <span
+              class="flex size-[30px] shrink-0 items-center justify-center rounded-lg text-[12px] font-bold"
+              :class="isOwner(t) ? 'bg-primary/10 text-primary' : 'bg-secondary/10 text-secondary'"
+              >{{ getTeamInitials(t.name) }}</span
+            >
+            <span class="min-w-0 flex-1">
+              <span class="flex min-w-0 items-center gap-1.5">
+                <span class="text-highlighted truncate text-[13px] font-semibold">{{
+                  t.name
+                }}</span>
+                <UBadge
+                  :color="isOwner(t) ? 'primary' : 'secondary'"
+                  variant="solid"
+                  size="sm"
+                  class="shrink-0"
+                  >{{ isOwner(t) ? 'Owner' : 'Employee' }}</UBadge
+                >
+              </span>
+              <span class="text-muted block text-[11px]">{{ teamSubtitle(t) }}</span>
+            </span>
+            <UIcon
+              v-if="isTeamActive(t)"
+              name="i-heroicons-check"
+              class="text-primary size-4 shrink-0"
+            />
+          </button>
+
+          <p
+            v-if="filteredTeams.length === 0"
+            class="text-muted px-3.5 py-6 text-center text-[13px]"
+            data-test="team-empty"
+          >
+            No teams match “{{ query }}”
+          </p>
+        </div>
+
+        <!-- Footer: create company -->
+        <div class="border-default border-t p-1.5">
+          <button
+            type="button"
+            :class="[menuItemClass, 'text-primary font-semibold']"
+            data-test="create-company"
+            @click="createCompany"
+          >
+            <span
+              class="bg-primary/10 text-primary flex size-[30px] shrink-0 items-center justify-center rounded-lg"
+            >
+              <UIcon name="i-heroicons-plus" class="size-4" />
+            </span>
+            Create company
+          </button>
+        </div>
+      </div>
+    </template>
+  </UPopover>
 </template>
 
 <script setup lang="ts">
 import { useUserDataStore, useTeamStore } from '@/stores'
 import { useGetTeamsQuery } from '@/queries/team.queries'
-import { storeToRefs } from 'pinia'
-import { computed } from 'vue'
+import type { Team } from '@/types/team'
+import { computed, ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 
 const router = useRouter()
 const route = useRoute()
 const userStore = useUserDataStore()
 const teamStore = useTeamStore()
-const { currentTeamId } = storeToRefs(teamStore)
+
+const open = ref(false)
+const query = ref('')
 
 const { data: teams, isPending: teamsLoading } = useGetTeamsQuery({
   queryParams: { userAddress: computed(() => userStore.address) }
 })
 
+/** Shared row styling for the dropdown items. */
+const menuItemClass =
+  'flex w-full items-center gap-2.5 rounded-[9px] px-2.5 py-2 text-left transition-colors hover:bg-muted'
+
+const gradientStyle = {
+  background: 'linear-gradient(135deg, var(--color-primary), var(--color-secondary))'
+}
+
 /**
- * Build short, readable initials for a team avatar:
+ * Short, readable initials for a team chip:
  * first letters of the first two words ("Globe & Citizen" → "GC"),
  * or the first two characters for a single-word name ("Acme" → "AC").
  */
@@ -40,28 +190,57 @@ const getTeamInitials = (name: string) => {
   return (words[0]![0]! + words[1]![0]!).toUpperCase()
 }
 
-const teamItems = computed(() =>
-  (teams.value ?? []).map((t) => ({
-    label: t.name,
-    id: t.id,
-    avatar: { text: getTeamInitials(t.name) }
-  }))
+const teamList = computed<Team[]>(() => teams.value ?? [])
+
+// The route is the source of truth for which company is open.
+const activeTeamId = computed(() => (route.params.id as string | undefined) ?? null)
+const selectedTeam = computed(() =>
+  teamList.value.find((t) => Number(t.id) === Number(activeTeamId.value))
 )
 
-// The active team id: prefer the route param (most authoritative), then the store
-const activeTeamId = computed(
-  () => (route.params.id as string | undefined) ?? currentTeamId.value ?? null
+const teamMark = computed(() =>
+  selectedTeam.value ? getTeamInitials(selectedTeam.value.name) : '∗'
 )
+const teamLabel = computed(() => selectedTeam.value?.name ?? 'All companies')
+const teamCountLabel = computed(() => `${teamList.value.length} companies`)
+const isAllCompaniesActive = computed(() => !activeTeamId.value)
 
-const selectedTeam = computed({
-  get() {
-    return teamItems.value.find((t) => Number(t.id) === Number(activeTeamId.value)) ?? undefined
-  },
-  set(item: { label: string; id: string } | undefined) {
-    if (item) {
-      teamStore.setCurrentTeamId(item.id)
-      router.push(`/teams/${item.id}`)
-    }
-  }
+const isOwner = (team: Team) =>
+  !!team.ownerAddress &&
+  !!userStore.address &&
+  team.ownerAddress.toLowerCase() === userStore.address.toLowerCase()
+
+const isTeamActive = (team: Team) => Number(team.id) === Number(activeTeamId.value)
+
+const memberCount = (team: Team) => team._count?.members ?? team.members?.length ?? 0
+const teamSubtitle = (team: Team) => `${memberCount(team)} members`
+
+const filteredTeams = computed(() => {
+  const q = query.value.trim().toLowerCase()
+  if (!q) return teamList.value
+  return teamList.value.filter(
+    (t) => t.name.toLowerCase().includes(q) || getTeamInitials(t.name).toLowerCase().includes(q)
+  )
 })
+
+const closeMenu = () => {
+  open.value = false
+  query.value = ''
+}
+
+const selectTeam = (team: Team) => {
+  teamStore.setCurrentTeamId(team.id)
+  router.push(`/teams/${team.id}`)
+  closeMenu()
+}
+
+const goAllCompanies = () => {
+  router.push('/teams')
+  closeMenu()
+}
+
+const createCompany = () => {
+  router.push({ path: '/teams', query: { create: '1' } })
+  closeMenu()
+}
 </script>

--- a/app/src/components/TeamSelectMenu.vue
+++ b/app/src/components/TeamSelectMenu.vue
@@ -28,11 +28,23 @@ const { data: teams, isPending: teamsLoading } = useGetTeamsQuery({
   queryParams: { userAddress: computed(() => userStore.address) }
 })
 
+/**
+ * Build short, readable initials for a team avatar:
+ * first letters of the first two words ("Globe & Citizen" → "GC"),
+ * or the first two characters for a single-word name ("Acme" → "AC").
+ */
+const getTeamInitials = (name: string) => {
+  const words = name.trim().split(/\s+/).filter(Boolean)
+  if (words.length === 0) return '?'
+  if (words.length === 1) return words[0]!.slice(0, 2).toUpperCase()
+  return (words[0]![0]! + words[1]![0]!).toUpperCase()
+}
+
 const teamItems = computed(() =>
   (teams.value ?? []).map((t) => ({
     label: t.name,
     id: t.id,
-    avatar: { text: t.name.charAt(0).toUpperCase() }
+    avatar: { text: getTeamInitials(t.name) }
   }))
 )
 

--- a/app/src/components/__tests__/NavBreadcrumb.spec.ts
+++ b/app/src/components/__tests__/NavBreadcrumb.spec.ts
@@ -1,38 +1,58 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { createRouter, createMemoryHistory } from 'vue-router'
 import NavBreadcrumb from '@/components/NavBreadcrumb.vue'
 import { mockTeamData } from '@/tests/mocks/index'
-import { mockTeamStore } from '@/tests/mocks/store.mock'
+import { mockTeamStore, mockUserStore } from '@/tests/mocks/store.mock'
 import { setMockRoute } from '@/tests/mocks/router.mock'
 
-// UBreadcrumb (auto-imported) renders the real component, so we assert on its output.
+// A real (memory) router so UBreadcrumb's RouterLink-based crumbs can resolve.
+// Component logic still reads the globally-mocked useRoute (mockRoute).
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/teams', name: 'teams', component: { template: '<div />' } },
+    { path: '/teams/:id', name: 'show-team', component: { template: '<div />' } }
+  ]
+})
+
+const mountBreadcrumb = () => mount(NavBreadcrumb, { global: { plugins: [router] } })
+
 describe('NavBreadcrumb', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('shows [team name] > [page] when viewing a team', () => {
-    // Default mock route: params.id = '1', meta.name = 'Team View'
-    const wrapper = mount(NavBreadcrumb)
-
-    expect(wrapper.text()).toContain(mockTeamData.name) // 'Test Team'
-    expect(wrapper.text()).toContain('Team View')
+  it('shows Companies / Team [role] / Page inside a team', () => {
+    // Default mock route: params.id = '1', meta.name = 'Team View'.
+    // mockUserStore.address differs from mockTeamData.ownerAddress → Employee.
+    const text = mountBreadcrumb().text()
+    expect(text).toContain('Companies')
+    expect(text).toContain(mockTeamData.name) // 'Test Team'
+    expect(text).toContain('Team View')
+    expect(text).toContain('Employee')
   })
 
-  it('shows only the page label on the Companies list (no team selected)', () => {
+  it('links the Companies and team crumbs', () => {
+    const wrapper = mountBreadcrumb()
+    expect(wrapper.find('a[href="/teams"]').exists()).toBe(true)
+    expect(wrapper.find('a[href="/teams/1"]').exists()).toBe(true)
+  })
+
+  it('marks the user as Owner when they own the team', () => {
+    mockUserStore.address = mockTeamData.ownerAddress as string
+    expect(mountBreadcrumb().text()).toContain('Owner')
+  })
+
+  it('shows only the Companies crumb on the companies list', () => {
     setMockRoute({ name: 'teams', params: {}, path: '/teams', meta: { name: 'Companies' } })
-
-    const wrapper = mount(NavBreadcrumb)
-
-    expect(wrapper.text()).toContain('Companies')
-    expect(wrapper.text()).not.toContain(mockTeamData.name)
+    const text = mountBreadcrumb().text()
+    expect(text).toContain('Companies')
+    expect(text).not.toContain(mockTeamData.name)
   })
 
-  it('renders a skeleton placeholder while the team is loading', () => {
+  it('renders a skeleton while the team is loading', () => {
     mockTeamStore.currentTeamMeta = { isPending: true, data: undefined } as never
-
-    const wrapper = mount(NavBreadcrumb)
-
-    expect(wrapper.find('[data-test="loader"]').exists()).toBe(true)
+    expect(mountBreadcrumb().find('[data-test="loader"]').exists()).toBe(true)
   })
 })

--- a/app/src/components/__tests__/NavBreadcrumb.spec.ts
+++ b/app/src/components/__tests__/NavBreadcrumb.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import NavBreadcrumb from '@/components/NavBreadcrumb.vue'
+import { mockTeamData } from '@/tests/mocks/index'
+import { mockTeamStore } from '@/tests/mocks/store.mock'
+import { setMockRoute } from '@/tests/mocks/router.mock'
+
+// UBreadcrumb (auto-imported) renders the real component, so we assert on its output.
+describe('NavBreadcrumb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows [team name] > [page] when viewing a team', () => {
+    // Default mock route: params.id = '1', meta.name = 'Team View'
+    const wrapper = mount(NavBreadcrumb)
+
+    expect(wrapper.text()).toContain(mockTeamData.name) // 'Test Team'
+    expect(wrapper.text()).toContain('Team View')
+  })
+
+  it('shows only the page label on the Companies list (no team selected)', () => {
+    setMockRoute({ name: 'teams', params: {}, path: '/teams', meta: { name: 'Companies' } })
+
+    const wrapper = mount(NavBreadcrumb)
+
+    expect(wrapper.text()).toContain('Companies')
+    expect(wrapper.text()).not.toContain(mockTeamData.name)
+  })
+
+  it('renders a skeleton placeholder while the team is loading', () => {
+    mockTeamStore.currentTeamMeta = { isPending: true, data: undefined } as never
+
+    const wrapper = mount(NavBreadcrumb)
+
+    expect(wrapper.find('[data-test="loader"]').exists()).toBe(true)
+  })
+})

--- a/app/src/components/__tests__/TeamSelectMenu.spec.ts
+++ b/app/src/components/__tests__/TeamSelectMenu.spec.ts
@@ -106,13 +106,19 @@ describe('TeamSelectMenu', () => {
       })
     })
 
-    it('renders the initial letter avatar for each team item', async () => {
+    it('renders an initials avatar (up to two letters) for each team item', async () => {
+      const initialsOf = (name: string) => {
+        const words = name.trim().split(/\s+/).filter(Boolean)
+        if (words.length === 1) return words[0]!.slice(0, 2).toUpperCase()
+        return (words[0]![0]! + words[1]![0]!).toUpperCase()
+      }
+
       const wrapper = createWrapper()
       await wrapper.find('button').trigger('click')
       await wrapper.vm.$nextTick()
 
       mockTeamsData.forEach((team) => {
-        expect(wrapper.html()).toContain(team.name.charAt(0).toUpperCase())
+        expect(wrapper.html()).toContain(initialsOf(team.name)) // e.g. 'Test Team' → 'TT'
       })
     })
   })

--- a/app/src/components/__tests__/TeamSelectMenu.spec.ts
+++ b/app/src/components/__tests__/TeamSelectMenu.spec.ts
@@ -1,232 +1,106 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
-import { ref } from 'vue'
-import { useRoute } from 'vue-router'
-import { useTeamStore } from '@/stores'
 import TeamSelectMenu from '@/components/TeamSelectMenu.vue'
 import { useGetTeamsQuery } from '@/queries/team.queries'
-import { mockTeamStore, mockTeamsData } from '@/tests/mocks/index'
-import { mockRouterPush } from '@/tests/mocks/router.mock'
+import { mockTeamStore, mockUserStore } from '@/tests/mocks/store.mock'
+import { mockTeamData } from '@/tests/mocks/index'
 import { createMockQueryResponse } from '@/tests/mocks/query.mock'
+import { mockRouterPush, setMockRoute } from '@/tests/mocks/router.mock'
 
-// Restore real SelectMenu for this test — it tests actual USelectMenu behavior
-vi.unmock('@nuxt/ui/components/SelectMenu.vue')
-
-// jsdom does not implement scrollIntoView — reka-ui calls it when highlighting items
-Element.prototype.scrollIntoView = vi.fn()
-
-// currentTeamId must be a Vue ref so that storeToRefs() can extract it properly
-const mockCurrentTeamId = ref<string | null>(mockTeamStore.currentTeamId)
-
-const createWrapper = () =>
-  mount(TeamSelectMenu, {
-    attachTo: document.body,
-    global: {
-      stubs: {
-        // Override global stubs — this test exercises the real USelectMenu
-        USelectMenu: false,
-        SelectMenu: false
-      }
-    }
-  })
+// UPopover is globally stubbed and renders both its trigger and content slots,
+// so the dropdown markup is always present in the DOM during these tests.
+const mountMenu = () => mount(TeamSelectMenu)
 
 describe('TeamSelectMenu', () => {
-  afterEach(() => {
-    document.body.innerHTML = ''
-  })
-
   beforeEach(() => {
     vi.clearAllMocks()
-    Element.prototype.scrollIntoView = vi.fn()
-    mockCurrentTeamId.value = mockTeamStore.currentTeamId
-
-    // Return the mock store with currentTeamId as a ref so storeToRefs works
-    vi.mocked(useTeamStore).mockImplementation(
-      () =>
-        ({
-          ...mockTeamStore,
-          currentTeamId: mockCurrentTeamId
-        }) as unknown as ReturnType<typeof useTeamStore>
-    )
   })
 
-  describe('rendering', () => {
-    it('renders the select trigger button', () => {
-      const wrapper = createWrapper()
-      expect(wrapper.find('button').exists()).toBe(true)
+  describe('trigger', () => {
+    it('shows the active team initials and name', () => {
+      // Default mock route has params.id = '1' → mockTeamData ('Test Team').
+      const trigger = mountMenu().find('[data-test="team-picker"]')
+      expect(trigger.text()).toContain('TT') // initials
+      expect(trigger.text()).toContain('Test Team')
     })
 
-    it('shows a loading icon when teams are being fetched', () => {
+    it('shows the "All companies" state when no team is in the route', () => {
+      setMockRoute({ name: 'teams', params: {}, path: '/teams', meta: { name: 'Companies' } })
+      expect(mountMenu().find('[data-test="team-picker"]').text()).toContain('All companies')
+    })
+
+    it('shows a loading spinner while teams are being fetched', () => {
       vi.mocked(useGetTeamsQuery).mockReturnValueOnce(
         createMockQueryResponse([], true) as ReturnType<typeof useGetTeamsQuery>
       )
-      const wrapper = createWrapper()
-      expect(wrapper.find('[data-test="u-icon"][data-icon*="loader"]').exists()).toBe(true)
-    })
-
-    it('shows placeholder text when no team matches', () => {
-      vi.mocked(useGetTeamsQuery).mockReturnValueOnce(
-        createMockQueryResponse([]) as ReturnType<typeof useGetTeamsQuery>
-      )
-      vi.mocked(useRoute).mockReturnValueOnce({
-        params: {},
-        path: '/teams',
-        meta: {}
-      } as ReturnType<typeof useRoute>)
-
-      const wrapper = createWrapper()
-      expect(wrapper.text()).toContain('Select Company')
+      const wrapper = mountMenu()
+      expect(wrapper.find('[data-test="team-picker"] [data-icon*="loader"]').exists()).toBe(true)
     })
   })
 
-  describe('default selection', () => {
-    it('pre-selects the company matching the current route param id', () => {
-      // useRoute is globally mocked with params.id = '1' and mockTeamsData[0].id = '1'
-      const wrapper = createWrapper()
-      expect(wrapper.text()).toContain(mockTeamsData[0]!.name)
+  describe('menu', () => {
+    it('lists each team with its role badge and member count', () => {
+      const option = mountMenu().find('[data-test="team-option-1"]')
+      expect(option.exists()).toBe(true)
+      expect(option.text()).toContain('Test Team')
+      expect(option.text()).toContain('Employee') // user is not the owner
+      expect(option.text()).toContain('3 members') // mockTeamData has 3 members
     })
 
-    it('does not auto-navigate when a team is already active via route param', async () => {
-      // useRoute returns params.id = '1' by default — team is already "active"
-      createWrapper()
-      await new Promise((r) => setTimeout(r, 0))
-
-      expect(mockRouterPush).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('team items', () => {
-    it('displays all team names in the dropdown', async () => {
-      const wrapper = createWrapper()
-      await wrapper.find('button').trigger('click')
-      await wrapper.vm.$nextTick()
-
-      mockTeamsData.forEach((team) => {
-        expect(wrapper.html()).toContain(team.name)
-      })
+    it('marks the team as Owner when the user owns it', () => {
+      mockUserStore.address = mockTeamData.ownerAddress as string
+      expect(mountMenu().find('[data-test="team-option-1"]').text()).toContain('Owner')
     })
 
-    it('renders an initials avatar (up to two letters) for each team item', async () => {
-      const initialsOf = (name: string) => {
-        const words = name.trim().split(/\s+/).filter(Boolean)
-        if (words.length === 1) return words[0]!.slice(0, 2).toUpperCase()
-        return (words[0]![0]! + words[1]![0]!).toUpperCase()
-      }
-
-      const wrapper = createWrapper()
-      await wrapper.find('button').trigger('click')
-      await wrapper.vm.$nextTick()
-
-      mockTeamsData.forEach((team) => {
-        expect(wrapper.html()).toContain(initialsOf(team.name)) // e.g. 'Test Team' → 'TT'
-      })
+    it('shows All companies and Create company actions', () => {
+      const wrapper = mountMenu()
+      expect(wrapper.find('[data-test="all-companies"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="create-company"]').exists()).toBe(true)
     })
   })
 
-  describe('team selection', () => {
-    it('calls setCurrentTeamId with the selected team id', async () => {
-      const wrapper = createWrapper()
-      await wrapper.find('button').trigger('click')
-      await wrapper.vm.$nextTick()
-
-      const options = Array.from(document.querySelectorAll('[role="option"]'))
-      expect(options.length).toBeGreaterThan(0)
-      await (options[0] as HTMLElement).click()
-      await wrapper.vm.$nextTick()
-      expect(mockTeamStore.setCurrentTeamId).toHaveBeenCalledWith(mockTeamsData[0]!.id)
+  describe('actions', () => {
+    it('selects a team: sets the current team and navigates to it', async () => {
+      const wrapper = mountMenu()
+      await wrapper.find('[data-test="team-option-1"]').trigger('click')
+      expect(mockTeamStore.setCurrentTeamId).toHaveBeenCalledWith('1')
+      expect(mockRouterPush).toHaveBeenCalledWith('/teams/1')
     })
 
-    it('navigates to /teams/:id when a team is selected', async () => {
-      const wrapper = createWrapper()
-      await wrapper.find('button').trigger('click')
-      await wrapper.vm.$nextTick()
-
-      const options = Array.from(document.querySelectorAll('[role="option"]'))
-      expect(options.length).toBeGreaterThan(0)
-      await (options[0] as HTMLElement).click()
-      await wrapper.vm.$nextTick()
-      expect(mockRouterPush).toHaveBeenCalledWith(`/teams/${mockTeamsData[0]!.id}`)
+    it('navigates to the companies list from "All companies"', async () => {
+      const wrapper = mountMenu()
+      await wrapper.find('[data-test="all-companies"]').trigger('click')
+      expect(mockRouterPush).toHaveBeenCalledWith('/teams')
     })
-  })
 
-  describe('query params', () => {
-    it('passes the reactive user address to useGetTeamsQuery', () => {
-      createWrapper()
-      const callArg = vi.mocked(useGetTeamsQuery).mock.calls[0]?.[0]
-      const userAddress = callArg?.queryParams?.userAddress
-      // Evaluate the computed to cover the arrow function in the component
-      expect(userAddress?.value).toBeDefined()
+    it('opens the create flow from "Create company"', async () => {
+      const wrapper = mountMenu()
+      await wrapper.find('[data-test="create-company"]').trigger('click')
+      expect(mockRouterPush).toHaveBeenCalledWith({ path: '/teams', query: { create: '1' } })
     })
   })
 
   describe('search', () => {
-    it('renders a search input with the correct placeholder', async () => {
-      const wrapper = createWrapper()
-      await wrapper.find('button').trigger('click')
-      await wrapper.vm.$nextTick()
-
-      // USelectMenu renders its dropdown in a portal attached to document.body
-      const input = document.querySelector('input')
-      expect(input).not.toBeNull()
-      expect(input?.getAttribute('placeholder')).toBe('Search company...')
-    })
-
-    it('filters companies by name based on search input', async () => {
+    it('filters teams by name', async () => {
       vi.mocked(useGetTeamsQuery).mockReturnValueOnce(
         createMockQueryResponse([
-          { ...mockTeamsData[0]!, id: '1', name: 'Alpha Team' },
-          { ...mockTeamsData[0]!, id: '2', name: 'Beta Squad' }
+          { ...mockTeamData, id: '1', name: 'Alpha Team' },
+          { ...mockTeamData, id: '2', name: 'Beta Squad' }
         ]) as ReturnType<typeof useGetTeamsQuery>
       )
+      const wrapper = mountMenu()
+      await wrapper.find('input').setValue('Beta')
 
-      const wrapper = createWrapper()
-      await wrapper.find('button').trigger('click')
-      await wrapper.vm.$nextTick()
-
-      const input = document.querySelector('input') as HTMLInputElement
-      expect(input).not.toBeNull()
-
-      // Simulate typing — use nativeInputValueSetter to trigger reka-ui's input handler
-      input.value = 'Beta'
-      input.dispatchEvent(new InputEvent('input', { bubbles: true, cancelable: true }))
-      await wrapper.vm.$nextTick()
-
-      const listbox = document.querySelector('[role="listbox"]')
-      expect(listbox?.textContent).toContain('Beta Squad')
-      expect(listbox?.textContent).not.toContain('Alpha Team')
-    })
-  })
-
-  describe('edge cases', () => {
-    it('shows placeholder when teams data is null/undefined', () => {
-      vi.mocked(useGetTeamsQuery).mockReturnValueOnce({
-        data: ref(undefined),
-        isPending: ref(false)
-      } as unknown as ReturnType<typeof useGetTeamsQuery>)
-      const wrapper = createWrapper()
-      expect(wrapper.text()).toContain('Select Company')
+      const menu = wrapper.find('[data-test="team-menu"]')
+      expect(menu.text()).toContain('Beta Squad')
+      expect(menu.text()).not.toContain('Alpha Team')
     })
 
-    it('shows placeholder when neither route param nor store has an active team id', () => {
-      mockCurrentTeamId.value = null
-      vi.mocked(useRoute).mockReturnValueOnce({
-        params: {},
-        path: '/teams',
-        meta: {}
-      } as ReturnType<typeof useRoute>)
-      const wrapper = createWrapper()
-      expect(wrapper.text()).toContain('Select Company')
-    })
-
-    it('does nothing when the selected item is cleared (item is undefined)', async () => {
-      // Use global stub (no real component override) so we can emit directly
-      const wrapper = mount(TeamSelectMenu, { attachTo: document.body })
-      const selectMenu = wrapper.findComponent({ name: 'USelectMenu' })
-      // Emit update:modelValue with undefined to exercise the if(item) false branch
-      await selectMenu.vm.$emit('update:modelValue', undefined)
-      await wrapper.vm.$nextTick()
-      expect(mockTeamStore.setCurrentTeamId).not.toHaveBeenCalled()
-      expect(mockRouterPush).not.toHaveBeenCalled()
+    it('hides "All companies" and shows an empty state when nothing matches', async () => {
+      const wrapper = mountMenu()
+      await wrapper.find('input').setValue('zzz')
+      expect(wrapper.find('[data-test="all-companies"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="team-empty"]').exists()).toBe(true)
     })
   })
 })

--- a/app/src/views/team/ListIndex.vue
+++ b/app/src/views/team/ListIndex.vue
@@ -143,7 +143,7 @@ import { useUserDataStore } from '@/stores'
 import AddTeamCard from '@/components/sections/TeamView/AddTeamCard.vue'
 import TeamCard from '@/components/sections/TeamView/TeamCard.vue'
 import { useGetTeamsQuery } from '@/queries/team.queries'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 const openModal = ref(false)
 const showHidden = ref(false)
@@ -173,6 +173,19 @@ const hasVisibleTeams = computed(
 )
 
 const router = useRouter()
+
+// Opened from the navbar team picker's "Create company" action (/teams?create=1):
+// auto-open the create modal, then strip the query so a refresh won't re-open it.
+watch(
+  () => route.query?.create,
+  (create) => {
+    if (create) {
+      openModal.value = true
+      router.replace({ query: {} })
+    }
+  },
+  { immediate: true }
+)
 
 const navigateToTeam = (id: number | string) => {
   router.push(`/teams/${id}`)

--- a/app/src/views/team/[id]/ShowIndex.vue
+++ b/app/src/views/team/[id]/ShowIndex.vue
@@ -1,13 +1,5 @@
 <template>
-  <!-- Navigation and breadcrumb -->
   <div class="flex w-full flex-col gap-6">
-    <div>
-      <UBreadcrumb v-if="!teamStore.currentTeamMeta.error" :items="breadcrumbItems">
-        <template #loader>
-          <USkeleton class="h-4 w-20" data-test="loader" />
-        </template>
-      </UBreadcrumb>
-    </div>
     <div v-if="teamStore.currentTeamMeta?.error" data-test="error-state">
       <UAlert
         v-if="teamStore.currentTeamMeta.error?.status == 404"
@@ -89,16 +81,6 @@ watch(teamStore.currentTeamMeta, () => {
 
 const hasContract = computed(() => {
   return (teamStore.currentTeamMeta.data?.teamContracts ?? []).length > 0
-})
-
-const breadcrumbItems = computed(() => {
-  if (teamStore.currentTeamMeta?.isPending) {
-    return [{ slot: 'loader' as const }, { label: route.meta.name as string }]
-  }
-  if (teamStore.currentTeamMeta?.data) {
-    return [{ label: teamStore.currentTeamMeta.data?.name }, { label: route.meta.name as string }]
-  }
-  return [{ label: route.meta.name as string }]
 })
 
 watch(

--- a/app/src/views/team/[id]/__tests__/ShowIndex.spec.ts
+++ b/app/src/views/team/[id]/__tests__/ShowIndex.spec.ts
@@ -1,48 +1,42 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ShowIndex from '@/views/team/[id]/ShowIndex.vue'
 import { mount } from '@vue/test-utils'
-import { createTestingPinia } from '@pinia/testing'
-import { createRouter, createWebHistory } from 'vue-router'
-import { mockTeamData } from '@/tests/mocks/index'
+import { setMockRoute } from '@/tests/mocks/router.mock'
 
 describe('ShowIndex', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  const router = createRouter({
-    history: createWebHistory(),
-    routes: [
-      {
-        path: '/team/:id',
-        name: 'show-team',
-        meta: { name: 'Team View' },
-        component: { template: '<div>Home</div>' }
-      } // Basic route
-    ] // Define your routes here if needed
-  })
-  // TODO test navigation
-
-  it('should render the team Breadcrumb', async () => {
-    const wrapper = mount(ShowIndex, {
+  const mountShowIndex = () =>
+    mount(ShowIndex, {
       global: {
-        plugins: [router, createTestingPinia({ createSpy: vi.fn })],
         stubs: {
           ContinueAddTeamForm: true,
-          TeamMeta: true
+          TeamMeta: true,
+          CompanyOverview: true,
+          TeamArchivedBanner: true,
+          RouterView: true
         }
       }
     })
-    await router.push({ name: 'show-team', params: { id: '1' } })
-    await wrapper.vm.$nextTick()
-    expect(wrapper.html()).toContain('Team View')
 
-    // Test that team name is rendered
-    expect(wrapper.html()).toContain(mockTeamData.name)
+  it('renders the team overview sections on the show-team route', () => {
+    // The global teamStore mock exposes currentTeamMeta.data = mockTeamData.
+    setMockRoute({ name: 'show-team', params: { id: '1' }, meta: { name: 'Overview' } })
+
+    const wrapper = mountShowIndex()
+
+    expect(wrapper.html()).toContain('team-meta-stub')
+    expect(wrapper.html()).toContain('company-overview-stub')
   })
 
-  // Display the component whit the officer address
+  it('no longer renders an in-page breadcrumb (it now lives in the navbar)', () => {
+    setMockRoute({ name: 'show-team', params: { id: '1' }, meta: { name: 'Overview' } })
 
-  // TODO: change route
-  // TODO: Click the modal
+    const wrapper = mountShowIndex()
+
+    // The breadcrumb skeleton/loader used to render here; it belongs to NavBreadcrumb now.
+    expect(wrapper.find('[data-test="loader"]').exists()).toBe(false)
+  })
 })

--- a/app/src/views/team/__tests__/ListIndex.spec.ts
+++ b/app/src/views/team/__tests__/ListIndex.spec.ts
@@ -3,7 +3,7 @@ import ListIndex from '@/views/team/ListIndex.vue'
 import { mount } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
 import { createMockQueryResponse } from '@/tests/mocks/query.mock'
-import { mockTeamsData, mockTeamData, mockRouterPush } from '@/tests/mocks'
+import { mockTeamsData, mockTeamData, mockRouterPush, mockRouterReplace } from '@/tests/mocks'
 import type { Team } from '@/types'
 import { useRoute } from 'vue-router'
 
@@ -333,6 +333,29 @@ describe('ListIndex - Team List View', () => {
 
       const teamCards = wrapper.findAll('[data-test^="team-card-"]')
       expect(teamCards).toHaveLength(1)
+    })
+  })
+
+  describe('Create company deep link', () => {
+    it('auto-opens the create modal and clears the query when navigated with ?create=1', async () => {
+      vi.mocked(useRoute).mockReturnValue({
+        params: {},
+        meta: { name: 'Team List View' },
+        query: { create: '1' }
+      } as unknown as ReturnType<typeof useRoute>)
+      vi.mocked(useGetTeamsQuery).mockReturnValueOnce(createMockQueryResponse(mockTeamsData))
+
+      const wrapper = mount(ListIndex, {
+        global: {
+          plugins: [createTestingPinia({ createSpy: vi.fn })],
+          stubs: { AddTeamCard: true, TeamCard: true, AddTeamForm: true }
+        }
+      })
+      await wrapper.vm.$nextTick()
+
+      // The mocked UModal only renders its body (with the close button) when open.
+      expect(wrapper.find('[data-test="close-wage-modal-button"]').exists()).toBe(true)
+      expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
     })
   })
 })


### PR DESCRIPTION
## What
Reworks the dashboard top navigation to match the **CNC Portal** design (claude.ai/design), using Nuxt UI components.

### Breadcrumb (`NavBreadcrumb`, in the navbar `#title` slot)
- Three-level, clickable: **Companies / Team [role] / Page** with a `/` separator.
- `Companies` links to `/teams`; the team name links to the team overview.
- An **Owner/Employee** role badge sits next to the team name (derived from team owner vs current user).
- Companies list: a single `Companies` crumb. Loading: a skeleton stands in for the team name. Team load error: falls back to `Companies / Page`.

### Company picker (`TeamSelectMenu`)
- `USelectMenu` → **`UPopover`-based** picker matching the design:
  - Trigger: soft-primary pill with a gradient initials chip (`∗` + "All companies" when no team is open).
  - Menu: "Switch team" header + count, search, **All companies** entry, per-team initials chip + **Owner/Employee** badge + member count, active check, and a **Create company** action.
- The picker is now shown **everywhere** (reads "All companies" on the Companies list).
- **All companies** → `/teams`. **Create company** → `/teams?create=1`, which auto-opens the existing create-company modal in `ListIndex`.

## Adaptations / notes
- Role model is **Owner/Employee** (owner = team `ownerAddress` matches the user), mirroring the design.
- Item subtitle shows **member count** only (the design's `· balance` isn't in the teams-list payload).
- Colors use the app's Nuxt UI tokens (flat `primary`/`secondary` + opacity, `text-dimmed`/`bg-muted`/…) since the app theme has no numeric color scales; the trigger gradient uses `var(--color-primary/secondary)`.

## Verification
- `vitest` green for NavBreadcrumb, TeamSelectMenu, ShowIndex, App, ListIndex (51 tests)
- `vite build` + `vue-tsc --build` pass
- `eslint` + `prettier` clean

Closes #2210