### PR TITLE
fix: 🐛 make FixedReturn beacon optional in Officer deployment

### DIFF
--- a/app/src/constant/index.ts
+++ b/app/src/constant/index.ts
@@ -163,9 +163,10 @@ export function validateAddresses() {
     'CashRemunerationEIP712Module#FactoryBeacon',
     'CashRemunerationEIP712Module#CashRemunerationEIP712',
     'SafeDepositRouterBeaconModule#SafeDepositRouter',
-    'SafeDepositRouterBeaconModule#Beacon',
-    'FixedReturnBeaconModule#Beacon',
-    'FixedReturnBeaconModule#FixedReturn'
+    'SafeDepositRouterBeaconModule#Beacon'
+    // FixedReturn is intentionally excluded: not yet deployed on all networks
+    // (e.g. Polygon prod). It's wired in as an optional beacon — see
+    // getBeaconConfigs()/getDeploymentConfigs() in contractDeploymentUtil.ts.
   ]
 
   requiredKeys.forEach(resolveAddress)

--- a/app/src/utils/__tests__/contractDeploymentUtil.spec.ts
+++ b/app/src/utils/__tests__/contractDeploymentUtil.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { encodeFunctionData, zeroAddress, type Address } from 'viem'
 import {
   validateBeaconAddresses,
@@ -83,5 +83,50 @@ describe('getDeploymentConfigs', () => {
       functionName: 'initialize',
       args: ['Acme', 'ACM', zeroAddress]
     })
+  })
+})
+
+describe('when the FixedReturn beacon is not deployed on the current network', () => {
+  // FixedReturn is only live on hardhat today (Polygon prod hasn't deployed
+  // it yet). Simulate that by nulling the resolved address and re-importing
+  // the module fresh, since the beacon configs/deployment configs are built
+  // from module-level constants.
+  beforeEach(() => {
+    vi.resetModules()
+    vi.doMock('@/constant', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('@/constant')>()),
+      FIXED_RETURN_BEACON_ADDRESS: null
+    }))
+  })
+
+  afterEach(() => {
+    vi.doUnmock('@/constant')
+    vi.resetModules()
+  })
+
+  it('does not throw even though FixedReturn has no beacon address', async () => {
+    const { validateBeaconAddresses: validateWithoutFixedReturn } =
+      await import('../contractDeploymentUtil')
+
+    expect(() => validateWithoutFixedReturn()).not.toThrow()
+  })
+
+  it('omits FixedReturn from the beacon configs', async () => {
+    const { getBeaconConfigs: getBeaconConfigsWithoutFixedReturn } =
+      await import('../contractDeploymentUtil')
+
+    const configs = getBeaconConfigsWithoutFixedReturn()
+    expect(configs.map((c) => c.beaconType)).not.toContain('FixedReturn')
+  })
+
+  it('omits FixedReturn from the deployment configs', async () => {
+    const { getDeploymentConfigs: getDeploymentConfigsWithoutFixedReturn } =
+      await import('../contractDeploymentUtil')
+
+    const configs = getDeploymentConfigsWithoutFixedReturn(CURRENT_USER, {
+      name: 'Acme',
+      symbol: 'ACM'
+    })
+    expect(configs.map((c) => c.contractType)).not.toContain('FixedReturn')
   })
 })

--- a/app/src/utils/__tests__/contractDeploymentUtil.spec.ts
+++ b/app/src/utils/__tests__/contractDeploymentUtil.spec.ts
@@ -7,7 +7,13 @@ import {
 } from '../contractDeploymentUtil'
 import { FIXED_RETURN_ABI } from '@/artifacts/abi/fixed-return'
 import { INVESTOR_ABI } from '@/artifacts/abi/investors'
-import { FIXED_RETURN_BEACON_ADDRESS, USDC_ADDRESS, USDC_E_ADDRESS, USDT_ADDRESS } from '@/constant'
+import {
+  FIXED_RETURN_BEACON_ADDRESS,
+  VESTING_BEACON_ADDRESS,
+  USDC_ADDRESS,
+  USDC_E_ADDRESS,
+  USDT_ADDRESS
+} from '@/constant'
 
 const CURRENT_USER = '0x000000000000000000000000000000000000A1' as Address
 
