### PR TITLE
feat: ✨ Sidebar — Companies icon, show on Companies page, and Company workspace gating

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -7,7 +7,7 @@
         <div v-if="userStore.isAuth">
           <!-- Responsive Drawer and Content -->
           <UDashboardGroup v-if="route.name">
-            <SidebarLayout v-if="route.name && route.name !== 'teams'"></SidebarLayout>
+            <SidebarLayout v-if="route.name"></SidebarLayout>
             <UDashboardPanel
               :ui="{
                 body: 'overflow-x-hidden'
@@ -20,7 +20,7 @@
                       icon="heroicons:arrow-left-start-on-rectangle"
                       trailing
                       trailing-icon="heroicons:arrow-right-start-on-rectangle"
-                      v-if="route.name && route.name !== 'teams'"
+                      v-if="route.name"
                     />
                   </template>
                   <template #trailing>

--- a/app/src/composables/__tests__/useSidebarNavItems.spec.ts
+++ b/app/src/composables/__tests__/useSidebarNavItems.spec.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { NavigationMenuItem } from '@nuxt/ui'
+import { useSidebarNavItems } from '@/composables/useSidebarNavItems'
+import { mockRoute } from '@/tests/mocks/router.mock'
+import { mockTeamStore } from '@/tests/mocks/store.mock'
+
+/** Flatten the grouped nav into a single list for easier lookups. */
+const flatten = (groups: NavigationMenuItem[][]) => groups.flat()
+
+const findByLabel = (groups: NavigationMenuItem[][], label: string) =>
+  flatten(groups).find((item) => item.label === label)
+
+/** The team-scoped surfaces that must follow the "has a company" gate. */
+const WORKSPACE_LABELS = [
+  'Company',
+  'Accounts',
+  'Payroll',
+  'Community Credit',
+  'Accounting',
+  'Contract Management',
+  'SHER Token',
+  'Administration',
+  'Vesting',
+  'Debt Financing'
+]
+
+describe('useSidebarNavItems', () => {
+  beforeEach(() => {
+    mockRoute.name = undefined
+    mockRoute.params = {}
+    mockTeamStore.currentTeamId = null as unknown as string
+  })
+
+  it('exposes Companies as a standalone first group with the building icon', () => {
+    const items = useSidebarNavItems()
+    const companies = items.value[0][0]
+
+    expect(companies.label).toBe('Companies')
+    expect(companies.icon).toBe('heroicons:building-office-2')
+    expect(companies.to).toBe('/teams')
+  })
+
+  it('marks Companies active only on the teams list route', () => {
+    const items = useSidebarNavItems()
+    expect(items.value[0][0].active).toBe(false)
+
+    mockRoute.name = 'teams'
+    expect(items.value[0][0].active).toBe(true)
+  })
+
+  describe('when no company is selected', () => {
+    it('labels the workspace group "Company workspace"', () => {
+      const items = useSidebarNavItems()
+      const label = items.value[1][0]
+
+      expect(label.type).toBe('label')
+      expect(label.label).toBe('Company workspace')
+    })
+
+    it('disables every workspace surface', () => {
+      const items = useSidebarNavItems()
+
+      for (const label of WORKSPACE_LABELS) {
+        expect(findByLabel(items.value, label)?.disabled, label).toBe(true)
+      }
+    })
+
+    it('keeps accordion surfaces collapsed', () => {
+      const items = useSidebarNavItems()
+      expect(findByLabel(items.value, 'Accounts')?.defaultOpen).toBe(false)
+    })
+  })
+
+  describe('when a company is selected', () => {
+    beforeEach(() => {
+      mockRoute.name = 'show-team'
+      mockRoute.params = { id: '42' }
+    })
+
+    it('shows the selected company name as the group label', () => {
+      mockTeamStore.currentTeam = { ...mockTeamStore.currentTeam, name: 'Layer8 Core' }
+
+      const items = useSidebarNavItems()
+      expect(items.value[1][0].label).toBe('Layer8 Core')
+    })
+
+    it('enables every workspace surface', () => {
+      const items = useSidebarNavItems()
+
+      for (const label of WORKSPACE_LABELS) {
+        expect(findByLabel(items.value, label)?.disabled, label).toBe(false)
+      }
+    })
+
+    it('treats a lingering store selection as a selected company', () => {
+      mockRoute.name = undefined
+      mockRoute.params = {}
+      mockTeamStore.currentTeamId = '7'
+
+      const items = useSidebarNavItems()
+      expect(findByLabel(items.value, 'Accounts')?.disabled).toBe(false)
+    })
+  })
+})

