### PR TITLE
chore: 🔧 gitignore .codex and scripts directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ backend/.env.production
 app/.env.production
 .mcp.json
 
+# Codex and scripts directories
+.codex/
+scripts/
+
 # Local review / architecture notes (not for public repo)
 /reviews/
 /archi-update.md


### PR DESCRIPTION
## Summary

Add .codex/ and scripts/ directories to .gitignore to prevent them from being tracked in version control.

## Changes

- Added .codex/ entry
- Added scripts/ entry

Closes #2271