### PR TITLE
feat: ✨ add a per-week weekly goals memo with a Markdown editor

### DIFF
--- a/app/src/components/MarkdownEditor.vue
+++ b/app/src/components/MarkdownEditor.vue
@@ -1,0 +1,98 @@
+<template>
+  <div
+    class="border-default flex flex-col overflow-hidden rounded-md border"
+    data-test="markdown-editor"
+  >
+    <!-- GitHub-style Write / Markdown toggle -->
+    <div class="border-default bg-elevated/50 flex items-center gap-1 border-b p-1">
+      <UButton
+        v-for="tab in tabs"
+        :key="tab.value"
+        :variant="mode === tab.value ? 'soft' : 'ghost'"
+        :color="mode === tab.value ? 'primary' : 'neutral'"
+        size="xs"
+        :data-test="`markdown-editor-tab-${tab.value}`"
+        @click="mode = tab.value"
+      >
+        {{ tab.label }}
+      </UButton>
+    </div>
+
+    <!-- Write: edit the rendered content directly (WYSIWYG) -->
+    <UEditor
+      v-if="mode === 'write'"
+      v-slot="{ editor }"
+      v-model="markdown"
+      content-type="markdown"
+      :placeholder="placeholder"
+      class="max-h-96 min-h-52 overflow-y-auto"
+      data-test="markdown-editor-wysiwyg"
+    >
+      <UEditorToolbar
+        :editor="editor"
+        :items="toolbarItems"
+        class="border-default bg-default sticky top-0 z-10 flex flex-wrap border-b"
+      />
+    </UEditor>
+
+    <!-- Markdown: raw source -->
+    <UTextarea
+      v-else
+      v-model="markdown"
+      :placeholder="placeholder"
+      :rows="12"
+      autoresize
+      :ui="{ base: 'font-mono resize-y' }"
+      data-test="markdown-editor-source"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { EditorToolbarItem } from '@nuxt/ui'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: string
+    placeholder?: string
+  }>(),
+  {
+    placeholder: 'Write your weekly goals in Markdown…'
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+// The WYSIWYG editor and the raw textarea both bind this same string, so
+// flipping tabs round-trips the content (GitHub Write/Markdown behaviour). Only
+// one is mounted at a time (v-if) to avoid a serialize/parse feedback loop.
+const markdown = computed({
+  get: () => props.modelValue,
+  set: (value: string) => emit('update:modelValue', value)
+})
+
+type Mode = 'write' | 'markdown'
+const mode = ref<Mode>('write')
+const tabs: { value: Mode; label: string }[] = [
+  { value: 'write', label: 'Write' },
+  { value: 'markdown', label: 'Markdown' }
+]
+
+// Handlers referenced by `kind` are provided by UEditor's default handler set;
+// lucide icons match the set already used across the app.
+const toolbarItems: EditorToolbarItem[] = [
+  { kind: 'mark', mark: 'bold', icon: 'i-lucide-bold' },
+  { kind: 'mark', mark: 'italic', icon: 'i-lucide-italic' },
+  { kind: 'mark', mark: 'strike', icon: 'i-lucide-strikethrough' },
+  { kind: 'heading', level: 1, icon: 'i-lucide-heading-1' },
+  { kind: 'heading', level: 2, icon: 'i-lucide-heading-2' },
+  { kind: 'bulletList', icon: 'i-lucide-list' },
+  { kind: 'orderedList', icon: 'i-lucide-list-ordered' },
+  { kind: 'blockquote', icon: 'i-lucide-quote' },
+  { kind: 'codeBlock', icon: 'i-lucide-code' },
+  { kind: 'link', icon: 'i-lucide-link' }
+]
+</script>

--- a/app/src/components/__tests__/MarkdownEditor.spec.ts
+++ b/app/src/components/__tests__/MarkdownEditor.spec.ts
@@ -1,0 +1,66 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import MarkdownEditor from '@/components/MarkdownEditor.vue'
+
+// The real UEditor is a TipTap/ProseMirror WYSIWYG editor that is heavy and
+// unstable under jsdom, so we stub it (and its toolbar) to a plain element that
+// still forwards attrs and exposes the slotted editor. UTextarea is stubbed to
+// a bare <textarea> so we can drive the raw-Markdown round-trip deterministically.
+vi.mock('@nuxt/ui/components/Editor.vue', () => ({
+  default: {
+    name: 'UEditor',
+    props: ['modelValue', 'contentType', 'placeholder'],
+    emits: ['update:modelValue'],
+    template: '<div><slot :editor="{}" /></div>'
+  }
+}))
+
+vi.mock('@nuxt/ui/components/EditorToolbar.vue', () => ({
+  default: {
+    name: 'UEditorToolbar',
+    props: ['editor', 'items'],
+    template: '<div data-test="editor-toolbar" />'
+  }
+}))
+
+vi.mock('@nuxt/ui/components/Textarea.vue', () => ({
+  default: {
+    name: 'UTextarea',
+    props: ['modelValue', 'placeholder', 'rows', 'autoresize', 'ui'],
+    emits: ['update:modelValue'],
+    template:
+      '<textarea :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />'
+  }
+}))
+
+const factory = (modelValue = '') => mount(MarkdownEditor, { props: { modelValue } })
+
+describe('MarkdownEditor', () => {
+  it('starts in Write mode showing the WYSIWYG editor, not the raw source', () => {
+    const wrapper = factory('# hi')
+
+    expect(wrapper.find('[data-test="markdown-editor-wysiwyg"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="markdown-editor-source"]').exists()).toBe(false)
+  })
+
+  it('switches to the raw Markdown source when the Markdown tab is clicked', async () => {
+    const wrapper = factory('# hi')
+
+    await wrapper.find('[data-test="markdown-editor-tab-markdown"]').trigger('click')
+
+    expect(wrapper.find('[data-test="markdown-editor-source"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="markdown-editor-wysiwyg"]').exists()).toBe(false)
+  })
+
+  it('shows the current value in the source view and round-trips edits back out', async () => {
+    const wrapper = factory('- a\n- b')
+
+    await wrapper.find('[data-test="markdown-editor-tab-markdown"]').trigger('click')
+    const textarea = wrapper.find('textarea')
+    expect((textarea.element as HTMLTextAreaElement).value).toBe('- a\n- b')
+
+    await textarea.setValue('## new goals')
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['## new goals'])
+  })
+})

