### PR TITLE
feat: ✨ allow duplicate team names with a unique slug

### DIFF
--- a/app/src/components/forms/AddTeamForm.vue
+++ b/app/src/components/forms/AddTeamForm.vue
@@ -16,7 +16,7 @@
         label="Company Name"
         name="name"
         required
-        help="Give your company a unique, recognizable name"
+        help="Give your company a recognizable name"
       >
         <UInput
           v-model="teamData.name"

--- a/app/src/tests/mocks/query.mock.ts
+++ b/app/src/tests/mocks/query.mock.ts
@@ -32,6 +32,7 @@ export const mockMembersData: User[] = [
 export const mockTeamData: Team = {
   id: '1',
   name: 'Test Team',
+  slug: 'test-team',
   description: 'Test Team Description',
   members: [
     mockMembersData[0] as Member,

--- a/app/src/types/team.ts
+++ b/app/src/types/team.ts
@@ -34,6 +34,12 @@ export interface CurrentOfficer {
 export interface Team {
   id: string
   name: string
+  /**
+   * Unique, URL-friendly identifier auto-generated from `name` on creation.
+   * Names are no longer unique — teams may share one — so the slug is what
+   * distinguishes homonyms (e.g. `acme-corp`, `acme-corp-2`).
+   */
+  slug: string
   description: string
   isHidden: boolean
   isArchived: boolean

--- a/backend/prisma/migrations/20260710130001_team_unique_slug/migration.sql
+++ b/backend/prisma/migrations/20260710130001_team_unique_slug/migration.sql
@@ -1,0 +1,47 @@
+-- Teams may now share a name; uniqueness moves to a generated `slug`.
+
+-- DropIndex
+DROP INDEX "Team_name_key";
+
+-- AlterTable: add slug (nullable during backfill)
+ALTER TABLE "Team" ADD COLUMN "slug" TEXT;
+
+-- Backfill slugs from existing names, de-duplicating homonyms with a numeric
+-- suffix (acme-corp, acme-corp-2, …). Names that slugify to nothing fall back
+-- to `team`.
+WITH base AS (
+  SELECT
+    "id",
+    COALESCE(
+      NULLIF(trim(BOTH '-' FROM regexp_replace(lower("name"), '[^a-z0-9]+', '-', 'g')), ''),
+      'team'
+    ) AS root
+  FROM "Team"
+),
+numbered AS (
+  SELECT
+    "id",
+    root,
+    row_number() OVER (PARTITION BY root ORDER BY "id") AS rn
+  FROM base
+)
+UPDATE "Team" t
+SET "slug" = CASE WHEN n.rn = 1 THEN n.root ELSE n.root || '-' || n.rn::text END
+FROM numbered n
+WHERE t."id" = n."id";
+
+-- Safety net: names were globally unique, but two distinct names can still
+-- slugify into the same value across partitions (e.g. "Acme" -> acme-2 and
+-- "Acme 2" -> acme-2). Break any residual collision with the row's unique id
+-- so the unique index below never aborts the migration.
+UPDATE "Team" t
+SET "slug" = t."slug" || '-' || t."id"::text
+WHERE EXISTS (
+  SELECT 1 FROM "Team" o WHERE o."slug" = t."slug" AND o."id" <> t."id"
+);
+
+-- Enforce NOT NULL + uniqueness
+ALTER TABLE "Team" ALTER COLUMN "slug" SET NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Team_slug_key" ON "Team"("slug");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -44,7 +44,8 @@ model Team {
   owner                  User                     @relation("OwnedTeams", fields: [ownerAddress], references: [address], onDelete: Restrict)
   ownerAddress           String
   description            String?
-  name                   String                   @unique
+  name                   String
+  slug                   String                   @unique
   isArchived             Boolean                  @default(false)
   BoardOfDirectorActions BoardOfDirectorActions[]
   teamContracts          TeamContract[]

--- a/backend/prisma/seeders/teams.ts
+++ b/backend/prisma/seeders/teams.ts
@@ -4,6 +4,7 @@ import { PrismaClient, User } from '@prisma/client';
 import { faker } from '@faker-js/faker';
 import { type SeedConfig } from './config';
 import { distributeDate } from './helpers';
+import { generateUniqueSlug } from '../../src/utils/slug.util';
 
 // All available contract types
 const CONTRACT_TYPES = [
@@ -36,13 +37,20 @@ export async function seedTeams(prisma: PrismaClient, config: SeedConfig, users:
     // All team members including owner
     const allMembers = [owner, ...selectedUsers];
 
+    // Slug is unique even when faker hands us the same company name twice.
+    const name = faker.company.name();
+    const slug = await generateUniqueSlug(name, async (candidate) =>
+      Boolean(await prisma.team.findUnique({ where: { slug: candidate }, select: { id: true } }))
+    );
+
     // Create team with owner, members, current Officer, and memberships.
     // Contracts are created in a follow-up step so we can link them to both
     // the team (required FK) and the officer (so they surface via the
     // currentOfficerWithContractsInclude relation).
     const team = await prisma.team.create({
       data: {
-        name: faker.company.name(),
+        name,
+        slug,
         description: faker.company.catchPhrase(),
         ownerAddress: owner.address,
         createdAt: teamCreatedAt,

--- a/backend/src/controllers/__tests__/teamController.test.ts
+++ b/backend/src/controllers/__tests__/teamController.test.ts
@@ -250,6 +250,37 @@ describe('Team Controller', () => {
       expect(response.status).toBe(500);
       expect(response.body.message).toBe('Internal server error has occured');
     });
+
+    it('auto-generates a slug from the team name', async () => {
+      vi.spyOn(prisma.user, 'findUnique').mockResolvedValue(mockOwner);
+      vi.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
+      vi.spyOn(prisma.team, 'create').mockResolvedValue(teamMockResolve);
+
+      const response = await request(app)
+        .post('/')
+        .send({ ...mockTeamData, name: 'Acme Corp' });
+
+      expect(response.status).toBe(201);
+      const createCall = vi.mocked(prisma.team.create).mock.calls[0][0];
+      expect(createCall.data).toMatchObject({ slug: 'acme-corp' });
+    });
+
+    it('appends a numeric suffix when the slug is already taken', async () => {
+      vi.spyOn(prisma.user, 'findUnique').mockResolvedValue(mockOwner);
+      // `acme-corp` is taken; the next candidate is free.
+      vi.spyOn(prisma.team, 'findUnique').mockImplementation((async (args: {
+        where: { slug: string };
+      }) => (args.where.slug === 'acme-corp' ? { id: 1 } : null)) as never);
+      vi.spyOn(prisma.team, 'create').mockResolvedValue(teamMockResolve);
+
+      const response = await request(app)
+        .post('/')
+        .send({ ...mockTeamData, name: 'Acme Corp' });
+
+      expect(response.status).toBe(201);
+      const createCall = vi.mocked(prisma.team.create).mock.calls[0][0];
+      expect(createCall.data).toMatchObject({ slug: 'acme-corp-2' });
+    });
   });
 
   describe('getTeam', () => {

--- a/backend/src/controllers/__tests__/teamController.test.ts
+++ b/backend/src/controllers/__tests__/teamController.test.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { Team, User } from '@prisma/client';
+import { Prisma, Team, User } from '@prisma/client';
 import express, { NextFunction, Request, Response } from 'express';
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -280,6 +280,36 @@ describe('Team Controller', () => {
       expect(response.status).toBe(201);
       const createCall = vi.mocked(prisma.team.create).mock.calls[0][0];
       expect(createCall.data).toMatchObject({ slug: 'acme-corp-2' });
+    });
+
+    it('retries once with a fresh slug when the insert loses a unique-constraint race', async () => {
+      vi.spyOn(prisma.user, 'findUnique').mockResolvedValue(mockOwner);
+      vi.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
+      const slugRace = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: '6.19.2',
+      });
+      vi.spyOn(prisma.team, 'create')
+        .mockRejectedValueOnce(slugRace)
+        .mockResolvedValueOnce(teamMockResolve);
+
+      const response = await request(app)
+        .post('/')
+        .send({ ...mockTeamData, name: 'Acme Corp' });
+
+      expect(response.status).toBe(201);
+      expect(prisma.team.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('surfaces a 500 when team creation fails for a non-slug reason', async () => {
+      vi.spyOn(prisma.user, 'findUnique').mockResolvedValue(mockOwner);
+      vi.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);
+      vi.spyOn(prisma.team, 'create').mockRejectedValue(new Error('DB down'));
+
+      const response = await request(app).post('/').send(mockTeamData);
+
+      expect(response.status).toBe(500);
+      expect(prisma.team.create).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/backend/src/controllers/teamController.ts
+++ b/backend/src/controllers/teamController.ts
@@ -1,10 +1,15 @@
-import { TeamContract, TeamOfficer, User } from '@prisma/client';
+import { Prisma, TeamContract, TeamOfficer, User } from '@prisma/client';
 import { Request, Response } from 'express';
 import { isAddress } from 'viem';
 import { addNotification, prisma } from '../utils';
 import { errorResponse } from '../utils/utils';
 import { resolveStorageImageUrl } from '../utils/profileImage.util';
+import { generateUniqueSlug } from '../utils/slug.util';
 import { CURRENT_OFFICER_VERSION } from './contractController';
+
+// A slug is taken when some team already holds it.
+const isTeamSlugTaken = async (slug: string) =>
+  Boolean(await prisma.team.findUnique({ where: { slug }, select: { id: true } }));
 
 // Shared: include the immediate predecessor (id + address only) so clients
 // can walk one step back for copy-forward flows (e.g. shareholder migration)
@@ -135,33 +140,50 @@ const addTeam = async (req: Request, res: Response) => {
       });
     }
 
-    // Create the team with the members connected and membership tracking records
-    const team = await prisma.team.create({
-      data: {
-        name,
-        description,
-        isArchived: false,
-        ownerAddress: String(callerAddress),
-        members: {
-          connect: members.map((member: User) => ({
-            address: member.address,
-          })),
-        },
-        memberTeamsData: {
-          create: members.map((member: User) => ({
-            memberAddress: member.address,
-          })),
-        },
-      },
-      include: {
-        members: {
-          select: {
-            address: true,
-            name: true,
+    // Teams may share a name; the unique identifier is a slug auto-generated
+    // from the name (acme-corp, acme-corp-2, …).
+    const createTeamWithSlug = (slug: string) =>
+      prisma.team.create({
+        data: {
+          name,
+          slug,
+          description,
+          isArchived: false,
+          ownerAddress: String(callerAddress),
+          members: {
+            connect: members.map((member: User) => ({
+              address: member.address,
+            })),
+          },
+          memberTeamsData: {
+            create: members.map((member: User) => ({
+              memberAddress: member.address,
+            })),
           },
         },
-      },
-    });
+        include: {
+          members: {
+            select: {
+              address: true,
+              name: true,
+            },
+          },
+        },
+      });
+
+    // Create the team with the members connected and membership tracking records.
+    let team;
+    try {
+      team = await createTeamWithSlug(await generateUniqueSlug(name, isTeamSlugTaken));
+    } catch (error: unknown) {
+      // Rare race: another team claimed the slug between the uniqueness check
+      // and the insert. Regenerate once and retry before giving up.
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        team = await createTeamWithSlug(await generateUniqueSlug(name, isTeamSlugTaken));
+      } else {
+        throw error;
+      }
+    }
 
     addNotification(
       members.map((member: User) => member.address),

--- a/backend/src/utils/__tests__/slug.util.test.ts
+++ b/backend/src/utils/__tests__/slug.util.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { generateUniqueSlug, slugify } from '../slug.util';
+
+describe('slugify', () => {
+  it('lowercases and hyphenates words', () => {
+    expect(slugify('Acme Corp')).toBe('acme-corp');
+  });
+
+  it('collapses runs of non-alphanumerics into a single hyphen', () => {
+    expect(slugify('Acme   Corp!!! & Co')).toBe('acme-corp-co');
+  });
+
+  it('trims leading and trailing hyphens', () => {
+    expect(slugify('  --Hello World--  ')).toBe('hello-world');
+  });
+
+  it('keeps digits', () => {
+    expect(slugify('Team 42')).toBe('team-42');
+  });
+
+  it('drops accented / non-ascii characters', () => {
+    expect(slugify('Café Déjà')).toBe('caf-d-j');
+  });
+
+  it('falls back to "team" when nothing usable remains', () => {
+    expect(slugify('!!!')).toBe('team');
+    expect(slugify('   ')).toBe('team');
+    expect(slugify('')).toBe('team');
+  });
+
+  it('always produces a value that matches the slug regex', () => {
+    const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+    expect(slugify('Hello, World! 123')).toMatch(slugRegex);
+    expect(slugify('###')).toMatch(slugRegex);
+  });
+});
+
+describe('generateUniqueSlug', () => {
+  it('returns the base slug when it is free', async () => {
+    const exists = vi.fn().mockResolvedValue(false);
+    await expect(generateUniqueSlug('Acme Corp', exists)).resolves.toBe('acme-corp');
+    expect(exists).toHaveBeenCalledWith('acme-corp');
+    expect(exists).toHaveBeenCalledTimes(1);
+  });
+
+  it('appends -2 on the first collision', async () => {
+    const exists = vi.fn(async (slug: string) => slug === 'acme-corp');
+    await expect(generateUniqueSlug('Acme Corp', exists)).resolves.toBe('acme-corp-2');
+  });
+
+  it('keeps incrementing until a free slug is found', async () => {
+    const taken = new Set(['acme-corp', 'acme-corp-2', 'acme-corp-3']);
+    const exists = vi.fn(async (slug: string) => taken.has(slug));
+    await expect(generateUniqueSlug('Acme Corp', exists)).resolves.toBe('acme-corp-4');
+  });
+
+  it('slugifies the base before checking', async () => {
+    const exists = vi.fn().mockResolvedValue(false);
+    await expect(generateUniqueSlug('  Weird Name!! ', exists)).resolves.toBe('weird-name');
+    expect(exists).toHaveBeenCalledWith('weird-name');
+  });
+});

--- a/backend/src/utils/slug.util.ts
+++ b/backend/src/utils/slug.util.ts
@@ -17,8 +17,13 @@
 export const slugify = (input: string): string => {
   const slug = input
     .toLowerCase()
+    // Collapse every run of non-alphanumerics to a single hyphen. After this
+    // the string never contains consecutive hyphens…
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    // …so trimming a single leading/trailing hyphen is enough — no `+`
+    // quantifier, which keeps the match linear (avoids the polynomial-regex
+    // ReDoS class CodeQL flags on user-controlled input).
+    .replace(/^-|-$/g, '');
   return slug || 'team';
 };
 

--- a/backend/src/utils/slug.util.ts
+++ b/backend/src/utils/slug.util.ts
@@ -1,0 +1,45 @@
+/**
+ * URL-friendly slug helpers.
+ *
+ * Kept dependency-free (no Prisma import) so the uniqueness strategy can be
+ * unit-tested with a fake `exists` predicate and reused by any caller that
+ * knows how to check its own store (controller, seeder, …).
+ */
+
+/**
+ * Turn an arbitrary string into a slug: lowercase, non-alphanumeric runs
+ * collapsed to a single hyphen, no leading/trailing hyphens. Falls back to
+ * `'team'` when the input has no usable characters (e.g. only symbols).
+ *
+ * The output always satisfies the shared `slugSchema` regex
+ * (`^[a-z0-9]+(?:-[a-z0-9]+)*$`) in `validation/utils.ts`.
+ */
+export const slugify = (input: string): string => {
+  const slug = input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'team';
+};
+
+/**
+ * Build a unique slug from `base` by appending a numeric suffix on collision:
+ * `acme-corp`, then `acme-corp-2`, `acme-corp-3`, … until `exists` reports the
+ * candidate is free.
+ *
+ * @param base   raw string to slugify (e.g. a team name)
+ * @param exists resolves `true` when the candidate slug is already taken
+ */
+export const generateUniqueSlug = async (
+  base: string,
+  exists: (slug: string) => Promise<boolean>
+): Promise<string> => {
+  const root = slugify(base);
+  let candidate = root;
+  let suffix = 1;
+  while (await exists(candidate)) {
+    suffix += 1;
+    candidate = `${root}-${suffix}`;
+  }
+  return candidate;
+};


### PR DESCRIPTION
Closes #2276

## What

Teams can now share a display **name**; uniqueness moves to a new, auto-generated **`slug`**.

- **Schema**: `Team.name` drops `@unique`; add `Team.slug String @unique`.
- **Slug generation**: `slugify(name)` + numeric suffix on collision (`acme-corp`, `acme-corp-2`, …), wired in `addTeam` and the seeder. The util (`backend/src/utils/slug.util.ts`) is a dependency-free pure function (`slugify` + `generateUniqueSlug(base, exists)`), so the store check is injected and trivially unit-testable.
- **Race guard**: on a `P2002` between the uniqueness check and the insert, the controller regenerates the slug and retries once.
- **Migration** (`20260710130001_team_unique_slug`): drops the name unique index, backfills slugs from existing names (de-duping homonyms), then a safety pass appends the row `id` to any residual cross-partition collision **before** creating the unique index, so it never aborts on real data.
- **Frontend**: `slug` added to the `Team` type; removed the now-inaccurate "unique" wording from the create-company name hint. Routing is unchanged (still by numeric `id`).

## Scope

Uniqueness only. Slug-based URLs and user-editable slugs are intentionally out of scope.

## Verification

- Backend unit suite: **666 passing** (incl. new `slug.util` tests and two `addTeam` slug tests).
- App: `type-check` clean, unit suite **2258 passing**.
- Migration backfill run against an ephemeral Postgres with edge cases (homonyms, symbol-only names, the `Acme` / `Acme 2` cross-partition collision, accents) — all slugs unique, `CREATE UNIQUE INDEX` succeeds.

> Apply the migration (`prisma migrate deploy`) in each environment on merge.