@@ -23,6 +29,13 @@ describe('getBeaconConfigs', () => {
     const fixedReturn = configs.find((c) => c.beaconType === 'FixedReturn')
 
     expect(fixedReturn?.beaconAddress).toBe(FIXED_RETURN_BEACON_ADDRESS)
+  })
+
+  it('includes a Vesting entry pointing at VESTING_BEACON_ADDRESS', () => {
+    const configs = getBeaconConfigs()
+    const vesting = configs.find((c) => c.beaconType === 'Vesting')
+
+    expect(vesting?.beaconAddress).toBe(VESTING_BEACON_ADDRESS)
   })
 
   it('returns one entry per known beacon type', () => {
@@ -128,5 +141,48 @@ describe('when the FixedReturn beacon is not deployed on the current network', (
       symbol: 'ACM'
     })
     expect(configs.map((c) => c.contractType)).not.toContain('FixedReturn')
+  })
+})
+
+describe('when the Vesting beacon is not deployed on the current network', () => {
+  // Same story as FixedReturn: Vesting is only live on hardhat today
+  // (Polygon prod hasn't deployed it yet).
+  beforeEach(() => {
+    vi.resetModules()
+    vi.doMock('@/constant', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('@/constant')>()),
+      VESTING_BEACON_ADDRESS: null
+    }))
+  })
+
+  afterEach(() => {
+    vi.doUnmock('@/constant')
+    vi.resetModules()
+  })
+
+  it('does not throw even though Vesting has no beacon address', async () => {
+    const { validateBeaconAddresses: validateWithoutVesting } =
+      await import('../contractDeploymentUtil')
+
+    expect(() => validateWithoutVesting()).not.toThrow()
+  })
+
+  it('omits Vesting from the beacon configs', async () => {
+    const { getBeaconConfigs: getBeaconConfigsWithoutVesting } =
+      await import('../contractDeploymentUtil')
+
+    const configs = getBeaconConfigsWithoutVesting()
+    expect(configs.map((c) => c.beaconType)).not.toContain('Vesting')
+  })
+
+  it('omits Vesting from the deployment configs', async () => {
+    const { getDeploymentConfigs: getDeploymentConfigsWithoutVesting } =
+      await import('../contractDeploymentUtil')
+
+    const configs = getDeploymentConfigsWithoutVesting(CURRENT_USER, {
+      name: 'Acme',
+      symbol: 'ACM'
+    })
+    expect(configs.map((c) => c.contractType)).not.toContain('Vesting')
   })
 })

--- a/app/src/utils/contractDeploymentUtil.ts
+++ b/app/src/utils/contractDeploymentUtil.ts
@@ -63,10 +63,10 @@ export const validateBeaconAddresses = (): void => {
     {
       name: 'SAFE_DEPOSIT_ROUTER_BEACON_ADDRESS',
       value: SAFE_DEPOSIT_ROUTER_BEACON_ADDRESS
-    },
-    { name: 'VESTING_BEACON_ADDRESS', value: VESTING_BEACON_ADDRESS }
-    // FixedReturn is optional — not yet deployed on all networks (e.g.
-    // Polygon prod). See getBeaconConfigs()/getDeploymentConfigs() below.
+    }
+    // Vesting and FixedReturn are optional — not yet deployed on all
+    // networks (e.g. Polygon prod). See getBeaconConfigs()/
+    // getDeploymentConfigs() below.
   ]
 
   const missingBeacons = requiredBeacons.filter((beacon) => !beacon.value)
@@ -114,16 +114,19 @@ export const getBeaconConfigs = (): BeaconConfig[] => {
     {
       beaconType: 'SafeDepositRouter',
       beaconAddress: SAFE_DEPOSIT_ROUTER_BEACON_ADDRESS!
-    },
-    {
-      beaconType: 'Vesting',
-      beaconAddress: VESTING_BEACON_ADDRESS!
     }
   ]
 