--- a/app/src/components/sections/CashRemunerationView/SubmitWeeklyGoals.vue
+++ b/app/src/components/sections/CashRemunerationView/SubmitWeeklyGoals.vue
@@ -1,0 +1,159 @@
+<template>
+  <TeamArchivedTooltip v-slot="{ disabled: archivedDisabled }">
+    <UTooltip :text="disabledTooltip" :delay-duration="0">
+      <span class="inline-flex max-w-full">
+        <UButton
+          color="neutral"
+          variant="subtle"
+          size="sm"
+          icon="i-lucide-target"
+          data-test="submit-weekly-goals-button"
+          :disabled="!canSubmit || archivedDisabled"
+          @click="openModal()"
+        >
+          {{ hasExistingGoals ? 'Edit Weekly Goals' : 'Submit Weekly Goals' }}
+        </UButton>
+      </span>
+    </UTooltip>
+  </TeamArchivedTooltip>
+
+  <UModal
+    v-if="modal.mount"
+    v-model:open="modal.show"
+    title="Weekly Goals"
+    description="Write a Markdown memo of what you plan to accomplish this week. One memo per week."
+    :ui="{ content: 'max-w-2xl' }"
+  >
+    <template #body>
+      <div class="flex flex-col gap-4">
+        <MarkdownEditor
+          v-model="goals"
+          placeholder="e.g. **Ship** the weekly goals editor, review 2 PRs…"
+        />
+
+        <UAlert
+          v-if="errorMessage"
+          color="error"
+          variant="soft"
+          icon="i-lucide-circle-alert"
+          title="Failed to submit weekly goals"
+          :description="errorMessage"
+          data-test="submit-weekly-goals-error"
+        />
+
+        <div class="flex justify-end gap-2">
+          <UButton
+            color="neutral"
+            variant="ghost"
+            :disabled="isPending"
+            data-test="submit-weekly-goals-cancel"
+            @click="modal.show = false"
+          >
+            Cancel
+          </UButton>
+          <UButton
+            color="success"
+            :loading="isPending"
+            data-test="submit-weekly-goals-confirm"
+            @click="handleSubmit"
+          >
+            Save Goals
+          </UButton>
+        </div>
+      </div>
+    </template>
+  </UModal>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import isoWeek from 'dayjs/plugin/isoWeek'
+import { useToast } from '@nuxt/ui/composables'
+import MarkdownEditor from '@/components/MarkdownEditor.vue'
+import TeamArchivedTooltip from '@/components/TeamArchivedTooltip.vue'
+import { useTeamStore } from '@/stores'
+import { useSubmitWeeklyGoalsMutation } from '@/queries/weeklyClaim.queries'
+import type { WeeklyClaim } from '@/types'
+import { getAxiosErrorMessage } from '@/utils/errorUtil'
+
+dayjs.extend(utc)
+dayjs.extend(isoWeek)
+
+const props = defineProps<{
+  weeklyClaim?: WeeklyClaim
+  selectedWeekStart?: string
+}>()
+
+const toast = useToast()
+const teamStore = useTeamStore()
+
+const modal = ref({ mount: false, show: false })
+const goals = ref('')
+const errorMessage = ref<string | null>(null)
+
+const teamId = computed(() => teamStore.currentTeamId)
+
+const hasExistingGoals = computed(() => !!props.weeklyClaim?.weeklyGoals)
+
+// Goals stay editable until the week is signed / withdrawn / disabled — mirrors
+// the daily-claim rule (only a `pending` week accepts changes). No existing
+// weekly claim means the week is fresh and open.
+const canSubmit = computed(() => {
+  if (!props.weeklyClaim) return true
+  return props.weeklyClaim.status === 'pending'
+})
+
+const disabledTooltip = computed(() =>
+  !canSubmit.value && props.weeklyClaim
+    ? `This week is ${props.weeklyClaim.status}; weekly goals can no longer be edited.`
+    : undefined
+)
+
+const openModal = () => {
+  goals.value = props.weeklyClaim?.weeklyGoals ?? ''
+  errorMessage.value = null
+  modal.value = { mount: true, show: true }
+}
+
+// Fully unmount the modal (and drop transient error state) once it closes.
+watch(
+  () => modal.value.show,
+  (isOpen) => {
+    if (!isOpen) {
+      errorMessage.value = null
+      modal.value = { mount: false, show: false }
+    }
+  },
+  { flush: 'post' }
+)
+
+const { mutateAsync: submitGoals, isPending } = useSubmitWeeklyGoalsMutation()
+
+const handleSubmit = async () => {
+  if (!teamId.value) {
+    toast.add({ title: 'Team not selected', color: 'error' })
+    return
+  }
+
+  const weekStart = props.selectedWeekStart ?? dayjs.utc().startOf('isoWeek').toISOString()
+  errorMessage.value = null
+
+  try {
+    await submitGoals({
+      body: {
+        teamId: teamId.value,
+        weekStart,
+        weeklyGoals: goals.value
+      }
+    })
+    toast.add({ title: 'Weekly goals saved successfully', color: 'success' })
+    modal.value.show = false
+  } catch (error) {
+    errorMessage.value = getAxiosErrorMessage(error, 'Failed to save weekly goals')
+  }
+}
+
+defineExpose({ modal, goals, handleSubmit, openModal })
+</script>

