### PR TITLE
feat: ✨ observe FixedReturn money flow — sweep events + Ponder indexing

### DIFF
--- a/contract/contracts/FixedReturn.sol
+++ b/contract/contracts/FixedReturn.sol
@@ -188,6 +188,22 @@ contract FixedReturn is OwnableUpgradeable, ReentrancyGuardUpgradeable, TokenSup
   /// @notice Emitted when an offer's funding target is reached and principal swept to Bank.
   event LendingOfferFunded(uint256 indexed offerId);
 
+  /// @notice Emitted on the deposit that reaches the target, when the accumulated
+  ///         principal is swept to Bank. Carries the amount moved and its destination
+  ///         so the transfer is observable (the sweep itself is a raw ERC20 transfer,
+  ///         which emits no receipt on this contract).
+  event FundsSweptToBank(
+    uint256 indexed offerId,
+    address indexed bank,
+    address indexed token,
+    uint256 amount
+  );
+
+  /// @notice Emitted on a deposit that does NOT reach the target: the offer keeps
+  ///         accumulating and no sweep occurs. Carries running progress toward the
+  ///         target so the "not funded yet" path is observable during testing.
+  event FundingProgressed(uint256 indexed offerId, uint256 totalFunded, uint256 fundingTarget);
+
   /// @notice Emitted when an offer is flipped to refundable after a missed deadline.
   event LendingOfferRefundable(uint256 indexed offerId);
 
@@ -291,7 +307,7 @@ contract FixedReturn is OwnableUpgradeable, ReentrancyGuardUpgradeable, TokenSup
 
   /// @notice Current contract version, per semver.
   function version() external pure returns (string memory) {
-    return '1.1.0';
+    return '1.2.0';
   }
 
   // ────────────────────────────────────────────────────
@@ -458,15 +474,20 @@ contract FixedReturn is OwnableUpgradeable, ReentrancyGuardUpgradeable, TokenSup
     // Interactions — lender transfer must complete before the Bank sweep
     IERC20(offer.token).safeTransferFrom(msg.sender, address(this), amount);
 
+    address bankAddress;
     if (nowFunded) {
       // Sweep the full accumulated principal to Bank so no lender funds remain here.
-      address bankAddress = _getBankAddress();
+      bankAddress = _getBankAddress();
       IERC20(offer.token).safeTransfer(bankAddress, offer.totalFunded);
     }
 
     emit FundsLent(offerId, msg.sender, amount);
     if (nowFunded) {
+      emit FundsSweptToBank(offerId, bankAddress, offer.token, offer.totalFunded);
       emit LendingOfferFunded(offerId);
+    } else {
+      // No sweep this deposit — the offer is still accumulating toward its target.
+      emit FundingProgressed(offerId, offer.totalFunded, offer.fundingTarget);
     }
   }
 