-  // FixedReturn is only live on networks where its beacon has been deployed
-  // (currently hardhat for testing). Skip it elsewhere instead of failing
-  // the whole Officer deployment.
+  // Vesting and FixedReturn are only live on networks where their beacon has
+  // been deployed (currently hardhat for testing). Skip them elsewhere
+  // instead of failing the whole Officer deployment.
+  if (VESTING_BEACON_ADDRESS) {
+    configs.push({
+      beaconType: 'Vesting',
+      beaconAddress: VESTING_BEACON_ADDRESS
+    })
+  }
+
   if (FIXED_RETURN_BEACON_ADDRESS) {
     configs.push({
       beaconType: 'FixedReturn',
@@ -221,14 +224,17 @@ export const getDeploymentConfigs = (
   })
 
   // Vesting contract — agreement-only; mints the team's InvestorV1 on release.
-  deployments.push({
-    contractType: 'Vesting',
-    initializerData: encodeFunctionData({
-      abi: VESTING_ABI,
-      functionName: 'initialize',
-      args: []
+  // Only when its beacon is deployed on this network.
+  if (VESTING_BEACON_ADDRESS) {
+    deployments.push({
+      contractType: 'Vesting',
+      initializerData: encodeFunctionData({
+        abi: VESTING_ABI,
+        functionName: 'initialize',
+        args: []
+      })
     })
-  })
+  }
 
   // FixedReturn contract — only when its beacon is deployed on this network
   if (FIXED_RETURN_BEACON_ADDRESS) {

--- a/app/src/utils/contractDeploymentUtil.ts
+++ b/app/src/utils/contractDeploymentUtil.ts
@@ -64,8 +64,9 @@ export const validateBeaconAddresses = (): void => {
       name: 'SAFE_DEPOSIT_ROUTER_BEACON_ADDRESS',
       value: SAFE_DEPOSIT_ROUTER_BEACON_ADDRESS
     },
-    { name: 'VESTING_BEACON_ADDRESS', value: VESTING_BEACON_ADDRESS },
-    { name: 'FIXED_RETURN_BEACON_ADDRESS', value: FIXED_RETURN_BEACON_ADDRESS }
+    { name: 'VESTING_BEACON_ADDRESS', value: VESTING_BEACON_ADDRESS }
+    // FixedReturn is optional — not yet deployed on all networks (e.g.
+    // Polygon prod). See getBeaconConfigs()/getDeploymentConfigs() below.
   ]
 
   const missingBeacons = requiredBeacons.filter((beacon) => !beacon.value)
@@ -81,7 +82,7 @@ export const validateBeaconAddresses = (): void => {
  * @returns Array of beacon configurations
  */
 export const getBeaconConfigs = (): BeaconConfig[] => {
-  return [
+  const configs: BeaconConfig[] = [
     {
       beaconType: 'Bank',
       beaconAddress: BANK_BEACON_ADDRESS!
@@ -117,12 +118,20 @@ export const getBeaconConfigs = (): BeaconConfig[] => {
     {
       beaconType: 'Vesting',
       beaconAddress: VESTING_BEACON_ADDRESS!
-    },
-    {
-      beaconType: 'FixedReturn',
-      beaconAddress: FIXED_RETURN_BEACON_ADDRESS!
     }
   ]
+
+  // FixedReturn is only live on networks where its beacon has been deployed
+  // (currently hardhat for testing). Skip it elsewhere instead of failing
+  // the whole Officer deployment.
+  if (FIXED_RETURN_BEACON_ADDRESS) {
+    configs.push({
+      beaconType: 'FixedReturn',
+      beaconAddress: FIXED_RETURN_BEACON_ADDRESS
+    })
+  }
+
+  return configs
 }
 
 /**
@@ -221,15 +230,17 @@ export const getDeploymentConfigs = (
     })
   })
 
-  // FixedReturn contract
-  deployments.push({
-    contractType: 'FixedReturn',
-    initializerData: encodeFunctionData({
-      abi: FIXED_RETURN_ABI,
-      functionName: 'initialize',
-      args: [[USDT_ADDRESS, USDC_ADDRESS, USDC_E_ADDRESS], currentUserAddress]
+  // FixedReturn contract — only when its beacon is deployed on this network
+  if (FIXED_RETURN_BEACON_ADDRESS) {
+    deployments.push({
+      contractType: 'FixedReturn',
+      initializerData: encodeFunctionData({
+        abi: FIXED_RETURN_ABI,
+        functionName: 'initialize',
+        args: [[USDT_ADDRESS, USDC_ADDRESS, USDC_E_ADDRESS], currentUserAddress]
+      })
     })
-  })
+  }
 
   return deployments
 }


### PR DESCRIPTION
## Problem

Officer deployment fails on Polygon (chain 137) because two beacons required unconditionally aren't actually deployed there yet — they only exist on hardhat for testing:

```
Officer deploy failed
Address not defined for "FixedReturnBeaconModule#Beacon" on chain 137
```
```
Officer deploy failed
Missing beacon addresses: VESTING_BEACON_ADDRESS
```

Because `validateAddresses()` and `validateBeaconAddresses()` required both beacons unconditionally on every chain, the entire Officer deployment flow (Bank, Proposals, Elections, etc.) was blocked on prod, not just the two sub-contracts that aren't live there yet.

## Fix

Make FixedReturn and Vesting beacons optional: when a beacon address doesn't resolve for the current chain, skip that sub-contract from the beacon configs and deployment configs instead of failing the whole Officer deployment.

- `app/src/constant/index.ts`: dropped the FixedReturn keys from `validateAddresses()`'s required list (Vesting was already optional there).
- `app/src/utils/contractDeploymentUtil.ts`: dropped FixedReturn and Vesting from `validateBeaconAddresses()`'s required list, and only push their entries into `getBeaconConfigs()` / `getDeploymentConfigs()` when the corresponding beacon address is defined.

Officer deployment now succeeds on Polygon without FixedReturn/Vesting; both stay fully wired on hardhat for continued testing.

## Follow-up

Once each beacon is deployed to Polygon prod, this becomes a no-op for it — the address resolves and the sub-contract is included again automatically.

Closes #2250

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Build, type-check, and unit tests pass (including new coverage for the beacon-absent branches)
- [x] Commit messages follow repo conventions