### PR TITLE
refactor: ♻️ decode Officer proxy from deployment receipt logs

### DIFF
--- a/app/src/composables/contracts/__tests__/useOfficerDeployment.spec.ts
+++ b/app/src/composables/contracts/__tests__/useOfficerDeployment.spec.ts
@@ -10,6 +10,18 @@ vi.mock('@wagmi/core', async (importOriginal) => {
     getConnections: mockGetConnections
   }
 })
+
+// parseEventLogs decodes the BeaconProxyCreated event straight from the
+// receipt; stub it since keccak256 is globally mocked (real decoding can't run).
+const { mockParseEventLogs } = vi.hoisted(() => ({ mockParseEventLogs: vi.fn() }))
+vi.mock('viem', async (importOriginal) => {
+  const actual = (await importOriginal()) as object
+  return {
+    ...actual,
+    encodeFunctionData: vi.fn(() => '0xEncodedData'),
+    parseEventLogs: mockParseEventLogs
+  }
+})
 import {
   deployOfficer,
   useDeployOfficer,
@@ -23,7 +35,6 @@ import {
   useQueryClientFn,
   mockInvalidateQueries
 } from '@/tests/mocks/composables.mock'
-import { mockGetLogs } from '@/tests/mocks/viem.actions.mock'
 import { mockParseError } from '@/tests/mocks/utils.mock'
 
 const USER = '0x1234567890123456789012345678901234567890' as Address
@@ -57,8 +68,7 @@ vi.mock('@/utils/contractDeploymentUtil', async (importOriginal) => {
     ...actual,
     validateBeaconAddresses: vi.fn(),
     getBeaconConfigs: vi.fn(() => []),
-    getDeploymentConfigs: vi.fn(() => []),
-    handleBeaconProxyCreatedLogs: vi.fn()
+    getDeploymentConfigs: vi.fn(() => [])
   }
 })
 