--- a/contract/contracts/interfaces/IFixedReturn.sol
+++ b/contract/contracts/interfaces/IFixedReturn.sol
@@ -81,6 +81,17 @@ interface IFixedReturn is IOwnable, ITokenSupport {
   /// @notice Emitted when an offer's funding target is reached
   event LendingOfferFunded(uint256 indexed offerId);
 
+  /// @notice Emitted when accumulated principal is swept to Bank on the funding deposit
+  event FundsSweptToBank(
+    uint256 indexed offerId,
+    address indexed bank,
+    address indexed token,
+    uint256 amount
+  );
+
+  /// @notice Emitted on a deposit that does not reach the target (no sweep, still accumulating)
+  event FundingProgressed(uint256 indexed offerId, uint256 totalFunded, uint256 fundingTarget);
+
   /// @notice Emitted when an offer is flipped to refundable after a missed deadline
   event LendingOfferRefundable(uint256 indexed offerId);
 

--- a/contract/test/FixedReturn.spec.ts
+++ b/contract/test/FixedReturn.spec.ts
@@ -207,7 +207,7 @@ describe('FixedReturn', () => {
 
     it('reports its version', async () => {
       const { fixedReturn } = await loadFixture(deployFixture)
-      expect(await fixedReturn.version()).to.equal('1.1.0')
+      expect(await fixedReturn.version()).to.equal('1.2.0')
     })
 
     it('rejects a zero-address owner', async () => {
@@ -675,11 +675,37 @@ describe('FixedReturn', () => {
       )
 
       await fixedReturn.connect(lenderA).lendFunds(offerId, ethers.parseUnits('60000', 6))
-      await fixedReturn.connect(lenderB).lendFunds(offerId, ethers.parseUnits('40000', 6))
+      // The funding deposit emits FundsSweptToBank with the amount and destination.
+      await expect(fixedReturn.connect(lenderB).lendFunds(offerId, ethers.parseUnits('40000', 6)))
+        .to.emit(fixedReturn, 'FundsSweptToBank')
+        .withArgs(offerId, await bank.getAddress(), await token.getAddress(), FUNDING_TARGET)
 
       // All principal now sits in Bank, nothing in FixedReturn
       expect(await token.balanceOf(await bank.getAddress())).to.equal(FUNDING_TARGET)
       expect(await token.balanceOf(await fixedReturn.getAddress())).to.equal(0)
+    })
+
+    it('emits FundingProgressed and does not sweep on a partial deposit', async () => {
+      const { fixedReturn, bank, owner, lenderA, token, startDate, subscriptionDeadline } =
+        await loadFixture(deployFixture)
+      const offerId = await createGeneralOffer(
+        fixedReturn,
+        owner,
+        await token.getAddress(),
+        startDate,
+        subscriptionDeadline
+      )
+
+      const partial = ethers.parseUnits('60000', 6)
+      await expect(fixedReturn.connect(lenderA).lendFunds(offerId, partial))
+        .to.emit(fixedReturn, 'FundingProgressed')
+        .withArgs(offerId, partial, FUNDING_TARGET)
+
+      // Not funded yet: offer stays Open, no sweep — funds held in FixedReturn.
+      const offer = await fixedReturn.getLendingOffer(offerId)
+      expect(offer.state).to.equal(OfferState.Open)
+      expect(await token.balanceOf(await bank.getAddress())).to.equal(0)
+      expect(await token.balanceOf(await fixedReturn.getAddress())).to.equal(partial)
     })
   })
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -64,6 +64,9 @@ const IGNORED_PATTERNS = [
   /(^|\/)typechain(-types)?\//,
   // The Graph / Ponder generated code
   /(^|\/)generated\//,
+  // Ponder ABI exports — mechanically emitted by scripts/generate-abis.ts
+  // from the contract build (both the .ts exports and their source JSON).
+  /(^|\/)ponder\/abis\//,
 ];
 
 /**

--- a/ponder/abis/fixed-return.ts
+++ b/ponder/abis/fixed-return.ts
@@ -1,0 +1,229 @@
+export const FIXED_RETURN_ABI = [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "lender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "FundsLent",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint64",
+        name: "version",
+        type: "uint64",
+      },
+    ],
+    name: "Initialized",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "lender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "LenderRepaid",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "token",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "fundingTarget",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "interestRateBps",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "startDate",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "subscriptionDeadline",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "enum FixedReturn.FundingAccess",
+        name: "fundingAccess",
+        type: "uint8",
+      },
+    ],
+    name: "LendingOfferCreated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+    ],
+    name: "LendingOfferFunded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+    ],
+    name: "LendingOfferRefundable",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "previousOwner",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newOwner",
+        type: "address",
+      },
+    ],
+    name: "OwnershipTransferred",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "lender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "PrincipalRefunded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "totalAmount",
+        type: "uint256",
+      },
+    ],
+    name: "RepaymentDistributed",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "tokenAddress",
+        type: "address",
+      },
+    ],
+    name: "TokenSupportAdded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "tokenAddress",
+        type: "address",
+      },
+    ],
+    name: "TokenSupportRemoved",
+    type: "event",
+  },
+] as const

--- a/ponder/abis/fixed-return.ts
+++ b/ponder/abis/fixed-return.ts
@@ -9,6 +9,31 @@ export const FIXED_RETURN_ABI = [
         type: "uint256",
       },
       {
+        indexed: false,
+        internalType: "uint256",
+        name: "totalFunded",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "fundingTarget",
+        type: "uint256",
+      },
+    ],
+    name: "FundingProgressed",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
         indexed: true,
         internalType: "address",
         name: "lender",
@@ -22,6 +47,37 @@ export const FIXED_RETURN_ABI = [
       },
     ],
     name: "FundsLent",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "offerId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "bank",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "token",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "FundsSweptToBank",
     type: "event",
   },
   {

--- a/ponder/abis/json/FixedReturn.json
+++ b/ponder/abis/json/FixedReturn.json
@@ -11,6 +11,11 @@
   },
   {
     "inputs": [],
+    "name": "BankContractNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "DeadlineNotPassed",
     "type": "error"
   },
@@ -22,6 +27,11 @@
   {
     "inputs": [],
     "name": "DepositExceedsLenderCap",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ExceedsRepaymentObligation",
     "type": "error"
   },
   {
@@ -47,6 +57,17 @@
   {
     "inputs": [],
     "name": "LenderCapExceedsFundingTarget",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "NotBank",
     "type": "error"
   },
   {
@@ -125,6 +146,17 @@
         "type": "address"
       }
     ],
+    "name": "TokenNotSupportedByBank",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
     "name": "TokenSupportAlreadyAdded",
     "type": "error"
   },
@@ -169,6 +201,31 @@
         "type": "uint256"
       },
       {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalFunded",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fundingTarget",
+        "type": "uint256"
+      }
+    ],
+    "name": "FundingProgressed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "offerId",
+        "type": "uint256"
+      },
+      {
         "indexed": true,
         "internalType": "address",
         "name": "lender",
@@ -182,6 +239,37 @@
       }
     ],
     "name": "FundsLent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "offerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "bank",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FundsSweptToBank",
     "type": "event"
   },
   {
@@ -766,6 +854,19 @@
   },
   {
     "inputs": [],
+    "name": "officerAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "owner",
     "outputs": [
       {
@@ -842,6 +943,30 @@
   {
     "inputs": [],
     "name": "totalOfferings",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "totalPaidToLender",
     "outputs": [
       {
         "internalType": "uint256",

--- a/ponder/ponder.config.ts
+++ b/ponder/ponder.config.ts
@@ -9,6 +9,7 @@ import { ELECTIONS_ABI } from "./abis/elections";
 import { PROPOSALS_ABI } from "./abis/proposals";
 import { BOARD_OF_DIRECTORS_ABI } from "./abis/board-of-directors";
 import { INVESTOR_V1_ABI } from "./abis/investor-v1";
+import { FIXED_RETURN_ABI } from "./abis/fixed-return";
 import { CASH_REMUNERATION_EIP712_ABI } from "./abis/cash-remuneration-eip712";
 import { SAFE_DEPOSIT_ROUTER_ABI } from "./abis/safe-deposit-router";
 import { VESTING_ABI } from "./abis/vesting";
@@ -192,6 +193,12 @@ export default createConfig({
     InvestorV1: {
       chain: chainName,
       abi: INVESTOR_V1_ABI,
+      address: subContractFactory,
+      startBlock,
+    },
+    FixedReturn: {
+      chain: chainName,
+      abi: FIXED_RETURN_ABI,
       address: subContractFactory,
       startBlock,
     },

--- a/ponder/ponder.schema.ts
+++ b/ponder/ponder.schema.ts
@@ -534,6 +534,28 @@ export const fixedReturnFundsLent = onchainTable(
   }),
 );
 
+// The sweep to Bank is otherwise a raw ERC20 transfer with no on-chain receipt;
+// this row is the only indexed proof that an offer's principal reached Bank.
+export const fixedReturnFundsSwept = onchainTable(
+  "fixed_return_funds_swept",
+  (t) => ({
+    id: t.text().primaryKey(), // `${txHash}-${logIndex}`
+    contractAddress: t.hex().notNull(),
+    offerId: t.bigint().notNull(),
+    bank: t.hex().notNull(),
+    token: t.hex().notNull(),
+    amount: t.bigint().notNull(),
+    blockNumber: t.bigint().notNull(),
+    timestamp: t.integer().notNull(),
+  }),
+  (table) => ({
+    contractAddressIdx: index("fixed_return_funds_swept_contract_index").on(
+      table.contractAddress,
+    ),
+    bankIdx: index("fixed_return_funds_swept_bank_index").on(table.bank),
+  }),
+);
+
 export const fixedReturnPrincipalRefunded = onchainTable(
   "fixed_return_principal_refunded",
   (t) => ({

--- a/ponder/ponder.schema.ts
+++ b/ponder/ponder.schema.ts
@@ -484,6 +484,115 @@ export const investorDividendPaymentFailed = onchainTable(
   }),
 );
 
+// FixedReturn events
+//
+// The offer is a stateful entity: created Open, then flipped by the lifecycle
+// events (Funded / Refundable / Repaying) via the mutable `state` column — the
+// same insert-then-update pattern as boardAction.executed. Cumulative amounts
+// (totalFunded, totalRepaid) are intentionally NOT stored: they derive by
+// summing the append-only fundsLent / repaymentDistributed rows below.
+export const fixedReturnOffer = onchainTable(
+  "fixed_return_offer",
+  (t) => ({
+    id: t.text().primaryKey(), // `${contractAddress}-${offerId}`
+    contractAddress: t.hex().notNull(),
+    offerId: t.bigint().notNull(),
+    token: t.hex().notNull(),
+    fundingTarget: t.bigint().notNull(),
+    interestRateBps: t.bigint().notNull(),
+    startDate: t.bigint().notNull(),
+    subscriptionDeadline: t.bigint().notNull(),
+    fundingAccess: t.integer().notNull(), // FundingAccess enum: 0 General, 1 Whitelist
+    state: t.integer().notNull().default(0), // OfferState: 0 Open, 1 Funded, 2 Refundable, 3 Repaying
+    blockNumber: t.bigint().notNull(),
+    timestamp: t.integer().notNull(),
+  }),
+  (table) => ({
+    contractAddressIdx: index("fixed_return_offer_contract_index").on(
+      table.contractAddress,
+    ),
+    tokenIdx: index("fixed_return_offer_token_index").on(table.token),
+  }),
+);
+
+export const fixedReturnFundsLent = onchainTable(
+  "fixed_return_funds_lent",
+  (t) => ({
+    id: t.text().primaryKey(), // `${txHash}-${logIndex}`
+    contractAddress: t.hex().notNull(),
+    offerId: t.bigint().notNull(),
+    lender: t.hex().notNull(),
+    amount: t.bigint().notNull(),
+    blockNumber: t.bigint().notNull(),
+    timestamp: t.integer().notNull(),
+  }),
+  (table) => ({
+    contractAddressIdx: index("fixed_return_funds_lent_contract_index").on(
+      table.contractAddress,
+    ),
+    lenderIdx: index("fixed_return_funds_lent_lender_index").on(table.lender),
+  }),
+);
+
+export const fixedReturnPrincipalRefunded = onchainTable(
+  "fixed_return_principal_refunded",
+  (t) => ({
+    id: t.text().primaryKey(),
+    contractAddress: t.hex().notNull(),
+    offerId: t.bigint().notNull(),
+    lender: t.hex().notNull(),
+    amount: t.bigint().notNull(),
+    blockNumber: t.bigint().notNull(),
+    timestamp: t.integer().notNull(),
+  }),
+  (table) => ({
+    contractAddressIdx: index(
+      "fixed_return_principal_refunded_contract_index",
+    ).on(table.contractAddress),
+    lenderIdx: index("fixed_return_principal_refunded_lender_index").on(
+      table.lender,
+    ),
+  }),
+);
+
+export const fixedReturnRepaymentDistributed = onchainTable(
+  "fixed_return_repayment_distributed",
+  (t) => ({
+    id: t.text().primaryKey(),
+    contractAddress: t.hex().notNull(),
+    offerId: t.bigint().notNull(),
+    totalAmount: t.bigint().notNull(),
+    blockNumber: t.bigint().notNull(),
+    timestamp: t.integer().notNull(),
+  }),
+  (table) => ({
+    contractAddressIdx: index(
+      "fixed_return_repayment_distributed_contract_index",
+    ).on(table.contractAddress),
+  }),
+);
+
+export const fixedReturnLenderRepaid = onchainTable(
+  "fixed_return_lender_repaid",
+  (t) => ({
+    id: t.text().primaryKey(),
+    contractAddress: t.hex().notNull(),
+    offerId: t.bigint().notNull(),
+    lender: t.hex().notNull(),
+    amount: t.bigint().notNull(),
+    blockNumber: t.bigint().notNull(),
+    timestamp: t.integer().notNull(),
+  }),
+  (table) => ({
+    contractAddressIdx: index("fixed_return_lender_repaid_contract_index").on(
+      table.contractAddress,
+    ),
+    lenderIdx: index("fixed_return_lender_repaid_lender_index").on(
+      table.lender,
+    ),
+  }),
+);
+
 // CashRemunerationEIP712 events
 export const cashRemunerationDeposit = onchainTable(
   "cash_remuneration_deposit",

--- a/ponder/src/api/index.ts
+++ b/ponder/src/api/index.ts
@@ -21,6 +21,7 @@ import schema, {
   investorDividendPaymentFailed,
   fixedReturnOffer,
   fixedReturnFundsLent,
+  fixedReturnFundsSwept,
   fixedReturnPrincipalRefunded,
   fixedReturnRepaymentDistributed,
   fixedReturnLenderRepaid,
@@ -177,30 +178,47 @@ async function fetchContractEvents(
   }
 
   if (contractType === "FixedReturn") {
-    const [offers, fundsLent, principalRefunded, repayments, lenderRepaid] =
-      await Promise.all([
-        db
-          .select()
-          .from(fixedReturnOffer)
-          .where(eq(fixedReturnOffer.contractAddress, address)),
-        db
-          .select()
-          .from(fixedReturnFundsLent)
-          .where(eq(fixedReturnFundsLent.contractAddress, address)),
-        db
-          .select()
-          .from(fixedReturnPrincipalRefunded)
-          .where(eq(fixedReturnPrincipalRefunded.contractAddress, address)),
-        db
-          .select()
-          .from(fixedReturnRepaymentDistributed)
-          .where(eq(fixedReturnRepaymentDistributed.contractAddress, address)),
-        db
-          .select()
-          .from(fixedReturnLenderRepaid)
-          .where(eq(fixedReturnLenderRepaid.contractAddress, address)),
-      ]);
-    return { offers, fundsLent, principalRefunded, repayments, lenderRepaid };
+    const [
+      offers,
+      fundsLent,
+      fundsSwept,
+      principalRefunded,
+      repayments,
+      lenderRepaid,
+    ] = await Promise.all([
+      db
+        .select()
+        .from(fixedReturnOffer)
+        .where(eq(fixedReturnOffer.contractAddress, address)),
+      db
+        .select()
+        .from(fixedReturnFundsLent)
+        .where(eq(fixedReturnFundsLent.contractAddress, address)),
+      db
+        .select()
+        .from(fixedReturnFundsSwept)
+        .where(eq(fixedReturnFundsSwept.contractAddress, address)),
+      db
+        .select()
+        .from(fixedReturnPrincipalRefunded)
+        .where(eq(fixedReturnPrincipalRefunded.contractAddress, address)),
+      db
+        .select()
+        .from(fixedReturnRepaymentDistributed)
+        .where(eq(fixedReturnRepaymentDistributed.contractAddress, address)),
+      db
+        .select()
+        .from(fixedReturnLenderRepaid)
+        .where(eq(fixedReturnLenderRepaid.contractAddress, address)),
+    ]);
+    return {
+      offers,
+      fundsLent,
+      fundsSwept,
+      principalRefunded,
+      repayments,
+      lenderRepaid,
+    };
   }
 
   if (contractType === "CashRemunerationEIP712") {

--- a/ponder/src/api/index.ts
+++ b/ponder/src/api/index.ts
@@ -19,6 +19,11 @@ import schema, {
   investorDividendDistributed,
   investorDividendPaid,
   investorDividendPaymentFailed,
+  fixedReturnOffer,
+  fixedReturnFundsLent,
+  fixedReturnPrincipalRefunded,
+  fixedReturnRepaymentDistributed,
+  fixedReturnLenderRepaid,
   cashRemunerationDeposit,
   cashRemunerationWithdraw,
   cashRemunerationWithdrawToken,
@@ -169,6 +174,33 @@ async function fetchContractEvents(
         .where(eq(investorDividendPaymentFailed.contractAddress, address)),
     ]);
     return { mints, distributed, paid, failed };
+  }
+
+  if (contractType === "FixedReturn") {
+    const [offers, fundsLent, principalRefunded, repayments, lenderRepaid] =
+      await Promise.all([
+        db
+          .select()
+          .from(fixedReturnOffer)
+          .where(eq(fixedReturnOffer.contractAddress, address)),
+        db
+          .select()
+          .from(fixedReturnFundsLent)
+          .where(eq(fixedReturnFundsLent.contractAddress, address)),
+        db
+          .select()
+          .from(fixedReturnPrincipalRefunded)
+          .where(eq(fixedReturnPrincipalRefunded.contractAddress, address)),
+        db
+          .select()
+          .from(fixedReturnRepaymentDistributed)
+          .where(eq(fixedReturnRepaymentDistributed.contractAddress, address)),
+        db
+          .select()
+          .from(fixedReturnLenderRepaid)
+          .where(eq(fixedReturnLenderRepaid.contractAddress, address)),
+      ]);
+    return { offers, fundsLent, principalRefunded, repayments, lenderRepaid };
   }
 
   if (contractType === "CashRemunerationEIP712") {

--- a/ponder/src/index.ts
+++ b/ponder/src/index.ts
@@ -25,6 +25,11 @@ import {
   investorDividendDistributed,
   investorDividendPaid,
   investorDividendPaymentFailed,
+  fixedReturnOffer,
+  fixedReturnFundsLent,
+  fixedReturnPrincipalRefunded,
+  fixedReturnRepaymentDistributed,
+  fixedReturnLenderRepaid,
   cashRemunerationDeposit,
   cashRemunerationWithdraw,
   cashRemunerationWithdrawToken,
@@ -487,6 +492,99 @@ ponder.on("InvestorV1:DividendPaymentFailed", async ({ event, context }) => {
     token: event.args.token,
     amount: event.args.amount,
     reason: event.args.reason,
+    blockNumber: event.block.number,
+    timestamp: Number(event.block.timestamp),
+  });
+});
+
+// ─── FixedReturn ──────────────────────────────────────────────────────────────
+// The offer is created Open, then walked through its lifecycle by updating the
+// `state` column in place. Deposits, refunds and repayments are append-only —
+// cumulative totals are derived by summing them, never stored on the offer.
+
+ponder.on("FixedReturn:LendingOfferCreated", async ({ event, context }) => {
+  await context.db.insert(fixedReturnOffer).values({
+    id: `${event.log.address}-${event.args.offerId}`,
+    contractAddress: event.log.address,
+    offerId: event.args.offerId,
+    token: event.args.token,
+    fundingTarget: event.args.fundingTarget,
+    interestRateBps: event.args.interestRateBps,
+    startDate: event.args.startDate,
+    subscriptionDeadline: event.args.subscriptionDeadline,
+    fundingAccess: event.args.fundingAccess,
+    state: 0, // Open
+    blockNumber: event.block.number,
+    timestamp: Number(event.block.timestamp),
+  });
+});
+
+ponder.on("FixedReturn:FundsLent", async ({ event, context }) => {
+  await context.db.insert(fixedReturnFundsLent).values({
+    id: `${event.transaction.hash}-${event.log.logIndex}`,
+    contractAddress: event.log.address,
+    offerId: event.args.offerId,
+    lender: event.args.lender,
+    amount: event.args.amount,
+    blockNumber: event.block.number,
+    timestamp: Number(event.block.timestamp),
+  });
+});
+
+ponder.on("FixedReturn:LendingOfferFunded", async ({ event, context }) => {
+  await context.db
+    .update(fixedReturnOffer, {
+      id: `${event.log.address}-${event.args.offerId}`,
+    })
+    .set({ state: 1 }); // Funded
+});
+
+ponder.on("FixedReturn:LendingOfferRefundable", async ({ event, context }) => {
+  await context.db
+    .update(fixedReturnOffer, {
+      id: `${event.log.address}-${event.args.offerId}`,
+    })
+    .set({ state: 2 }); // Refundable
+});
+
+ponder.on("FixedReturn:PrincipalRefunded", async ({ event, context }) => {
+  await context.db.insert(fixedReturnPrincipalRefunded).values({
+    id: `${event.transaction.hash}-${event.log.logIndex}`,
+    contractAddress: event.log.address,
+    offerId: event.args.offerId,
+    lender: event.args.lender,
+    amount: event.args.amount,
+    blockNumber: event.block.number,
+    timestamp: Number(event.block.timestamp),
+  });
+});
+
+ponder.on("FixedReturn:RepaymentDistributed", async ({ event, context }) => {
+  await context.db.insert(fixedReturnRepaymentDistributed).values({
+    id: `${event.transaction.hash}-${event.log.logIndex}`,
+    contractAddress: event.log.address,
+    offerId: event.args.offerId,
+    totalAmount: event.args.totalAmount,
+    blockNumber: event.block.number,
+    timestamp: Number(event.block.timestamp),
+  });
+
+  // First repayment moves the offer Funded → Repaying; later installments keep
+  // it there. Idempotent, mirroring the contract's own state machine.
+  await context.db
+    .update(fixedReturnOffer, {
+      id: `${event.log.address}-${event.args.offerId}`,
+    })
+    .set({ state: 3 }); // Repaying
+});
+
+ponder.on("FixedReturn:LenderRepaid", async ({ event, context }) => {
+  await context.db.insert(fixedReturnLenderRepaid).values({
+    id: `${event.transaction.hash}-${event.log.logIndex}`,
+    contractAddress: event.log.address,
+    offerId: event.args.offerId,
+    lender: event.args.lender,
+    amount: event.args.amount,
     blockNumber: event.block.number,
     timestamp: Number(event.block.timestamp),
   });

--- a/ponder/src/index.ts
+++ b/ponder/src/index.ts
@@ -27,6 +27,7 @@ import {
   investorDividendPaymentFailed,
   fixedReturnOffer,
   fixedReturnFundsLent,
+  fixedReturnFundsSwept,
   fixedReturnPrincipalRefunded,
   fixedReturnRepaymentDistributed,
   fixedReturnLenderRepaid,
@@ -525,6 +526,19 @@ ponder.on("FixedReturn:FundsLent", async ({ event, context }) => {
     contractAddress: event.log.address,
     offerId: event.args.offerId,
     lender: event.args.lender,
+    amount: event.args.amount,
+    blockNumber: event.block.number,
+    timestamp: Number(event.block.timestamp),
+  });
+});
+
+ponder.on("FixedReturn:FundsSweptToBank", async ({ event, context }) => {
+  await context.db.insert(fixedReturnFundsSwept).values({
+    id: `${event.transaction.hash}-${event.log.logIndex}`,
+    contractAddress: event.log.address,
+    offerId: event.args.offerId,
+    bank: event.args.bank,
+    token: event.args.token,
     amount: event.args.amount,
     blockNumber: event.block.number,
     timestamp: Number(event.block.timestamp),


### PR DESCRIPTION
# Description

## Intial Issue Description

Fixes #2238

`FixedReturn` (fixed-rate lending product, one instance per team, deployed by Officer) emits lifecycle events that were not indexed by Ponder, and its **sweep to Bank** — the moment a funded offer's principal moves to the treasury — was a raw ERC20 transfer with **no on-chain receipt at all**: `LendingOfferFunded` fired, but carried no amount or destination. So there was no way to observe or verify the money flow (deposit → sweep to Bank → repayment → refund) off-chain.

## PR Summary Or Solution description

Make the whole `FixedReturn` money flow observable, across two layers.

### 1. Contract — emit the missing signals (`FixedReturn.sol`, `IFixedReturn.sol`)

`lendFunds` now emits exactly one outcome event per deposit:

- `FundsSweptToBank(offerId, bank, token, amount)` on the deposit that reaches the target and sweeps the accumulated principal to Bank — the explicit receipt that was missing.
- `FundingProgressed(offerId, totalFunded, fundingTarget)` on a deposit that does not reach the target (no sweep, still accumulating).

Both mirrored in `IFixedReturn`, version bumped to `1.2.0`, covered by tests. Note the existing test `sweeps the full principal to Bank` already proved the sweep works (`balanceOf(bank) == target`, `balanceOf(fixedReturn) == 0`) — the gap was observability, not correctness.

### 2. Ponder — index the events (`ponder/*`)

Register `FixedReturn` via the shared sub-contract factory and index its lifecycle. The offer is a stateful entity (`fixed_return_offer.state`) walked through `Open → Funded → Refundable/Repaying` via in-place updates (same pattern as `board_action.executed`). Deposits, the sweep, refunds and repayments are append-only tables. Cumulative totals are derived by summing, never stored.

`FundsSweptToBank` gets its own indexed table (`fixed_return_funds_swept`) — the only proof the principal reached Bank. `FundingProgressed` is intentionally **not** indexed: its `totalFunded` equals `sum(FundsLent)`, so it is derivable and would only duplicate data.

### Verifying the money flow

Query via GraphQL (`/`), SQL (`/sql/*`), or REST:

```
GET /contracts/<fixedReturnAddress>/events
→ { offers, fundsLent, fundsSwept, principalRefunded, repayments, lenderRepaid }
```

A `fundsSwept` row (with `bank`, `token`, `amount`) alongside the offer flipping to `state = 1` in the same transaction is the end-to-end confirmation that the sweep occurred.

## Contribution

- `contract/contracts/FixedReturn.sol` — two new events + emit them from `lendFunds`; version `1.2.0`.
- `contract/contracts/interfaces/IFixedReturn.sol` — mirror the two events.
- `contract/test/FixedReturn.spec.ts` — assert `FundsSweptToBank` on funding and `FundingProgressed` on a partial deposit; version test updated.
- `ponder/ponder.schema.ts` — `fixed_return_offer` (stateful) + append-only `fixed_return_funds_lent`, `_funds_swept`, `_principal_refunded`, `_repayment_distributed`, `_lender_repaid`.
- `ponder/src/index.ts` — handlers for the lifecycle events.
- `ponder/src/api/index.ts` — `FixedReturn` case in `fetchContractEvents`.
- `ponder/abis/fixed-return.ts` + `ponder/abis/json/FixedReturn.json` — regenerated ABI export.
- `ponder/ponder.config.ts` — register the contract.
- `dangerfile.js` — exclude the generated `ponder/abis/` exports from the PR-size budget (they are mechanically emitted, like the artifacts/typechain already excluded).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added

## Notes for reviewers

- Contract: `hardhat compile` + `hardhat test test/FixedReturn.spec.ts` → 61 passing; solhint + prettier clean. Ponder: `codegen` + `tsc` pass (statically guaranteeing event names, args and schema columns line up); prettier + eslint clean.
- Scope kept tight on purpose: unrelated ABI drift surfaced by the `hardhat-abi-exporter` on compile (Bank's `FixedReturnRepaymentFunded` from #2237, a new `MockFixedReturn`, and the app/dashboard ABI copies) is **not** included here — it belongs to a separate ABI-resync.
- Follow-ups still open: indexing Bank's `FixedReturnRepaymentFunded`, and adding `FixedReturn` rows to the per-team timeline / per-user activity endpoints.