--- a/app/src/components/sections/CashRemunerationView/__tests__/SubmitWeeklyGoals.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/__tests__/SubmitWeeklyGoals.spec.ts
@@ -1,0 +1,114 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import SubmitWeeklyGoals from '../SubmitWeeklyGoals.vue'
+import type { WeeklyClaim } from '@/types'
+import { mockTeamStore, mockToast } from '@/tests/mocks'
+
+// The mutation hook is replaced with a controllable spy; every other export of
+// the queries module is preserved so unrelated imports keep working.
+const { submitGoalsMock } = vi.hoisted(() => ({ submitGoalsMock: vi.fn() }))
+
+vi.mock('@/queries/weeklyClaim.queries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/queries/weeklyClaim.queries')>()
+  return {
+    ...actual,
+    useSubmitWeeklyGoalsMutation: () => ({ mutateAsync: submitGoalsMock, isPending: false })
+  }
+})
+
+const TeamArchivedTooltipStub = {
+  name: 'TeamArchivedTooltip',
+  template: '<div><slot :disabled="false" /></div>'
+}
+
+// Stub the editor to a bare textarea so the modal's memo value is drivable.
+const MarkdownEditorStub = {
+  name: 'MarkdownEditor',
+  props: ['modelValue', 'placeholder'],
+  emits: ['update:modelValue'],
+  template:
+    '<textarea data-test="md-editor-stub" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />'
+}
+
+const WEEK_START = '2024-06-30T00:00:00.000Z'
+
+const makeWeeklyClaim = (overrides: Partial<WeeklyClaim> = {}): WeeklyClaim =>
+  ({
+    id: 1,
+    status: 'pending',
+    weekStart: WEEK_START,
+    weeklyGoals: null,
+    ...overrides
+  }) as WeeklyClaim
+
+const createComponent = (props: Record<string, unknown> = {}) =>
+  mount(SubmitWeeklyGoals, {
+    props: { selectedWeekStart: WEEK_START, ...props },
+    global: {
+      stubs: {
+        TeamArchivedTooltip: TeamArchivedTooltipStub,
+        MarkdownEditor: MarkdownEditorStub
+      }
+    }
+  })
+
+describe('SubmitWeeklyGoals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    submitGoalsMock.mockResolvedValue({})
+    mockTeamStore.currentTeamId = '1'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('labels the button "Submit Weekly Goals" when no memo exists yet', () => {
+    const wrapper = createComponent({ weeklyClaim: makeWeeklyClaim() })
+    expect(wrapper.get('[data-test="submit-weekly-goals-button"]').text()).toBe(
+      'Submit Weekly Goals'
+    )
+  })
+
+  it('labels the button "Edit Weekly Goals" when a memo already exists', () => {
+    const wrapper = createComponent({
+      weeklyClaim: makeWeeklyClaim({ weeklyGoals: '# Existing' })
+    })
+    expect(wrapper.get('[data-test="submit-weekly-goals-button"]').text()).toBe('Edit Weekly Goals')
+  })
+
+  it('disables the button once the week is signed', () => {
+    const wrapper = createComponent({ weeklyClaim: makeWeeklyClaim({ status: 'signed' }) })
+    expect(
+      wrapper.get('[data-test="submit-weekly-goals-button"]').attributes('disabled')
+    ).toBeDefined()
+  })
+
+  it('submits the memo with the team id and selected week, then toasts success', async () => {
+    const wrapper = createComponent({
+      weeklyClaim: makeWeeklyClaim({ weeklyGoals: '# Existing goals' })
+    })
+
+    await wrapper.get('[data-test="submit-weekly-goals-button"]').trigger('click')
+    await wrapper.get('[data-test="submit-weekly-goals-confirm"]').trigger('click')
+    await flushPromises()
+
+    expect(submitGoalsMock).toHaveBeenCalledWith({
+      body: { teamId: '1', weekStart: WEEK_START, weeklyGoals: '# Existing goals' }
+    })
+    expect(mockToast.add).toHaveBeenCalledWith(expect.objectContaining({ color: 'success' }))
+  })
+
+  it('sends the edited memo content from the editor', async () => {
+    const wrapper = createComponent({ weeklyClaim: makeWeeklyClaim() })
+
+    await wrapper.get('[data-test="submit-weekly-goals-button"]').trigger('click')
+    await wrapper.get('[data-test="md-editor-stub"]').setValue('## Rewritten plan')
+    await wrapper.get('[data-test="submit-weekly-goals-confirm"]').trigger('click')
+    await flushPromises()
+
+    expect(submitGoalsMock).toHaveBeenCalledWith({
+      body: { teamId: '1', weekStart: WEEK_START, weeklyGoals: '## Rewritten plan' }
+    })
+  })
+})

--- a/app/src/components/sections/ClaimHistoryView/ClaimHistory.vue
+++ b/app/src/components/sections/ClaimHistoryView/ClaimHistory.vue
@@ -26,6 +26,8 @@
           :is-restricted="isRestricted"
           @quick-submit="handleQuickSubmit"
         />
+
+        <WeeklyGoalsDisplay :weekly-claim="selectWeekWeelyClaim" />
       </div>
     </div>
   </div>
@@ -48,6 +50,7 @@ import ClaimHistoryMemberHeader from './ClaimHistoryMemberHeader.vue'
 import ClaimHistoryWeekNavigator from './ClaimHistoryWeekNavigator.vue'
 import ClaimHistoryActionAlerts from './ClaimHistoryActionAlerts.vue'
 import ClaimHistoryDailyBreakdown from './ClaimHistoryDailyBreakdown.vue'
+import WeeklyGoalsDisplay from './WeeklyGoalsDisplay.vue'
 
 dayjs.extend(utc)
 dayjs.extend(isoWeek)

--- a/app/src/components/sections/ClaimHistoryView/ClaimHistoryActionAlerts.vue
+++ b/app/src/components/sections/ClaimHistoryView/ClaimHistoryActionAlerts.vue
@@ -10,22 +10,38 @@
         :description="claimSubmitMessage"
       >
         <template #actions>