@@ -72,14 +82,10 @@ describe('deployOfficer (pure)', () => {
     setConnectedUser(USER)
     vi.mocked(executeContractWrite).mockResolvedValue({
       hash: TX_HASH,
-      receipt: { blockNumber: 42n } as never,
+      receipt: { blockNumber: 42n, logs: [] } as never,
       simulation: {} as never
     })
-    mockGetLogs.mockResolvedValue([
-      { args: { deployer: USER, proxy: OFFICER_PROXY }, transactionHash: TX_HASH }
-    ] as never)
-    const utils = await import('@/utils/contractDeploymentUtil')
-    vi.mocked(utils.handleBeaconProxyCreatedLogs).mockReturnValue(OFFICER_PROXY)
+    mockParseEventLogs.mockReturnValue([{ args: { proxy: OFFICER_PROXY, deployer: USER } }])
   })
 
   it('throws when no wallet is connected', async () => {
@@ -100,22 +106,20 @@ describe('deployOfficer (pure)', () => {
     expect(res.deployedAt.getTime()).toBeGreaterThanOrEqual(before)
   })
 
-  it('throws when the proxy address cannot be extracted from event logs', async () => {
-    const utils = await import('@/utils/contractDeploymentUtil')
-    vi.mocked(utils.handleBeaconProxyCreatedLogs).mockReturnValue(null)
+  it('throws when no BeaconProxyCreated event is found in the receipt', async () => {
+    mockParseEventLogs.mockReturnValue([])
 
     await expect(
       deployOfficer({ investorInput: { name: 'Shares', symbol: 'SH' } })
     ).rejects.toThrow(/extract Officer proxy address/)
   })
 
-  it('queries logs for the exact deployment block', async () => {
+  it('decodes the proxy address from the receipt logs (no extra RPC)', async () => {
     await deployOfficer({ investorInput: { name: 'Shares', symbol: 'SH' } })
 
-    const call = mockGetLogs.mock.calls[0]
-    expect(call).toBeDefined()
-    const params = call![1]
-    expect(params).toMatchObject({ fromBlock: 42n, toBlock: 42n })
+    expect(mockParseEventLogs).toHaveBeenCalledWith(
+      expect.objectContaining({ eventName: 'BeaconProxyCreated', logs: [] })
+    )
   })
 })
 
@@ -125,14 +129,10 @@ describe('useDeployOfficer (TanStack wrapper)', () => {
     setConnectedUser(USER)
     vi.mocked(executeContractWrite).mockResolvedValue({
       hash: TX_HASH,
-      receipt: { blockNumber: 42n } as never,
+      receipt: { blockNumber: 42n, logs: [] } as never,
       simulation: {} as never
     })
-    mockGetLogs.mockResolvedValue([
-      { args: { deployer: USER, proxy: OFFICER_PROXY }, transactionHash: TX_HASH }
-    ] as never)
-    const utils = await import('@/utils/contractDeploymentUtil')
-    vi.mocked(utils.handleBeaconProxyCreatedLogs).mockReturnValue(OFFICER_PROXY)
+    mockParseEventLogs.mockReturnValue([{ args: { proxy: OFFICER_PROXY, deployer: USER } }])
 
     useMutationFn.mockImplementation(smartUseMutation)
     useQueryClientFn.mockReturnValue({

--- a/app/src/composables/contracts/__tests__/useOfficerDeployment.spec.ts
+++ b/app/src/composables/contracts/__tests__/useOfficerDeployment.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { Address } from 'viem'
+import { parseEventLogs, type Address } from 'viem'
 
 // Local getConnections mock — not covered by the shared wagmi setup.
 const { mockGetConnections } = vi.hoisted(() => ({ mockGetConnections: vi.fn() }))
@@ -11,17 +11,9 @@ vi.mock('@wagmi/core', async (importOriginal) => {
   }
 })
 
-// parseEventLogs decodes the BeaconProxyCreated event straight from the
-// receipt; stub it since keccak256 is globally mocked (real decoding can't run).
-const { mockParseEventLogs } = vi.hoisted(() => ({ mockParseEventLogs: vi.fn() }))
-vi.mock('viem', async (importOriginal) => {
-  const actual = (await importOriginal()) as object
-  return {
-    ...actual,
-    encodeFunctionData: vi.fn(() => '0xEncodedData'),
-    parseEventLogs: mockParseEventLogs
-  }
-})
+// `parseEventLogs` is globally stubbed in tests/setup/viem.setup.ts (keccak256
+// is mocked there, so real event decoding can't run). We just drive its return.
+const mockParseEventLogs = vi.mocked(parseEventLogs)
 import {
   deployOfficer,
   useDeployOfficer,
@@ -85,7 +77,9 @@ describe('deployOfficer (pure)', () => {
       receipt: { blockNumber: 42n, logs: [] } as never,
       simulation: {} as never
     })
-    mockParseEventLogs.mockReturnValue([{ args: { proxy: OFFICER_PROXY, deployer: USER } }])
+    mockParseEventLogs.mockReturnValue([
+      { args: { proxy: OFFICER_PROXY, deployer: USER } }
+    ] as never)
   })
 
   it('throws when no wallet is connected', async () => {
@@ -132,7 +126,9 @@ describe('useDeployOfficer (TanStack wrapper)', () => {
       receipt: { blockNumber: 42n, logs: [] } as never,
       simulation: {} as never
     })
-    mockParseEventLogs.mockReturnValue([{ args: { proxy: OFFICER_PROXY, deployer: USER } }])
+    mockParseEventLogs.mockReturnValue([
+      { args: { proxy: OFFICER_PROXY, deployer: USER } }
+    ] as never)
 
     useMutationFn.mockImplementation(smartUseMutation)
     useQueryClientFn.mockReturnValue({

--- a/app/src/composables/contracts/__tests__/useOfficerDeployment.spec.ts
+++ b/app/src/composables/contracts/__tests__/useOfficerDeployment.spec.ts
@@ -1,18 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { parseEventLogs, type Address } from 'viem'
+import { getConnections } from '@wagmi/core'
 
-// Local getConnections mock — not covered by the shared wagmi setup.
-const { mockGetConnections } = vi.hoisted(() => ({ mockGetConnections: vi.fn() }))
-vi.mock('@wagmi/core', async (importOriginal) => {
-  const actual = (await importOriginal()) as object
-  return {
-    ...actual,
-    getConnections: mockGetConnections
-  }
-})
-
-// `parseEventLogs` is globally stubbed in tests/setup/viem.setup.ts (keccak256
-// is mocked there, so real event decoding can't run). We just drive its return.
+// Both `@wagmi/core` (incl. getConnections) and `parseEventLogs` are globally
+// stubbed in tests/setup (wagmi.vue.setup.ts / viem.setup.ts). keccak256 is
+// mocked there too, so real event decoding can't run — we just drive returns.
+const mockGetConnections = vi.mocked(getConnections)
 const mockParseEventLogs = vi.mocked(parseEventLogs)
 import {
   deployOfficer,
@@ -65,7 +58,7 @@ vi.mock('@/utils/contractDeploymentUtil', async (importOriginal) => {
 })
 
 const setConnectedUser = (address: Address | null) => {
-  mockGetConnections.mockReturnValue(address ? [{ accounts: [address] }] : [])
+  mockGetConnections.mockReturnValue(address ? ([{ accounts: [address] }] as never) : [])
 }
 
 describe('deployOfficer (pure)', () => {

--- a/app/src/composables/contracts/useOfficerDeployment.ts
+++ b/app/src/composables/contracts/useOfficerDeployment.ts
@@ -14,8 +14,7 @@
  */
 import { useMutation, useQueryClient } from '@tanstack/vue-query'
 import { getConnections } from '@wagmi/core'
-import { encodeFunctionData, type Address, type Hex } from 'viem'
-import { getLogs } from 'viem/actions'
+import { encodeFunctionData, parseEventLogs, type Address, type Hex } from 'viem'
 import { config } from '@/wagmi.config'
 import { log, parseError } from '@/utils'
 import { executeContractWrite } from '@/composables/contracts/useContractWritesV3'
@@ -24,8 +23,7 @@ import { contractKeys } from '@/queries/contract.queries'
 import {
   validateBeaconAddresses,
   getBeaconConfigs,
-  getDeploymentConfigs,
-  handleBeaconProxyCreatedLogs
+  getDeploymentConfigs
 } from '@/utils/contractDeploymentUtil'
 import { OFFICER_BEACON, validateAddresses } from '@/constant'
 import { OFFICER_ABI } from '@/artifacts/abi/officer'
@@ -97,28 +95,30 @@ export async function deployOfficer(args: DeployOfficerArgs): Promise<OfficerDep
 
   log.info('Officer contract deployment confirmed:', { hash, receipt })
 
-  const publicClient = config.getClient()
-  const blockNumber = receipt.blockNumber
-
-  const logs = await getLogs(publicClient, {
-    address: OFFICER_BEACON as Address,
-    event: {
-      type: 'event',
-      name: 'BeaconProxyCreated',
-      inputs: [
-        { type: 'address', name: 'proxy', indexed: true },
-        { type: 'address', name: 'deployer', indexed: true }
-      ]
-    },
-    fromBlock: blockNumber,
-    toBlock: blockNumber
+  // The deployment receipt already carries every log emitted by this exact
+  // transaction, so we decode the BeaconProxyCreated event straight from it
+  // instead of issuing a second `getLogs` RPC over the whole block (which
+  // could also surface proxies created by other txs in the same block).
+  const [event] = parseEventLogs({
+    abi: [
+      {
+        type: 'event',
+        name: 'BeaconProxyCreated',
+        inputs: [
+          { type: 'address', name: 'proxy', indexed: true },
+          { type: 'address', name: 'deployer', indexed: true }
+        ]
+      }
+    ] as const,
+    eventName: 'BeaconProxyCreated',
+    logs: receipt.logs
   })
 
-  const proxyAddress = handleBeaconProxyCreatedLogs(logs, hash, address)
-
-  if (!proxyAddress) {
+  if (!event) {
     throw new Error('Failed to extract Officer proxy address from deployment event')
   }
+
+  const proxyAddress = event.args.proxy
 
   log.info('Officer proxy address extracted:', proxyAddress)
 
@@ -126,7 +126,7 @@ export async function deployOfficer(args: DeployOfficerArgs): Promise<OfficerDep
     hash,
     receipt,
     officerAddress: proxyAddress,
-    deployBlockNumber: Number(blockNumber),
+    deployBlockNumber: Number(receipt.blockNumber),
     deployedAt: new Date()
   }
 }

--- a/app/src/tests/mocks/wagmi.vue.mock.ts
+++ b/app/src/tests/mocks/wagmi.vue.mock.ts
@@ -41,7 +41,8 @@ export const mockWagmiCore = {
   getBalance: vi.fn(),
   getWalletClient: vi.fn(),
   estimateGas: vi.fn(),
-  getPublicClient: vi.fn()
+  getPublicClient: vi.fn(),
+  getConnections: vi.fn(() => [])
 }
 
 // Mock useConnection composable

--- a/app/src/tests/setup/viem.setup.ts
+++ b/app/src/tests/setup/viem.setup.ts
@@ -13,6 +13,7 @@ vi.mock('viem', async (importOriginal) => {
     //   return !!address && typeof address === 'string'
     // }), // No need to mock this function because we will allway use a real address in tests, and the real function will work fine with that. If we need to test invalid addresses, we can do that on a case by case basis in individual tests.
     encodeFunctionData: vi.fn(() => '0xEncodedData'),
+    parseEventLogs: vi.fn(() => []),
     parseSignature: vi.fn(),
     hashTypedData: vi.fn(),
     keccak256: vi.fn()

--- a/app/src/utils/__tests__/contractDeploymentUtil.spec.ts
+++ b/app/src/utils/__tests__/contractDeploymentUtil.spec.ts
@@ -3,13 +3,11 @@ import { encodeFunctionData, zeroAddress, type Address } from 'viem'
 import {
   validateBeaconAddresses,
   getBeaconConfigs,
-  getDeploymentConfigs,
-  handleBeaconProxyCreatedLogs
+  getDeploymentConfigs
 } from '../contractDeploymentUtil'
 import { FIXED_RETURN_ABI } from '@/artifacts/abi/fixed-return'
 import { INVESTOR_ABI } from '@/artifacts/abi/investors'
 import { FIXED_RETURN_BEACON_ADDRESS, USDC_ADDRESS, USDC_E_ADDRESS, USDT_ADDRESS } from '@/constant'
-import { mockLog } from '@/tests/mocks/utils.mock'
 
 const CURRENT_USER = '0x000000000000000000000000000000000000A1' as Address
 
@@ -83,54 +81,5 @@ describe('getDeploymentConfigs', () => {
       functionName: 'initialize',
       args: ['Acme', 'ACM', zeroAddress]
     })
-  })
-})
-
-describe('handleBeaconProxyCreatedLogs', () => {
-  const PROXY_ADDRESS = '0x000000000000000000000000000000000000B2' as Address
-  const TX_HASH = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const
-
-  function buildLog(overrides: Partial<{ deployer: Address; proxy: Address; hash: string }> = {}) {
-    return {
-      args: {
-        deployer: overrides.deployer ?? CURRENT_USER,
-        proxy: overrides.proxy ?? PROXY_ADDRESS
-      },
-      transactionHash: overrides.hash ?? TX_HASH
-    }
-  }
-
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  it('returns the proxy address when the hash and deployer both match', () => {
-    const result = handleBeaconProxyCreatedLogs([buildLog()], TX_HASH, CURRENT_USER)
-    expect(result).toBe(PROXY_ADDRESS)
-  })
-
-  it('returns null and logs an error when there are no logs', () => {
-    const result = handleBeaconProxyCreatedLogs([], TX_HASH, CURRENT_USER)
-    expect(result).toBeNull()
-    expect(mockLog.error).toHaveBeenCalledWith('No logs found')
-  })
-
-  it('returns null when the transaction hash does not match', () => {
-    const result = handleBeaconProxyCreatedLogs([buildLog()], '0xdeadbeef', CURRENT_USER)
-    expect(result).toBeNull()
-    expect(mockLog.error).toHaveBeenCalledWith('Transaction hash does not match')
-  })
-
-  it('returns null when the deployer does not match the current user', () => {
-    const otherDeployer = '0x000000000000000000000000000000000000C3' as Address
-    const result = handleBeaconProxyCreatedLogs(
-      [buildLog({ deployer: otherDeployer })],
-      TX_HASH,
-      CURRENT_USER
-    )
-    expect(result).toBeNull()
-    expect(mockLog.error).toHaveBeenCalledWith(
-      'Deployer address does not match with the current user address'
-    )
   })
 })

--- a/app/src/utils/contractDeploymentUtil.ts
+++ b/app/src/utils/contractDeploymentUtil.ts
@@ -22,7 +22,6 @@ import { INVESTOR_ABI } from '@/artifacts/abi/investors'
 import { SAFE_DEPOSIT_ROUTER_ABI } from '@/artifacts/abi/safe-deposit-router'
 import { PROPOSALS_ABI } from '@/artifacts/abi/proposals'
 import { FIXED_RETURN_ABI } from '@/artifacts/abi/fixed-return'
-import { log } from '@/utils'
 
 /**
  * Beacon configuration type
@@ -216,46 +215,4 @@ export const getDeploymentConfigs = (
   })
 
   return deployments
-}
-
-/**
- * Handles the BeaconProxyCreated event logs
- * @param logs - Event logs from the contract
- * @param expectedHash - Expected transaction hash
- * @param currentUserAddress - Current user's wallet address
- * @returns The proxy address if validation succeeds, null otherwise
- */
-export const handleBeaconProxyCreatedLogs = (
-  logs: unknown[],
-  expectedHash: `0x${string}` | undefined,
-  currentUserAddress: Address
-): Address | null => {
-  if (!logs.length) {
-    log.error('No logs found')
-    return null
-  }
-
-  interface BeaconProxyLog {
-    args: {
-      deployer: Address
-      proxy: Address
-    }
-    transactionHash: `0x${string}`
-  }
-
-  const firstLog = logs[0] as BeaconProxyLog
-
-  if (!firstLog || firstLog.transactionHash !== expectedHash) {
-    log.error('Transaction hash does not match')
-    return null
-  }
-
-  const { deployer, proxy: proxyAddress } = firstLog.args
-
-  if (currentUserAddress !== deployer) {
-    log.error('Deployer address does not match with the current user address')
-    return null
-  }
-
-  return proxyAddress
 }


### PR DESCRIPTION
## What

Replace the post-deploy `getLogs` RPC + `handleBeaconProxyCreatedLogs` helper with viem's `parseEventLogs` over `receipt.logs` in `deployOfficer`.

## Why

The deployment receipt already carries every log emitted by the deploy transaction, so:
- **One fewer RPC round-trip** per Officer deployment.
- **Tx-scoped, not block-scoped**: `getLogs(fromBlock=toBlock)` could surface a `BeaconProxyCreated` event from another tx in the same block; `receipt.logs` is inherently scoped to our tx, making the old tx-hash/deployer guard tautological.
- **No timing/reorg fragility** from querying logs before the block is indexed.

## Changes

- `useOfficerDeployment.ts`: decode the proxy address from `receipt.logs`; drop `getLogs` + `handleBeaconProxyCreatedLogs` usage and unused imports.
- `contractDeploymentUtil.ts`: remove the now-dead `handleBeaconProxyCreatedLogs` helper (and unused `log` import).
- Tests: remove the helper's spec; in the deployment spec, mock `parseEventLogs` (`keccak256` is globally stubbed so real decoding can't run) and assert decoding happens from `receipt.logs`.

## Tests

✅ 29 tests green across `useOfficerDeployment`, `useOfficerRedeploy`, and `contractDeploymentUtil` specs.

Closes #2220