--- a/app/src/composables/__tests__/useSidebarNavItems.spec.ts
+++ b/app/src/composables/__tests__/useSidebarNavItems.spec.ts
@@ -1,8 +1,8 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { NavigationMenuItem } from '@nuxt/ui'
 import { useSidebarNavItems } from '@/composables/useSidebarNavItems'
 import { mockRoute } from '@/tests/mocks/router.mock'
-import { mockTeamStore } from '@/tests/mocks/store.mock'
+import { mockTeamStore, mockUserStore } from '@/tests/mocks/store.mock'
 
 /** Flatten the grouped nav into a single list for easier lookups. */
 const flatten = (groups: NavigationMenuItem[][]) => groups.flat()
@@ -99,6 +99,57 @@ describe('useSidebarNavItems', () => {
 
       const items = useSidebarNavItems()
       expect(findByLabel(items.value, 'Accounts')?.disabled).toBe(false)
+    })
+
+    it('falls back to "Company workspace" when the company has no name yet', () => {
+      mockRoute.params = { id: '42' }
+      mockTeamStore.currentTeam = undefined as never
+
+      const items = useSidebarNavItems()
+      expect(items.value[1][0].label).toBe('Company workspace')
+    })
+  })
+
+  describe('route-derived item details', () => {
+    beforeEach(() => {
+      mockRoute.params = { id: '42' }
+    })
+
+    const payrollHistoryChild = () => {
+      const payroll = findByLabel(useSidebarNavItems().value, 'Payroll')
+      return payroll?.children?.find((c) => c.active !== undefined)
+    }
+
+    it('labels the payroll-history entry "Member" for another member', () => {
+      mockRoute.name = 'payroll-history'
+      mockRoute.params = { id: '42', memberAddress: '0xSomeoneElse' }
+
+      const child = payrollHistoryChild()
+      expect(child?.label).toBe('Member Payroll History')
+      expect(child?.active).toBe(true)
+    })
+
+    it('labels the payroll-history entry "My" for the current user', () => {
+      mockRoute.name = 'payroll-history'
+      mockRoute.params = { id: '42', memberAddress: mockUserStore.address }
+
+      const child = payrollHistoryChild()
+      expect(child?.label).toBe('My Payroll History')
+      expect(child?.active).toBe(true)
+    })
+
+    it('marks Community Credit active on community-credit routes', () => {
+      mockRoute.name = 'community-credit-detail'
+
+      expect(findByLabel(useSidebarNavItems().value, 'Community Credit')?.active).toBe(true)
+    })
+
+    it('falls back to 0x for the Safe address when none is configured', () => {
+      mockTeamStore.getContractAddressByType = vi.fn(() => undefined)
+
+      const accounts = findByLabel(useSidebarNavItems().value, 'Accounts')
+      const safe = accounts?.children?.find((c) => c.label === 'Safe Account')
+      expect((safe?.to as { params: { address: string } }).params.address).toBe('0x')
     })
   })
 })