-          <SubmitClaims
-            ref="submitClaimsRef"
-            v-if="hasWage"
-            :weekly-claim="weeklyClaim"
-            :signed-week-starts="signedWeekStarts"
-            :selected-week-start="selectedWeekStart"
-          />
-          <UButton
-            v-else
-            color="success"
-            size="sm"
-            :disabled="true"
-            data-test="submit-claim-disabled-button"
-          >
-            Submit Claim
-          </UButton>
+          <template v-if="hasWage">
+            <SubmitClaims
+              ref="submitClaimsRef"
+              :weekly-claim="weeklyClaim"
+              :signed-week-starts="signedWeekStarts"
+              :selected-week-start="selectedWeekStart"
+            />
+            <SubmitWeeklyGoals
+              :weekly-claim="weeklyClaim"
+              :selected-week-start="selectedWeekStart"
+            />
+          </template>
+          <template v-else>
+            <UButton
+              color="success"
+              size="sm"
+              :disabled="true"
+              data-test="submit-claim-disabled-button"
+            >
+              Submit Claim
+            </UButton>
+            <UButton
+              color="neutral"
+              variant="subtle"
+              size="sm"
+              icon="i-lucide-target"
+              :disabled="true"
+              data-test="submit-weekly-goals-disabled-button"
+            >
+              Submit Weekly Goals
+            </UButton>
+          </template>
         </template>
       </UAlert>
 
@@ -92,6 +108,7 @@ import { useTeamStore, useUserDataStore } from '@/stores'
 import { useGetTeamWagesQuery, useGetTeamWeeklyClaimsQuery } from '@/queries'
 import type { WeeklyClaim } from '@/types'
 import SubmitClaims from '../CashRemunerationView/SubmitClaims.vue'
+import SubmitWeeklyGoals from '../CashRemunerationView/SubmitWeeklyGoals.vue'
 import CRSigne from '../CashRemunerationView/CRSigne.vue'
 import CRWithdrawClaim from '../CashRemunerationView/CRWithdrawClaim.vue'
 

--- a/app/src/components/sections/ClaimHistoryView/WeeklyGoalsDisplay.vue
+++ b/app/src/components/sections/ClaimHistoryView/WeeklyGoalsDisplay.vue
@@ -1,0 +1,40 @@
+<template>
+  <UCard class="w-full" data-test="weekly-goals-display">
+    <div class="flex flex-col gap-3">
+      <div class="flex items-center gap-2">
+        <UIcon name="i-lucide-target" class="h-5 w-5 text-gray-500" />
+        <h2>Weekly Goals</h2>
+      </div>
+
+      <!-- Read-only render of the member's memo, visible to the whole team. The
+           same UEditor powers the author's WYSIWYG, so the rendering matches
+           exactly; `editable=false` drops interaction and no toolbar is slotted.
+           Keyed on the memo so navigating weeks swaps the content reliably. -->
+      <UEditor
+        v-if="hasGoals"
+        :key="goals"
+        :model-value="goals"
+        content-type="markdown"
+        :editable="false"
+        class="max-h-96 overflow-y-auto"
+        data-test="weekly-goals-content"
+      />
+
+      <p v-else class="text-sm text-gray-500" data-test="weekly-goals-empty">
+        No weekly goals set for this week.
+      </p>
+    </div>
+  </UCard>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { WeeklyClaim } from '@/types'
+
+const props = defineProps<{
+  weeklyClaim?: WeeklyClaim
+}>()
+
+const goals = computed(() => props.weeklyClaim?.weeklyGoals ?? '')
+const hasGoals = computed(() => goals.value.trim().length > 0)
+</script>

--- a/app/src/components/sections/ClaimHistoryView/__tests__/ClaimHistoryActionAlerts.spec.ts
+++ b/app/src/components/sections/ClaimHistoryView/__tests__/ClaimHistoryActionAlerts.spec.ts
@@ -49,6 +49,11 @@ describe('ClaimHistoryActionAlerts', () => {
         },
         template: '<div data-test="submit-claims">{{ signedWeekStarts.length }}</div>'
       }),
