### PR TITLE
refactor: ♻️ drive contract table with shared ownable+pausable ABI

### DIFF
--- a/app/src/artifacts/abi/ownable-pausable.ts
+++ b/app/src/artifacts/abi/ownable-pausable.ts
@@ -1,0 +1,21 @@
+import type { Abi } from 'viem'
+import Ownable from './json/Ownable.json'
+import Pausable from './json/Pausable.json'
+
+// OpenZeppelin's `Pausable` only exposes the `paused()` view; the public
+// `pause()` / `unpause()` entrypoints are declared by the concrete contracts,
+// so they are not part of `Pausable.json`. Add them here so the shared
+// management ABI can drive both the status read and the pause/unpause writes.
+const PAUSE_CONTROLS = [
+  { type: 'function', name: 'pause', inputs: [], outputs: [], stateMutability: 'nonpayable' },
+  { type: 'function', name: 'unpause', inputs: [], outputs: [], stateMutability: 'nonpayable' }
+] as const
+
+/**
+ * Minimal ABI shared by every team contract on the contract-management table.
+ *
+ * Combines Ownable (`owner`, `transferOwnership`, `renounceOwnership`) and
+ * Pausable (`paused`, `pause`, `unpause`). It lets the table read and manage
+ * any Ownable/Pausable contract without importing each contract's full ABI.
+ */
+export const OWNABLE_PAUSABLE_ABI = [...Ownable, ...Pausable, ...PAUSE_CONTROLS] as Abi

--- a/app/src/utils/contractManagementUtil.ts
+++ b/app/src/utils/contractManagementUtil.ts
@@ -1,15 +1,9 @@
 import type { Action, ActionResponse, TeamContract, User } from '@/types'
+import type { Address } from 'viem'
 import { config } from '@/wagmi.config'
 import { readContract } from '@wagmi/core'
 import { log, parseError } from '@/utils'
-import { EXPENSE_ACCOUNT_EIP712_ABI as ExpenseAccountAbi } from '@/artifacts/abi/expense-account-eip712'
-import { BANK_ABI as BankAbi } from '@/artifacts/abi/bank'
-
-import { CASH_REMUNERATION_EIP712_ABI as CashRemunerationAbi } from '@/artifacts/abi/cash-remuneration-eip712'
-import { ELECTIONS_ABI as ElectionsAbi } from '@/artifacts/abi/elections'
-import { INVESTOR_ABI as InvestorsAbi } from '@/artifacts/abi/investors'
-import { PROPOSALS_ABI as ProposalsAbi } from '@/artifacts/abi/proposals'
-import { VOTING_ABI as VotingAbi } from '@/artifacts/abi/voting'
+import { OWNABLE_PAUSABLE_ABI } from '@/artifacts/abi/ownable-pausable'
 
 export type FormattedAction = (Action & {
   requestedBy: User
@@ -53,59 +47,35 @@ export const filterAndFormatActions = (
     }))
 }
 
+// Reads a single Ownable/Pausable view, tolerating contracts that don't
+// implement it (e.g. a Safe has no `owner`/`paused`) so one non-conforming
+// contract never blanks the whole table.
+const readContractField = async (address: Address, functionName: 'owner' | 'paused') => {
+  try {
+    return await readContract(config, { address, abi: OWNABLE_PAUSABLE_ABI, functionName })
+  } catch {
+    return null
+  }
+}
+
 export const getTeamContracts = async (contracts: TeamContract[]) => {
   try {
     return Promise.all(
-      contractsWithAbis(contracts)
-        .filter((contract) => contract != null)
-        .map(async (contract) => {
-          if (!contract || !contract.abi) {
-            log.info('Skipping contract with undefined or null ABI: ', contract)
-            throw new Error('Contract is undefined or null')
-          }
-          const owner = await readContract(config, {
-            address: contract.address,
-            abi: contract.abi,
-            functionName: 'owner'
-          })
+      contracts.map(async (contract) => {
+        const [owner, paused] = await Promise.all([
+          readContractField(contract.address, 'owner'),
+          readContractField(contract.address, 'paused')
+        ])
 
-          const paused = await readContract(config, {
-            address: contract.address,
-            abi: contract.abi,
-            functionName: 'paused'
-          })
-
-          return {
-            ...contract,
-            owner,
-            paused
-          }
-        })
+        return {
+          ...contract,
+          abi: OWNABLE_PAUSABLE_ABI,
+          owner,
+          paused
+        }
+      })
     )
   } catch (error) {
     log.error('Error fetching contract owners: ', parseError(error))
   }
-}
-
-const contractsWithAbis = (contracts: TeamContract[]) => {
-  return contracts.map((contract) => {
-    switch (contract.type) {
-      case 'Bank':
-        return { ...contract, abi: BankAbi }
-      case 'CashRemunerationEIP712':
-        return { ...contract, abi: CashRemunerationAbi }
-      case 'Elections':
-        return { ...contract, abi: ElectionsAbi }
-      case 'ExpenseAccountEIP712':
-        return { ...contract, abi: ExpenseAccountAbi }
-      case 'InvestorV1':
-        return { ...contract, abi: InvestorsAbi }
-      case 'Proposals':
-        return { ...contract, abi: ProposalsAbi }
-      case 'Voting':
-        return { ...contract, abi: VotingAbi }
-      default:
-        return null // Default ABI if none matches
-    }
-  })
 }


### PR DESCRIPTION
## What

Replace the per-type ABI `switch` in `getTeamContracts` with a single minimal `OWNABLE_PAUSABLE_ABI` attached to every team contract.

## Why

`MainContractTable` only needs `owner()` / `paused()`, but the util imported all 7 contract ABIs to read them, and its `default` branch returned `null` — silently dropping every unlisted type (`BoardOfDirectors`, `Campaign`, `VestingV1`, `SafeDepositRouter`, `Safe`, `FixedReturn`) from the table.

## Changes

- **New** `app/src/artifacts/abi/ownable-pausable.ts`: minimal ABI = `Ownable.json` + `Pausable.json` + the public `pause()` / `unpause()` entrypoints (not part of OZ `Pausable`). Drives both the table reads and the `MainContractActions` writes (`transferOwnership` / `pause` / `unpause`) read off `row.abi`.
- **Refactor** `contractManagementUtil.ts`: drop the 7 ABI imports and `contractsWithAbis`; attach the shared ABI to every contract so all types are discovered.
- `owner` / `paused` reads are now per-contract tolerant — a non-Ownable/Pausable contract (e.g. a `Safe`) yields `null` instead of rejecting the whole batch and blanking the table.

## Verification

- `build-only` ✅ · `type-check` ✅ · `ContractManagementView` unit tests ✅ (106/106) · prettier ✅

## Note

Non-Ownable contracts (e.g. `Safe`) now appear with `owner: null` / `paused: null`; their action buttons stay disabled (`row.owner !== userDataStore.address`). If we’d rather keep them hidden, we can filter `owner === null`.

Closes #2225