### PR TITLE
feat: ✨ index Bank transfer fees in Ponder with a non-fabricating derived fallback

### DIFF
--- a/ponder/abis/fee-collector.ts
+++ b/ponder/abis/fee-collector.ts
@@ -170,4 +170,20 @@ export const FEE_COLLECTOR_ABI = [
     name: "Withdrawn",
     type: "event",
   },
+  // View functions read by the indexer to derive the per-transfer Bank fee when
+  // no FeePaid event is present for a transfer (see src/index.ts).
+  {
+    inputs: [{ internalType: "string", name: "contractType", type: "string" }],
+    name: "getFeeFor",
+    outputs: [{ internalType: "uint16", name: "", type: "uint16" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "_token", type: "address" }],
+    name: "isTokenSupported",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
 ] as const

--- a/ponder/ponder.config.ts
+++ b/ponder/ponder.config.ts
@@ -73,6 +73,12 @@ const feeCollectorAddress = (process.env.FEE_COLLECTOR_ADDRESS ??
 if (!feeCollectorAddress)
   throw new Error(missing("FeeCollector", "FEE_COLLECTOR_ADDRESS"));
 
+// The (global, singleton) FeeCollector address, re-exported so indexing
+// functions can read `getFeeFor` / `isTokenSupported` when deriving a Bank
+// transfer's fee. Every Officer is constructed with this same collector, so a
+// single address covers every team's Bank.
+export const FEE_COLLECTOR_ADDRESS: `0x${string}` = feeCollectorAddress;
+
 // On Hardhat start from block 0; on Polygon skip pre-deployment blocks.
 const startBlock = isHardhat ? 0 : Number(process.env.START_BLOCK);
 

--- a/ponder/src/index.ts
+++ b/ponder/src/index.ts
@@ -65,6 +65,81 @@ import {
   feeCollectorTokenSupportAdded,
   feeCollectorTokenSupportRemoved,
 } from "ponder:schema";
+import { FEE_COLLECTOR_ABI } from "../abis/fee-collector";
+import { FEE_COLLECTOR_ADDRESS } from "../ponder.config";
+
+// ─── Bank fee derivation ─────────────────────────────────────────────────────
+// The Bank charges a protocol fee (default 0.5%) on every outbound transfer to
+// another contract, skimmed to the FeeCollector, which emits the authoritative
+// `FeePaid` event carrying the exact fee. That event is indexed into
+// `bankFeePaid` keyed by transaction hash (one Bank transfer = one fee per tx).
+//
+// When a Bank transfer has **no** matching `FeePaid` in the same transaction —
+// e.g. the FeeCollector wasn't yet in the indexed range — we recover the fee
+// here so the ledger still sees it. This never fabricates a fee: we read the
+// fee rate (and, for tokens, whether the token is fee-charged) from the
+// FeeCollector at the transfer's block, so a zero rate or an unsupported token
+// yields no row, exactly like the contract. The exact `FeePaid` always wins:
+// it runs first (lower log index) and this helper skips when its row exists.
+async function indexDerivedBankFee(
+  context: { db: any; client: any },
+  args: {
+    txHash: `0x${string}`;
+    bank: `0x${string}`;
+    token: `0x${string}` | null;
+    net: bigint;
+    blockNumber: bigint;
+    timestamp: number;
+  },
+): Promise<void> {
+  const { txHash, bank, token, net, blockNumber, timestamp } = args;
+
+  // Authoritative on-chain fee already indexed for this tx — leave it untouched.
+  const existing = await context.db.find(bankFeePaid, { id: txHash });
+  if (existing) return;
+
+  // Fee rate in basis points at the transfer's block. 0 ⇒ no fee was charged.
+  const rawBps = await context.client.readContract({
+    abi: FEE_COLLECTOR_ABI,
+    address: FEE_COLLECTOR_ADDRESS,
+    functionName: "getFeeFor",
+    args: ["BANK"],
+    blockNumber,
+  });
+  const bps = BigInt(rawBps);
+  if (bps === 0n) return;
+
+  // ERC20 fees apply only to FeeCollector-supported tokens; native (token null)
+  // always pays when the rate is non-zero — mirrors Bank.transferToken.
+  if (token !== null) {
+    const supported = await context.client.readContract({
+      abi: FEE_COLLECTOR_ABI,
+      address: FEE_COLLECTOR_ADDRESS,
+      functionName: "isTokenSupported",
+      args: [token],
+      blockNumber,
+    });
+    if (!supported) return;
+  }
+
+  // The Bank event carries the NET (gross − fee). Recover the fee with the same
+  // basis-point math the contract used: fee = net · bps / (10000 − bps).
+  const fee = (net * bps) / (10_000n - bps);
+  if (fee === 0n) return;
+
+  await context.db
+    .insert(bankFeePaid)
+    .values({
+      id: txHash,
+      contractAddress: bank,
+      feeCollector: FEE_COLLECTOR_ADDRESS,
+      token,
+      amount: fee,
+      blockNumber,
+      timestamp,
+    })
+    .onConflictDoNothing();
+}
 
 // ─── Officer Factory ─────────────────────────────────────────────────────────
 
@@ -130,6 +205,16 @@ ponder.on("Bank:Transfer", async ({ event, context }) => {
     blockNumber: event.block.number,
     timestamp: Number(event.block.timestamp),
   });
+
+  // Native transfers pay the fee whenever the rate is non-zero (token: null).
+  await indexDerivedBankFee(context, {
+    txHash: event.transaction.hash,
+    bank: event.log.address,
+    token: null,
+    net: event.args.amount,
+    blockNumber: event.block.number,
+    timestamp: Number(event.block.timestamp),
+  });
 });
 
 ponder.on("Bank:TokenTransfer", async ({ event, context }) => {
@@ -143,20 +228,43 @@ ponder.on("Bank:TokenTransfer", async ({ event, context }) => {
     blockNumber: event.block.number,
     timestamp: Number(event.block.timestamp),
   });
+
+  await indexDerivedBankFee(context, {
+    txHash: event.transaction.hash,
+    bank: event.log.address,
+    token: event.args.token,
+    net: event.args.amount,
+    blockNumber: event.block.number,
+    timestamp: Number(event.block.timestamp),
+  });
 });
 
 ponder.on("FeeCollector:FeePaid", async ({ event, context }) => {
   const id = `${event.transaction.hash}-${event.log.logIndex}`;
 
-  await context.db.insert(bankFeePaid).values({
-    id,
-    contractAddress: event.args.payer,
-    feeCollector: event.log.address,
-    token: event.args.token,
-    amount: event.args.amount,
-    blockNumber: event.block.number,
-    timestamp: Number(event.block.timestamp),
-  });
+  // Authoritative per-transfer fee: keyed by transaction hash so it dedups with
+  // any row the derived-fee fallback may write for the same Bank transfer, and
+  // the exact on-chain amount always wins (onConflictDoUpdate). One Bank
+  // transfer charges at most one fee per tx.
+  await context.db
+    .insert(bankFeePaid)
+    .values({
+      id: event.transaction.hash,
+      contractAddress: event.args.payer,
+      feeCollector: event.log.address,
+      token: event.args.token,
+      amount: event.args.amount,
+      blockNumber: event.block.number,
+      timestamp: Number(event.block.timestamp),
+    })
+    .onConflictDoUpdate({
+      contractAddress: event.args.payer,
+      feeCollector: event.log.address,
+      token: event.args.token,
+      amount: event.args.amount,
+      blockNumber: event.block.number,
+      timestamp: Number(event.block.timestamp),
+    });
 
   await context.db.insert(feeCollectorFeePaid).values({
     id,


### PR DESCRIPTION
## Description

Bank transfers charge a 0.5% protocol fee that only reached the accounting layer through the FeeCollector's `FeePaid` event, so it showed as $0 whenever that event wasn't indexed. This indexes the fee directly in the Bank transfer handlers — using the exact `FeePaid` when present, otherwise deriving it from the transfer's net amount and the live fee rate — without ever fabricating a fee when none was actually charged.