+      SubmitWeeklyGoals: {
+        name: 'SubmitWeeklyGoals',
+        props: ['weeklyClaim', 'selectedWeekStart'],
+        template: '<div data-test="submit-weekly-goals" />'
+      },
       CRSigne: {
         name: 'CRSigne',
         props: ['disabled'],

--- a/app/src/components/sections/ClaimHistoryView/__tests__/WeeklyGoalsDisplay.spec.ts
+++ b/app/src/components/sections/ClaimHistoryView/__tests__/WeeklyGoalsDisplay.spec.ts
@@ -1,0 +1,72 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import WeeklyGoalsDisplay from '../WeeklyGoalsDisplay.vue'
+import type { WeeklyClaim } from '@/types'
+
+// The real UEditor is a heavy TipTap/ProseMirror instance that is unstable under
+// jsdom, so we stub it to a plain element that still surfaces the forwarded
+// model value and its editable flag.
+vi.mock('@nuxt/ui/components/Editor.vue', () => ({
+  default: {
+    name: 'UEditor',
+    props: ['modelValue', 'contentType', 'editable'],
+    template:
+      '<div data-test="weekly-goals-content" :data-editable="String(editable)">{{ modelValue }}</div>'
+  }
+}))
+
+const makeWeeklyClaim = (overrides: Partial<WeeklyClaim> = {}): WeeklyClaim =>
+  ({
+    id: 1,
+    status: 'pending',
+    weekStart: '2024-06-30T00:00:00.000Z',
+    weeklyGoals: null,
+    ...overrides
+  }) as WeeklyClaim
+
+const factory = (props: Record<string, unknown> = {}) =>
+  mount(WeeklyGoalsDisplay, {
+    props,
+    global: {
+      stubs: {
+        UCard: { template: '<div><slot /></div>' },
+        UIcon: { template: '<span />' }
+      }
+    }
+  })
+
+describe('WeeklyGoalsDisplay', () => {
+  it('renders the memo read-only when goals are set', () => {
+    const wrapper = factory({
+      weeklyClaim: makeWeeklyClaim({ weeklyGoals: '## Ship it' })
+    })
+
+    const content = wrapper.get('[data-test="weekly-goals-content"]')
+    expect(content.text()).toContain('## Ship it')
+    expect(content.attributes('data-editable')).toBe('false')
+    expect(wrapper.find('[data-test="weekly-goals-empty"]').exists()).toBe(false)
+  })
+
+  it('shows an empty state when the memo is null', () => {
+    const wrapper = factory({ weeklyClaim: makeWeeklyClaim({ weeklyGoals: null }) })
+
+    expect(wrapper.find('[data-test="weekly-goals-content"]').exists()).toBe(false)
+    expect(wrapper.get('[data-test="weekly-goals-empty"]').text()).toBe(
+      'No weekly goals set for this week.'
+    )
+  })
+
+  it('treats a whitespace-only memo as empty', () => {
+    const wrapper = factory({ weeklyClaim: makeWeeklyClaim({ weeklyGoals: '   \n  ' }) })
+
+    expect(wrapper.find('[data-test="weekly-goals-content"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="weekly-goals-empty"]').exists()).toBe(true)
+  })
+
+  it('shows the empty state when there is no weekly claim at all', () => {
+    const wrapper = factory({})
+
+    expect(wrapper.find('[data-test="weekly-goals-content"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="weekly-goals-empty"]').exists()).toBe(true)
+  })
+})

--- a/app/src/queries/__tests__/weeklyClaimGoals.queries.spec.ts
+++ b/app/src/queries/__tests__/weeklyClaimGoals.queries.spec.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { smartUseMutation, useMutationFn, useQueryClientFn } from '@/tests/mocks/composables.mock'
+import apiClient from '@/lib/axios'
+
+// Imported after the composables mock (see setup files) so the createMutationHook
+// factory resolves the mocked `useMutation` / `useQueryClient`.
+const weeklyClaimQueries =
+  await vi.importActual<typeof import('../weeklyClaim.queries')>('../weeklyClaim.queries')
+
+const mockQueryClient = (invalidateQueries = vi.fn().mockResolvedValue(undefined)) => {
+  useQueryClientFn.mockReturnValue({
+    invalidateQueries,
+    getQueryData: vi.fn(),
+    setQueryData: vi.fn(),
+    removeQueries: vi.fn()
+  })
+  return invalidateQueries
+}
+
+describe('useSubmitWeeklyGoalsMutation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useMutationFn.mockImplementation(smartUseMutation)
+    mockQueryClient()
+  })
+
+  it('PUTs the goals memo to weeklyClaim/goals and invalidates team queries', async () => {
+    const invalidateQueries = mockQueryClient()
+    vi.mocked(apiClient.put).mockResolvedValue({ data: undefined })
+    const body = { teamId: 7, weekStart: '2024-01-01T00:00:00.000Z', weeklyGoals: '# Goals' }
+
+    await weeklyClaimQueries.useSubmitWeeklyGoalsMutation().mutateAsync({ body })
+
+    expect(apiClient.put).toHaveBeenCalledWith('weeklyClaim/goals', body, undefined)
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: weeklyClaimQueries.weeklyClaimKeys.teams()
+    })
+  })
+})

--- a/app/src/queries/weeklyClaim.queries.ts
+++ b/app/src/queries/weeklyClaim.queries.ts
@@ -222,6 +222,42 @@ export const useUpdateWeeklyClaimMutation = createMutationHook<void, UpdateWeekl
 })
 
 // ============================================================================
+// PUT /weeklyClaim/goals - Submit / update the weekly goals memo
+// ============================================================================
+
+/**
+ * Combined parameters for useSubmitWeeklyGoalsMutation
+ */
+export interface SubmitWeeklyGoalsParams {
+  body: {
+    /** Team ID */
+    teamId: number | string
+    /** Any ISO datetime within the target week (normalized to isoWeek start server-side) */
+    weekStart: string
+    /** Markdown memo; an empty string clears the saved memo */
+    weeklyGoals: string
+  }
+}
+
+/**
+ * Submit or update the caller's weekly goals memo for a given week. Upserts the
+ * WeeklyClaim row (creating a claim-less one for weeks with no hours logged yet).
+ *
+ * @endpoint PUT /weeklyClaim/goals
+ * @pathParams none
+ * @queryParams none
+ * @body { teamId, weekStart, weeklyGoals }
+ */
+export const useSubmitWeeklyGoalsMutation = createMutationHook<
+  WeeklyClaim,
+  SubmitWeeklyGoalsParams
+>({
+  method: 'PUT',
+  endpoint: 'weeklyClaim/goals',
+  invalidateKeys: () => [weeklyClaimKeys.teams()]
+})
+
+// ============================================================================
 // POST /weeklyClaim/sync - Sync weekly claims
 // ============================================================================
 