--- a/app/src/composables/useSidebarNavItems.ts
+++ b/app/src/composables/useSidebarNavItems.ts
@@ -5,122 +5,161 @@ import { useTeamStore } from '@/stores/teamStore'
 import { useUserDataStore } from '@/stores/user'
 
 /**
- * Builds the team-scoped navigation tree for the dashboard sidebar. Kept in a
- * composable so {@link SidebarLayout} stays focused on layout markup.
+ * Builds the sidebar navigation as two groups:
+ *
+ * 1. **Companies** — the portfolio entry point, always reachable.
+ * 2. **Company workspace** — the team-scoped surfaces (Overview, Accounts,
+ *    Payroll, …). These are disabled until a company is selected, since they
+ *    have no team to operate on; the group label then shows the active
+ *    company's name.
+ *
+ * Kept in a composable so {@link SidebarLayout} stays focused on layout markup.
  */
-export function useSidebarNavItems(): ComputedRef<NavigationMenuItem[]> {
+export function useSidebarNavItems(): ComputedRef<NavigationMenuItem[][]> {
   const route = useRoute()
   const userStore = useUserDataStore()
   const teamStore = useTeamStore()
 
+  /**
+   * A company is selected when the route is scoped to one (`/teams/:id/…`) or
+   * the store still holds the last selection. Mirrors the `activeTeamId`
+   * derivation in {@link TeamSelectMenu}.
+   */
+  const hasCompany = computed(() => Boolean(route.params.id ?? teamStore.currentTeamId))
+
   /** Current team id, falling back to `'1'` before a team is selected. */
   const teamParams = () => ({ id: teamStore.currentTeamId || '1' })
 
-  return computed<NavigationMenuItem[]>(() => [
-    {
-      label: 'Companies',
-      icon: 'heroicons:squares-2x2',
-      to: '/teams'
-    },
-    {
-      label: 'Company',
-      icon: 'heroicons:home',
-      active: route.name === 'show-team',
-      to: { name: 'show-team', params: teamParams() }
-    },
-    {
-      label: 'Accounts',
-      icon: 'heroicons:currency-dollar',
-      to: { name: 'bank-account', params: teamParams() },
-      defaultOpen: true,
-      children: [
-        { label: 'Bank Account', to: { name: 'bank-account', params: teamParams() } },
+  return computed<NavigationMenuItem[][]>(() => {
+    const disabled = !hasCompany.value
+
+    return [
+      [
         {
-          label: 'Safe Account',
-          to: {
-            name: 'safe-account',
-            params: {
-              id: teamStore.currentTeamId || '1',
-              address: teamStore.getContractAddressByType('Safe') || '0x'
-            }
-          }
-        },
-        { label: 'Expense Account', to: { name: 'expense-account', params: teamParams() } }
-      ]
-    },
-    {
-      label: 'Payroll',
-      icon: 'heroicons:currency-dollar',
-      to: { name: 'payroll-account', params: teamParams() },
-      defaultOpen: true,
-      children: [
-        { label: 'Payroll Account', to: { name: 'payroll-account', params: teamParams() } },
+          label: 'Companies',
+          icon: 'heroicons:building-office-2',
+          active: route.name === 'teams',
+          to: '/teams'
+        }
+      ],
+      [
         {
-          label:
-            route.name === 'payroll-history' && route.params.memberAddress !== userStore.address
-              ? 'Member Payroll History'
-              : 'My Payroll History',
-          active: route.name === 'payroll-history',
-          to: {
-            name: 'payroll-history',
-            params: { id: teamStore.currentTeamId || '1', memberAddress: userStore.address }
-          }
+          label: hasCompany.value
+            ? (teamStore.currentTeam?.name ?? 'Company workspace')
+            : 'Company workspace',
+          type: 'label'
         },
-        { label: 'Company Payroll', to: { name: 'team-payroll', params: teamParams() } }
+        {
+          label: 'Company',
+          icon: 'heroicons:home',
+          active: route.name === 'show-team',
+          disabled,
+          to: { name: 'show-team', params: teamParams() }
+        },
+        {
+          label: 'Accounts',
+          icon: 'heroicons:currency-dollar',
+          disabled,
+          to: { name: 'bank-account', params: teamParams() },
+          defaultOpen: hasCompany.value,
+          children: [
+            { label: 'Bank Account', to: { name: 'bank-account', params: teamParams() } },
+            {
+              label: 'Safe Account',
+              to: {
+                name: 'safe-account',
+                params: {
+                  id: teamStore.currentTeamId || '1',
+                  address: teamStore.getContractAddressByType('Safe') || '0x'
+                }
+              }
+            },
+            { label: 'Expense Account', to: { name: 'expense-account', params: teamParams() } }
+          ]
+        },
+        {
+          label: 'Payroll',
+          icon: 'heroicons:currency-dollar',
+          disabled,
+          to: { name: 'payroll-account', params: teamParams() },
+          defaultOpen: hasCompany.value,
+          children: [
+            { label: 'Payroll Account', to: { name: 'payroll-account', params: teamParams() } },
+            {
+              label:
+                route.name === 'payroll-history' && route.params.memberAddress !== userStore.address
+                  ? 'Member Payroll History'
+                  : 'My Payroll History',
+              active: route.name === 'payroll-history',
+              to: {
+                name: 'payroll-history',
+                params: { id: teamStore.currentTeamId || '1', memberAddress: userStore.address }
+              }
+            },
+            { label: 'Company Payroll', to: { name: 'team-payroll', params: teamParams() } }
+          ]
+        },
+        {
+          label: 'Community Credit',
+          icon: 'heroicons:hand-raised',
+          active: String(route.name ?? '').startsWith('community-credit'),
+          disabled,
+          to: { name: 'community-credit', params: teamParams() }
+        },
+        {
+          label: 'Accounting',
+          icon: 'heroicons:book-open',
+          disabled,
+          to: { name: 'accounting', params: teamParams() },
+          defaultOpen: false,
+          children: [
+            { label: 'Summary', to: { name: 'accounting-summary', params: teamParams() } },
+            { label: 'Income Statement', to: { name: 'accounting-income', params: teamParams() } },
+            { label: 'Balance Sheet', to: { name: 'accounting-balance', params: teamParams() } },
+            { label: 'Trial Balance', to: { name: 'accounting-trial', params: teamParams() } },
+            { label: 'General Ledger', to: { name: 'accounting-ledger', params: teamParams() } }
+          ]
+        },
+        {
+          label: 'Contract Management',
+          icon: 'heroicons:wrench',
+          disabled,
+          to: { name: 'contract-management', params: teamParams() }
+        },
+        {
+          label: 'SHER Token',
+          icon: 'heroicons:chart-pie',
+          disabled,
+          to: { name: 'sher-token', params: teamParams() }
+        },
+        {
+          label: 'Administration',
+          icon: 'heroicons:chart-bar',
+          disabled,
+          to: { name: 'bod-elections', params: teamParams() },
+          children: [
+            { label: 'Board Election', to: { name: 'bod-elections', params: teamParams() } },
+            { label: 'Proposals', to: { name: 'bod-proposals', params: teamParams() } }
+          ]
+        },
+        {
+          label: 'Vesting',
+          icon: 'heroicons:lock-closed',
+          disabled,
+          to: { name: 'vesting', params: teamParams() }
+        },
+        {
+          label: 'Debt Financing',
+          icon: 'heroicons:banknotes',
+          disabled,
+          to: { name: 'fixed-return', params: teamParams() },
+          defaultOpen: hasCompany.value,
+          children: [
+            { label: 'Fixed Return', to: { name: 'fixed-return', params: teamParams() } },
+            { label: 'Browse & Lend', to: { name: 'lender-marketplace', params: teamParams() } }
+          ]
+        }
       ]
-    },
-    {
-      label: 'Community Credit',
-      icon: 'heroicons:hand-raised',
-      active: String(route.name ?? '').startsWith('community-credit'),
-      to: { name: 'community-credit', params: teamParams() }
-    },
-    {
-      label: 'Accounting',
-      icon: 'heroicons:book-open',
-      to: { name: 'accounting', params: teamParams() },
-      defaultOpen: false,
-      children: [
-        { label: 'Summary', to: { name: 'accounting-summary', params: teamParams() } },
-        { label: 'Income Statement', to: { name: 'accounting-income', params: teamParams() } },
-        { label: 'Balance Sheet', to: { name: 'accounting-balance', params: teamParams() } },
-        { label: 'Trial Balance', to: { name: 'accounting-trial', params: teamParams() } },
-        { label: 'General Ledger', to: { name: 'accounting-ledger', params: teamParams() } }
-      ]
-    },
-    {
-      label: 'Contract Management',
-      icon: 'heroicons:wrench',
-      to: { name: 'contract-management', params: teamParams() }
-    },
-    {
-      label: 'SHER Token',
-      icon: 'heroicons:chart-pie',
-      to: { name: 'sher-token', params: teamParams() }
-    },
-    {
-      label: 'Administration',
-      icon: 'heroicons:chart-bar',
-      to: { name: 'bod-elections', params: teamParams() },
-      children: [
-        { label: 'Board Election', to: { name: 'bod-elections', params: teamParams() } },
-        { label: 'Proposals', to: { name: 'bod-proposals', params: teamParams() } }
-      ]
-    },
-    {
-      label: 'Vesting',
-      icon: 'heroicons:lock-closed',
-      to: { name: 'vesting', params: teamParams() }
-    },
-    {
-      label: 'Debt Financing',
-      icon: 'heroicons:banknotes',
-      to: { name: 'fixed-return', params: teamParams() },
-      defaultOpen: true,
-      children: [
-        { label: 'Fixed Return', to: { name: 'fixed-return', params: teamParams() } },
-        { label: 'Browse & Lend', to: { name: 'lender-marketplace', params: teamParams() } }
-      ]
-    }
-  ])
+    ]
+  })
 }


### PR DESCRIPTION
# Description

## Initial Issue Description

Fixes #2212

Implements the sidebar updates from the CNC Portal design.

## PR Summary Or Solution description

Three changes, all on the dashboard sidebar:

1. **Show the sidebar on the Companies page.** `App.vue` hid the sidebar (and its collapse toggle) on the `/teams` route via a `route.name !== 'teams'` guard. That guard is removed, so the sidebar renders on the Companies list like every other authenticated route.

2. **Companies icon.** The Companies entry now uses `heroicons:building-office-2` (was `heroicons:squares-2x2`), matching the design.

3. **Company workspace group + disabled gating.** The nav is split into two groups:
   - **Companies** — standalone, always enabled, active only on the list route.
   - **Company workspace** — a label header (showing the selected company's name once one is active, else "Company workspace") followed by the team-scoped surfaces (Overview, Accounts, Payroll, …). These are **disabled when no company is selected**, and accordion surfaces stay collapsed in that state.

"A company is selected" reuses the existing `activeTeamId` derivation — `route.params.id ?? currentTeamId` — already used in `TeamSelectMenu`. So the workspace is greyed out on a fresh visit to the Companies list and enables once a company is opened/selected.

### Reviewer note
The group label reads `teamStore.currentTeam?.name`. That alias is marked `@deprecated` in favour of `currentTeamMeta.data`, but it's the auto-unwrapped accessor already used across ~30 components and the only one that behaves consistently in both the real store (a raw `Ref`) and the test mock (a plain object).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)

## Verification

- New spec `useSidebarNavItems.spec.ts` — 8 tests (icon, active rule, disabled gate both directions, dynamic label, lingering store selection).
- `vitest run` on the new spec + `SidebarLayout.spec` + `App.spec` → 12 passed.
- `build-only` + `type-check` clean; `prettier` and `eslint` clean on the touched files.