--- a/app/src/tests/mocks/query.mock.ts
+++ b/app/src/tests/mocks/query.mock.ts
@@ -156,6 +156,7 @@ export const mockWeeklyClaimData: WeeklyClaim[] = [
     data: {},
     signature: null,
     signedAgainstContractAddress: null,
+    weeklyGoals: null,
     wageId: 1,
     wage: mockWageData[0] as Wage,
     claims: [

--- a/app/src/types/cash-remuneration.ts
+++ b/app/src/types/cash-remuneration.ts
@@ -83,6 +83,11 @@ export interface WeeklyClaim {
    * rows signed before this column existed.
    */
   signedAgainstContractAddress: Address | null
+  /**
+   * Free-form Markdown memo of the member's goals for the week. One per weekly
+   * claim; null when no goals have been set. Upserted via PUT /weeklyclaim/goals.
+   */
+  weeklyGoals: string | null
   wageId: number
   createdAt: string // ISO date string
   updatedAt: string // ISO date string

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -139,7 +139,18 @@ export default defineConfig(async ({ mode }) => {
       // `xlsx` is only reached via the lazy `import('xlsx')` in the accounting
       // export — without this, the first Export click re-optimizes and reloads
       // the page, silently aborting the download.
-      include: ['viem/accounts', 'xlsx']
+      // The ProseMirror packages back the Nuxt UI `UEditor` (weekly goals memo).
+      // Pre-bundling them as a single copy avoids the "Adding different instances
+      // of a keyed plugin" TipTap error and mid-session re-optimize reloads.
+      include: [
+        'viem/accounts',
+        'xlsx',
+        '@nuxt/ui > prosemirror-state',
+        '@nuxt/ui > prosemirror-transform',
+        '@nuxt/ui > prosemirror-model',
+        '@nuxt/ui > prosemirror-view',
+        '@nuxt/ui > prosemirror-gapcursor'
+      ]
     },
     build: {
       // 'hidden' generates source maps but does NOT reference them in the

--- a/backend/prisma/migrations/20260703000000_add_weekly_goals/migration.sql
+++ b/backend/prisma/migrations/20260703000000_add_weekly_goals/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "WeeklyClaim" ADD COLUMN "weeklyGoals" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -141,6 +141,11 @@ model WeeklyClaim {
   // for re-signing) when the team's CashRemunerationEIP712 contract is later
   // redeployed. Nullable for legacy rows signed before this column existed.
   signedAgainstContractAddress String?
+  // Free-form Markdown memo of the member's goals for the week. One per weekly
+  // claim (the [wageId, weekStart] pair). Upserted independently of daily
+  // claims — a goals-only week creates a claim-less WeeklyClaim row. Nullable
+  // for weeks with no goals set.
+  weeklyGoals                  String?
   claims                       Claim[]  @relation("WeeklyClaimToClaims")
   wageId                       Int
   wage                         Wage     @relation(fields: [wageId], references: [id], onDelete: Cascade)

--- a/backend/src/controllers/__tests__/claimController.test.ts
+++ b/backend/src/controllers/__tests__/claimController.test.ts
@@ -900,6 +900,29 @@ describe('Claim Controller', () => {
       expect(mockWeeklyClaimDelete).toHaveBeenCalledWith({ where: { id: 1 } });
     });
 
+    it('should keep the weekly claim when it is the last claim but goals are set', async () => {
+      // A goals-only week: deleting the last daily claim must not wipe the memo.
+      vi.spyOn(prisma.claim, 'findFirst').mockResolvedValue({
+        id: 1,
+        wage: { userAddress: TEST_ADDRESS },
+        weeklyClaim: {
+          id: 1,
+          status: 'pending',
+          weeklyGoals: '# Ship the editor',
+          claims: [{ id: 1 }],
+        },
+      } as any);
+      const mockClaimDelete = vi.spyOn(prisma.claim, 'delete').mockResolvedValue({} as any);
+      const mockWeeklyClaimDelete = vi.spyOn(prisma.weeklyClaim, 'delete');
+
+      const response = await request(app).delete('/1');
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toBe('Claim deleted successfully');
+      expect(mockClaimDelete).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(mockWeeklyClaimDelete).not.toHaveBeenCalled();
+    });
+
     it('should only delete claim when other claims exist in weekly claim', async () => {
       setupMockClaim('pending', TEST_ADDRESS, true);
       const mockClaimDelete = vi.spyOn(prisma.claim, 'delete').mockResolvedValue({} as any);

--- a/backend/src/controllers/__tests__/weeklyClaimController.test.ts
+++ b/backend/src/controllers/__tests__/weeklyClaimController.test.ts
@@ -94,8 +94,13 @@ vi.mock('../../utils', async () => {
         findFirst: vi.fn().mockResolvedValue({ id: 1 }),
         findUnique: vi.fn().mockResolvedValue({ isArchived: false }),
       },
+      wage: {
+        findFirst: vi.fn(),
+      },
       weeklyClaim: {
+        findFirst: vi.fn(),
         findMany: vi.fn(),
+        create: vi.fn(),
         update: vi.fn(),
         findUnique: vi.fn(),
         count: vi.fn().mockResolvedValue(0),
@@ -919,6 +924,88 @@ describe('Weekly Claim Controller', () => {
         message: 'Internal server error has occured',
         error: 'Database failure',
       });
+    });
+  });
+
+  describe('PUT /goals', () => {
+    const GOALS_BODY = {
+      teamId: 1,
+      weekStart: '2024-07-22T00:00:00.000Z',
+      weeklyGoals: '# Week goals\n\n- Ship the editor',
+    };
+    const currentWage = { id: 7, teamId: 1, userAddress: CALLER, nextWageId: null };
+
+    it('creates a claim-less weekly claim when none exists yet', async () => {
+      vi.mocked(prisma.wage.findFirst).mockResolvedValue(currentWage as never);
+      vi.mocked(prisma.weeklyClaim.findFirst).mockResolvedValue(null as never);
+      vi.mocked(prisma.weeklyClaim.create).mockResolvedValue(
+        weeklyClaimFactory({ id: 42, weeklyGoals: GOALS_BODY.weeklyGoals }) as never
+      );
+
+      const response = await request(app).put('/goals').send(GOALS_BODY);
+
+      expect(response.status).toBe(200);
+      expect(prisma.weeklyClaim.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            wageId: currentWage.id,
+            memberAddress: CALLER,
+            teamId: 1,
+            status: 'pending',
+            weeklyGoals: GOALS_BODY.weeklyGoals,
+          }),
+        })
+      );
+      expect(prisma.weeklyClaim.update).not.toHaveBeenCalled();
+    });
+
+    it('updates the memo on an existing pending weekly claim', async () => {
+      vi.mocked(prisma.wage.findFirst).mockResolvedValue(currentWage as never);
+      vi.mocked(prisma.weeklyClaim.findFirst).mockResolvedValue(
+        weeklyClaimFactory({ id: 5, status: 'pending', signature: null }) as never
+      );
+      vi.mocked(prisma.weeklyClaim.update).mockResolvedValue(
+        weeklyClaimFactory({ id: 5, weeklyGoals: GOALS_BODY.weeklyGoals }) as never
+      );
+
+      const response = await request(app).put('/goals').send(GOALS_BODY);
+
+      expect(response.status).toBe(200);
+      expect(prisma.weeklyClaim.update).toHaveBeenCalledWith({
+        where: { id: 5 },
+        data: { weeklyGoals: GOALS_BODY.weeklyGoals },
+      });
+      expect(prisma.weeklyClaim.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects with 409 when the week is already signed', async () => {
+      vi.mocked(prisma.wage.findFirst).mockResolvedValue(currentWage as never);
+      vi.mocked(prisma.weeklyClaim.findFirst).mockResolvedValue(
+        weeklyClaimFactory({ id: 5, status: 'signed', signature: '0xabc' }) as never
+      );
+
+      const response = await request(app).put('/goals').send(GOALS_BODY);
+
+      expect(response.status).toBe(409);
+      expect(prisma.weeklyClaim.update).not.toHaveBeenCalled();
+      expect(prisma.weeklyClaim.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the caller has no current wage', async () => {
+      vi.mocked(prisma.wage.findFirst).mockResolvedValue(null as never);
+
+      const response = await request(app).put('/goals').send(GOALS_BODY);
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe('No wage found for the user');
+    });
+
+    it('returns 400 when the body fails validation', async () => {
+      const response = await request(app)
+        .put('/goals')
+        .send({ teamId: 1, weekStart: 'not-a-date', weeklyGoals: 'x' });
+
+      expect(response.status).toBe(400);
     });
   });
 });

--- a/backend/src/controllers/claimController.ts
+++ b/backend/src/controllers/claimController.ts
@@ -416,7 +416,9 @@ export const deleteClaim = async (req: Request, res: Response) => {
 
     if (weeklyClaim) {
       const remainingClaims = (weeklyClaim.claims ?? []).filter((c) => c.id !== claimId);
-      if (remainingClaims.length === 0) {
+      // Keep a claim-less weekly claim alive when it still carries a goals memo —
+      // deleting it here would silently wipe the member's weekly goals.
+      if (remainingClaims.length === 0 && !weeklyClaim.weeklyGoals) {
         await prisma.weeklyClaim.delete({
           where: { id: weeklyClaim.id },
         });

--- a/backend/src/controllers/weeklyClaimController.ts
+++ b/backend/src/controllers/weeklyClaimController.ts
@@ -1,3 +1,6 @@
+import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+import utc from 'dayjs/plugin/utc';
 import { Request, Response } from 'express';
 import { errorResponse, getMondayStart, prisma } from '../utils';
 import { Prisma } from '@prisma/client';
@@ -27,6 +30,9 @@ const WAGE_CLAIM_TYPES = {
     { name: 'date', type: 'uint256' },
   ],
 } as const;
+
+dayjs.extend(utc);
+dayjs.extend(isoWeek);
 
 export type WeeklyClaimAction = 'sign' | 'withdraw' | 'disable' | 'enable';
 type statusType = 'pending' | 'signed' | 'withdrawn' | 'disabled';
@@ -571,6 +577,88 @@ export const syncWeeklyClaims = async (req: Request, res: Response) => {
     });
   } catch (error) {
     console.error('Error syncing weekly claims:', error);
+    return errorResponse(500, error, res);
+  }
+};
+
+/**
+ * Upsert the member's weekly goals memo (free-form Markdown) for a given ISO
+ * week. Exactly one memo exists per weekly claim ([wageId, weekStart]). The
+ * caller can only set their own goals — `req.address` is the member address.
+ *
+ * The memo is decoupled from daily claims: submitting goals for a week that has
+ * no claims yet creates a claim-less WeeklyClaim row (status `pending`), so a
+ * member can plan the week before logging any hours. Once the week is signed /
+ * withdrawn / disabled the memo is locked, mirroring the addClaim guards.
+ */
+export const submitWeeklyGoals = async (req: Request, res: Response) => {
+  const callerAddress = req.address;
+  const {
+    teamId,
+    weekStart: weekStartInput,
+    weeklyGoals,
+  } = req.body as {
+    teamId: number;
+    weekStart: string;
+    weeklyGoals: string;
+  };
+
+  // Normalize to Monday 00:00 UTC the same way addClaim does, so the row lines
+  // up with the [wageId, weekStart] uniqueness used by daily claims.
+  const weekStart = dayjs.utc(weekStartInput).startOf('isoWeek').toDate();
+
+  try {
+    // A WeeklyClaim requires a wageId, so the member needs a current wage
+    // before any goals can be recorded (mirrors addClaim).
+    const wage = await prisma.wage.findFirst({
+      where: { userAddress: callerAddress, nextWageId: null, teamId },
+    });
+
+    if (!wage) {
+      return errorResponse(400, 'No wage found for the user', res);
+    }
+
+    const existing = await prisma.weeklyClaim.findFirst({
+      where: {
+        wage: { teamId, nextWageId: null },
+        weekStart,
+        memberAddress: callerAddress,
+        teamId,
+      },
+    });
+
+    if (existing) {
+      if (existing.status === 'disabled') {
+        return errorResponse(409, 'Week is disabled. Submission not allowed.', res);
+      }
+      if (existing.status === 'withdrawn') {
+        return errorResponse(409, 'Week already withdrawn. Submission not allowed.', res);
+      }
+      if (existing.status === 'signed' || !!existing.signature) {
+        return errorResponse(409, 'Week already signed. Submission not allowed.', res);
+      }
+
+      const updated = await prisma.weeklyClaim.update({
+        where: { id: existing.id },
+        data: { weeklyGoals },
+      });
+      return res.status(200).json(updated);
+    }
+
+    const created = await prisma.weeklyClaim.create({
+      data: {
+        wageId: wage.id,
+        weekStart,
+        memberAddress: callerAddress,
+        teamId,
+        data: {},
+        status: 'pending',
+        weeklyGoals,
+      },
+    });
+
+    return res.status(200).json(created);
+  } catch (error) {
     return errorResponse(500, error, res);
   }
 };

--- a/backend/src/routes/weeklyClaimRoute.ts
+++ b/backend/src/routes/weeklyClaimRoute.ts
@@ -1,14 +1,17 @@
 import express from 'express';
 import {
   getTeamWeeklyClaims,
+  submitWeeklyGoals,
   syncWeeklyClaims,
   updateWeeklyClaims,
 } from '../controllers/weeklyClaimController';
 import { rejectIfArchived, requireTeamMember } from '../middleware/teamAuthzMiddleware';
 import {
   validate,
+  validateBody,
   validateQuery,
   getWeeklyClaimsQuerySchema,
+  submitWeeklyGoalsBodySchema,
   syncWeeklyClaimsQuerySchema,
   weeklyClaimIdParamsSchema,
   updateWeeklyClaimQuerySchema,
@@ -230,6 +233,79 @@ weeklyClaimRoutes.post(
   requireTeamMember('query.teamId'),
   rejectIfArchived('query.teamId'),
   syncWeeklyClaims
+);
+
+/**
+ * @openapi
+ * /weekly-claim/goals:
+ *  put:
+ *   summary: Submit or update the caller's weekly goals memo
+ *   tags: [Weekly Claims]
+ *   security:
+ *     - bearerAuth: []
+ *   description: |
+ *     Upserts the authenticated member's free-form Markdown goals memo for a
+ *     given ISO week. Exactly one memo exists per weekly claim. Submitting goals
+ *     for a week with no claims yet creates a claim-less weekly claim (status
+ *     `pending`). The memo is locked once the week is signed, withdrawn, or
+ *     disabled.
+ *   requestBody:
+ *     required: true
+ *     content:
+ *       application/json:
+ *         schema:
+ *           type: object
+ *           required: [teamId, weekStart, weeklyGoals]
+ *           properties:
+ *             teamId:
+ *               type: integer
+ *               minimum: 1
+ *             weekStart:
+ *               type: string
+ *               format: date-time
+ *               description: Any ISO datetime within the target week (normalized to the Monday isoWeek start).
+ *             weeklyGoals:
+ *               type: string
+ *               maxLength: 10000
+ *               description: Markdown memo. An empty string clears the saved memo.
+ *   responses:
+ *     200:
+ *       description: Weekly goals saved successfully
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WeeklyClaim'
+ *     400:
+ *       description: Bad request - invalid body or no wage for the caller
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ErrorResponse'
+ *     403:
+ *       description: Forbidden - caller is not a member of the team
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ErrorResponse'
+ *     409:
+ *       description: Conflict - the week is already signed, withdrawn, or disabled
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ErrorResponse'
+ *     500:
+ *       description: Internal server error
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ErrorResponse'
+ */
+weeklyClaimRoutes.put(
+  '/goals',
+  validateBody(submitWeeklyGoalsBodySchema),
+  requireTeamMember('body.teamId'),
+  rejectIfArchived('body.teamId'),
+  submitWeeklyGoals
 );
 
 /**

--- a/backend/src/validation/schemas/weeklyClaim.ts
+++ b/backend/src/validation/schemas/weeklyClaim.ts
@@ -64,6 +64,19 @@ export const syncWeeklyClaimsQuerySchema = z.object({
   teamId: teamIdSchema,
 });
 
+// Submit / update weekly goals request body
+//
+// The weekly goals memo is free-form Markdown, upserted per ISO week. weekStart
+// is any ISO datetime within the target week — the controller normalizes it to
+// the Monday isoWeek start. An empty string is allowed so the member can clear
+// a previously saved memo. Capped to keep the payload (and the TEXT column)
+// bounded.
+export const submitWeeklyGoalsBodySchema = z.object({
+  teamId: teamIdSchema,
+  weekStart: z.string().datetime({ message: 'weekStart must be an ISO datetime string' }),
+  weeklyGoals: z.string().max(10_000, 'Weekly goals cannot exceed 10000 characters'),
+});
+
 // Update weekly claim path parameters
 export const weeklyClaimIdParamsSchema = z.object({
   id: positiveIntegerSchema,


### PR DESCRIPTION
## What & why

Adds a **weekly goals** memo — one free-form Markdown note per weekly claim (per member, per ISO week) — so members can record what they plan to accomplish for the week, alongside their hours.

Closes #2240

## Backend

- New nullable `weeklyGoals` column on `WeeklyClaim` (natural `[wageId, weekStart]` key) + migration.
- `PUT /weeklyclaim/goals` upserts the memo. Submitting goals for a week with **no hours logged yet** creates a claim-less `WeeklyClaim` (status `pending`), so goals can be set up front. The memo is locked once the week is signed / withdrawn / disabled (mirrors the daily-claim rules).
- Deleting the last daily claim of a week no longer wipes the row when a goals memo is set — goals-only weeks survive.

## Frontend

- Reusable `MarkdownEditor` built on the Nuxt UI `Editor` component, with a GitHub-style toggle:
  - **Write** — edit the rendered content directly (WYSIWYG).
  - **Markdown** — the raw source.
  - Both bind the same value, so flipping tabs round-trips the content.
- A **Submit Weekly Goals** button next to **Submit Claim** in the claim-history action alerts. Opens the editor in a modal, pre-filled with any existing memo, and upserts via `useSubmitWeeklyGoalsMutation`. Disabled once the week is signed.
- Pre-bundle the ProseMirror packages in `vite.config.ts` so the editor loads a single copy (avoids the "Adding different instances of a keyed plugin" TipTap error).

## Testing

- Backend: full suite green (653 passing). New cases cover create/update/reject-signed/no-wage on the goals endpoint and the delete-preserves-goals guard.
- Frontend: full unit suite green (2222 passing). New specs cover the editor toggle/round-trip, the submit modal + payload, and the goals mutation.
- Type-check, lint, and prettier pass on both projects.

## Notes for the reviewer

- Goals are keyed to the member's **current** wage, matching how daily claims resolve their weekly claim.
- The migration is `20260703000000_add_weekly_goals` (a plain `ADD COLUMN`); it was hand-authored since the worktree has no DB — run `prisma migrate dev` / `prisma generate` locally to apply.
