### PR TITLE
Bugfix/Add Fee badge

### DIFF
--- a/app/src/components/sections/AccountingView/GeneralLedger.vue
+++ b/app/src/components/sections/AccountingView/GeneralLedger.vue
@@ -16,11 +16,23 @@
               <span class="text-[15px] font-semibold">General ledger</span>
               <UBadge color="primary" variant="subtle" :label="`${total} entries`" />
             </div>
-            <SegmentedPills
-              :items="categoryItems"
-              :model-value="filter"
-              @update:model-value="filter = $event"
-            />
+            <div class="flex items-center gap-2">
+              <SegmentedPills
+                :items="categoryItems"
+                :model-value="filter"
+                @update:model-value="filter = $event"
+              />
+              <UButton
+                :variant="feeOnly ? 'solid' : 'outline'"
+                :color="feeOnly ? 'warning' : 'neutral'"
+                size="xs"
+                icon="i-heroicons-receipt-percent"
+                label="Fee"
+                :aria-pressed="feeOnly"
+                data-test="ledger-fee-filter"
+                @click="feeOnly = !feeOnly"
+              />
+            </div>
           </div>
 
           <!-- Reporting period + show/hide columns -->
@@ -71,6 +83,9 @@ import {
   ledgerRows,
   ledgerTotal,
   ledgerCategories,
+  entryHasFee,
+  ledgerFeeRows,
+  ledgerFeeTotal,
   LEDGER_COLUMNS,
   type LedgerColumnKey
 } from '@/utils/accounting/ledgerPresenter'
@@ -88,6 +103,10 @@ const visibleColumns = useLocalStorage<LedgerColumnKey[]>(
 // rather than snapping back to "All".
 const filter = useLocalStorage('ledger_active_category_filter', 'All')
 
+// "Fee only" toggle — isolates the Transaction Fee Expense legs. Layered on top
+// of the category / period filters, so it composes with whatever tab is active.
+const feeOnly = useLocalStorage('ledger_fee_only', false)
+
 // Reporting period (range mode) — defaults to "All time" (whole book).
 const period = ref<Range>(defaultValueForMode('range') as Range)
 
@@ -98,18 +117,27 @@ const acc = useAccountingContext()
 // Filter once, paginate by entry (a posting spans two rows), then flatten the
 // current page into table rows. The "Total movements" figure stays the grand
 // total across the whole filtered book, not just the page.
-const filtered = computed(() =>
-  filterLedgerEntries(acc.entries.value, filter.value, period.value.start, period.value.end)
-)
+const filtered = computed(() => {
+  const entries = filterLedgerEntries(
+    acc.entries.value,
+    filter.value,
+    period.value.start,
+    period.value.end
+  )
+  return feeOnly.value ? entries.filter(entryHasFee) : entries
+})
 const total = computed(() => filtered.value.length)
-const grandTotal = computed(() => ledgerTotal(filtered.value))
+const grandTotal = computed(() =>
+  feeOnly.value ? ledgerFeeTotal(filtered.value) : ledgerTotal(filtered.value)
+)
 
 const { page, pageSize, reset } = usePagination(() => total.value, { key: 'ledger' })
-watch([filter, period], reset, { deep: true })
+watch([filter, period, feeOnly], reset, { deep: true })
 
 const pageRows = computed(() => {
   const start = (page.value - 1) * pageSize.value
-  return ledgerRows(filtered.value.slice(start, start + pageSize.value))
+  const slice = filtered.value.slice(start, start + pageSize.value)
+  return feeOnly.value ? ledgerFeeRows(slice) : ledgerRows(slice)
 })
 
 // A real date window is in play only when the picker isn't on "All time" (whose

--- a/app/src/components/sections/AccountingView/GeneralLedger.vue
+++ b/app/src/components/sections/AccountingView/GeneralLedger.vue
@@ -16,23 +16,11 @@
               <span class="text-[15px] font-semibold">General ledger</span>
               <UBadge color="primary" variant="subtle" :label="`${total} entries`" />
             </div>
-            <div class="flex items-center gap-2">
-              <SegmentedPills
-                :items="categoryItems"
-                :model-value="filter"
-                @update:model-value="filter = $event"
-              />
-              <UButton
-                :variant="feeOnly ? 'solid' : 'outline'"
-                :color="feeOnly ? 'warning' : 'neutral'"
-                size="xs"
-                icon="i-heroicons-receipt-percent"
-                label="Fee"
-                :aria-pressed="feeOnly"
-                data-test="ledger-fee-filter"
-                @click="feeOnly = !feeOnly"
-              />
-            </div>
+            <SegmentedPills
+              :items="categoryItems"
+              :model-value="filter"
+              @update:model-value="filter = $event"
+            />
           </div>
 
           <!-- Reporting period + show/hide columns -->
@@ -83,9 +71,9 @@ import {
   ledgerRows,
   ledgerTotal,
   ledgerCategories,
-  entryHasFee,
   ledgerFeeRows,
   ledgerFeeTotal,
+  FEE_FILTER,
   LEDGER_COLUMNS,
   type LedgerColumnKey
 } from '@/utils/accounting/ledgerPresenter'
@@ -100,12 +88,9 @@ const visibleColumns = useLocalStorage<LedgerColumnKey[]>(
 )
 
 // Active category filter — persisted so a reload keeps the user's chosen tab
-// rather than snapping back to "All".
+// rather than snapping back to "All". `Fee` is a pseudo-category pill that
+// isolates the Transaction Fee Expense legs (see filterLedgerEntries).
 const filter = useLocalStorage('ledger_active_category_filter', 'All')
-
-// "Fee only" toggle — isolates the Transaction Fee Expense legs. Layered on top
-// of the category / period filters, so it composes with whatever tab is active.
-const feeOnly = useLocalStorage('ledger_fee_only', false)
 
 // Reporting period (range mode) — defaults to "All time" (whole book).
 const period = ref<Range>(defaultValueForMode('range') as Range)
@@ -117,27 +102,22 @@ const acc = useAccountingContext()
 // Filter once, paginate by entry (a posting spans two rows), then flatten the
 // current page into table rows. The "Total movements" figure stays the grand
 // total across the whole filtered book, not just the page.
-const filtered = computed(() => {
-  const entries = filterLedgerEntries(
-    acc.entries.value,
-    filter.value,
-    period.value.start,
-    period.value.end
-  )
-  return feeOnly.value ? entries.filter(entryHasFee) : entries
-})
+const filtered = computed(() =>
+  filterLedgerEntries(acc.entries.value, filter.value, period.value.start, period.value.end)
+)
+const isFeeFilter = computed(() => filter.value === FEE_FILTER)
 const total = computed(() => filtered.value.length)
 const grandTotal = computed(() =>
-  feeOnly.value ? ledgerFeeTotal(filtered.value) : ledgerTotal(filtered.value)
+  isFeeFilter.value ? ledgerFeeTotal(filtered.value) : ledgerTotal(filtered.value)
 )
 
 const { page, pageSize, reset } = usePagination(() => total.value, { key: 'ledger' })
-watch([filter, period, feeOnly], reset, { deep: true })
+watch([filter, period], reset, { deep: true })
 
 const pageRows = computed(() => {
   const start = (page.value - 1) * pageSize.value
   const slice = filtered.value.slice(start, start + pageSize.value)
-  return feeOnly.value ? ledgerFeeRows(slice) : ledgerRows(slice)
+  return isFeeFilter.value ? ledgerFeeRows(slice) : ledgerRows(slice)
 })
 
 // A real date window is in play only when the picker isn't on "All time" (whose

--- a/app/src/components/sections/AccountingView/LedgerTable.vue
+++ b/app/src/components/sections/AccountingView/LedgerTable.vue
@@ -49,14 +49,16 @@
     </template>
 
     <template #account-cell="{ row: { original: row } }">
-      <span
-        v-if="!row.isTotal"
-        class="text-sm tabular-nums"
-        :class="
-          row.accountDimmed ? 'text-dimmed' : row.accountMuted ? 'text-muted' : 'text-default'
-        "
-      >
-        {{ row.account }}
+      <span v-if="!row.isTotal" class="inline-flex items-center gap-1.5">
+        <span
+          class="text-sm tabular-nums"
+          :class="
+            row.accountDimmed ? 'text-dimmed' : row.accountMuted ? 'text-muted' : 'text-default'
+          "
+        >
+          {{ row.account }}
+        </span>
+        <UBadge v-if="row.isFee" color="warning" variant="subtle" size="xs" label="Fee" />
       </span>
     </template>
 

--- a/app/src/components/sections/AccountingView/LedgerTable.vue
+++ b/app/src/components/sections/AccountingView/LedgerTable.vue
@@ -10,8 +10,17 @@
     </template>
 
     <template #action-cell="{ row: { original: row } }">
+      <!-- A fee leg reads as its own action ("Fee"), on the same footing as the
+           category pills (Expense / Transfer / …) — even on a continuation row. -->
       <span
-        v-if="row.isFirst && !row.isTotal"
+        v-if="row.isFee"
+        class="inline-block rounded-full px-2 py-0.5 text-xs font-medium"
+        :class="FEE_BADGE"
+      >
+        Fee
+      </span>
+      <span
+        v-else-if="row.isFirst && !row.isTotal"
         class="inline-block rounded-full px-2 py-0.5 text-xs font-medium"
         :class="row.catClass"
       >
@@ -49,16 +58,14 @@
     </template>
 
     <template #account-cell="{ row: { original: row } }">
-      <span v-if="!row.isTotal" class="inline-flex items-center gap-1.5">
-        <span
-          class="text-sm tabular-nums"
-          :class="
-            row.accountDimmed ? 'text-dimmed' : row.accountMuted ? 'text-muted' : 'text-default'
-          "
-        >
-          {{ row.account }}
-        </span>
-        <UBadge v-if="row.isFee" color="warning" variant="subtle" size="xs" label="Fee" />
+      <span
+        v-if="!row.isTotal"
+        class="text-sm tabular-nums"
+        :class="
+          row.accountDimmed ? 'text-dimmed' : row.accountMuted ? 'text-muted' : 'text-default'
+        "
+      >
+        {{ row.account }}
       </span>
     </template>
 
@@ -129,6 +136,10 @@ const props = defineProps<{
 }>()
 
 type LedgerTableRow = LedgerRow & { isTotal: boolean }
+
+// Action-pill classes for a fee leg — amber, a peer of the category badges
+// (CATEGORY_BADGE in ledgerPresenter). A static string so Tailwind keeps it.
+const FEE_BADGE = 'bg-warning/10 text-warning'
 
 /** A cash pocket account rendered as a contract avatar (document icon + short name). */
 function pocketUser(account: string) {

--- a/app/src/utils/accounting/__tests__/ledgerFee.spec.ts
+++ b/app/src/utils/accounting/__tests__/ledgerFee.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ledgerRows,
+  entryHasFee,
+  ledgerFeeRows,
+  ledgerFeeTotal,
+  FEE_ACCOUNT
+} from '@/utils/accounting/ledgerPresenter'
+import type { LedgerEntry } from '@/utils/accounting/ledgerEntry'
+
+// A standalone fee posting (its transfer isn't in view, so it stays on its own).
+const standaloneFee: LedgerEntry = {
+  id: 'fee-1',
+  timestamp: 100,
+  useCase: 'FEE',
+  debit: FEE_ACCOUNT,
+  credit: 'Cash — Bank',
+  amountUsd: 0.5,
+  token: 'usdc',
+  rawAmount: '500000',
+  memo: 'Transaction fee skimmed from Bank',
+  enrichment: 'not-applicable'
+}
+
+// A transfer that skimmed a fee in the same tx: the fee is folded onto the
+// outflow as `mergedBankFee` (what mergeBankFees produces).
+const transferWithFee: LedgerEntry = {
+  id: 'xfer-1',
+  timestamp: 200,
+  useCase: 'INTERNAL',
+  debit: 'Cash — Expense',
+  credit: 'Cash — Bank',
+  amountUsd: 10,
+  token: 'usdc',
+  rawAmount: '10000000',
+  memo: '',
+  enrichment: 'not-applicable',
+  mergedBankFee: { amountUsd: 0.05, rawAmount: '50000', token: 'usdc' }
+}
+
+const plainTransfer: LedgerEntry = {
+  id: 'xfer-2',
+  timestamp: 300,
+  useCase: 'INTERNAL',
+  debit: 'Cash — Expense',
+  credit: 'Cash — Bank',
+  amountUsd: 20,
+  token: 'usdc',
+  rawAmount: '20000000',
+  memo: '',
+  enrichment: 'not-applicable'
+}
+
+describe('Fee badge (isFee row flag)', () => {
+  it('flags the Transaction Fee Expense leg — standalone posting', () => {
+    // Its single debit row is the fee leg.
+    expect(ledgerRows([standaloneFee])[0].isFee).toBe(true)
+  })
+
+  it('flags only the fee leg of a folded transfer (Dr net · Dr fee · Cr gross)', () => {
+    const rows = ledgerRows([transferWithFee])
+    expect(rows.map((r) => r.isFee)).toEqual([false, true, false])
+    expect(rows[1].account).toBe(FEE_ACCOUNT)
+  })
+
+  it('leaves non-fee rows unflagged', () => {
+    expect(ledgerRows([plainTransfer]).every((r) => !r.isFee)).toBe(true)
+  })
+})
+
+describe('Fee filter', () => {
+  it('entryHasFee matches folded and standalone fees only', () => {
+    expect(entryHasFee(standaloneFee)).toBe(true)
+    expect(entryHasFee(transferWithFee)).toBe(true)
+    expect(entryHasFee(plainTransfer)).toBe(false)
+  })
+
+  it('ledgerFeeRows isolates one contextual fee line per fee-bearing entry', () => {
+    const rows = ledgerFeeRows([standaloneFee, transferWithFee, plainTransfer])
+    expect(rows).toHaveLength(2)
+    expect(rows.every((r) => r.isFee && r.account === FEE_ACCOUNT)).toBe(true)
+    // The folded fee shows the fee amount ($0.05), not the transfer's $10.
+    expect(rows[1].dr).toBe('$0.05')
+    // The line keeps its date so it still reads in isolation.
+    expect(rows[1].isFirst).toBe(true)
+    expect(rows[1].date).not.toBe('')
+  })
+
+  it('ledgerFeeTotal sums only the fee legs', () => {
+    expect(ledgerFeeTotal([standaloneFee, transferWithFee, plainTransfer])).toBe('$0.55')
+  })
+})

--- a/app/src/utils/accounting/__tests__/ledgerFee.spec.ts
+++ b/app/src/utils/accounting/__tests__/ledgerFee.spec.ts
@@ -4,7 +4,9 @@ import {
   entryHasFee,
   ledgerFeeRows,
   ledgerFeeTotal,
-  FEE_ACCOUNT
+  presentLedger,
+  FEE_ACCOUNT,
+  FEE_FILTER
 } from '@/utils/accounting/ledgerPresenter'
 import type { LedgerEntry } from '@/utils/accounting/ledgerEntry'
 
@@ -59,7 +61,7 @@ describe('Fee badge (isFee row flag)', () => {
 
   it('flags only the fee leg of a folded transfer (Dr net · Dr fee · Cr gross)', () => {
     const rows = ledgerRows([transferWithFee])
-    expect(rows.map((r) => r.isFee)).toEqual([false, true, false])
+    expect(rows.map((r) => Boolean(r.isFee))).toEqual([false, true, false])
     expect(rows[1].account).toBe(FEE_ACCOUNT)
   })
 
@@ -88,5 +90,13 @@ describe('Fee filter', () => {
 
   it('ledgerFeeTotal sums only the fee legs', () => {
     expect(ledgerFeeTotal([standaloneFee, transferWithFee, plainTransfer])).toBe('$0.55')
+  })
+
+  it('presentLedger(FEE_FILTER) isolates fees — the on-screen + print/export funnel', () => {
+    const view = presentLedger([standaloneFee, transferWithFee, plainTransfer], FEE_FILTER)
+    expect(view.entryCount).toBe(2)
+    expect(view.rows).toHaveLength(2)
+    expect(view.rows.every((r) => r.isFee)).toBe(true)
+    expect(view.total).toBe('$0.55')
   })
 })

--- a/app/src/utils/accounting/ledgerPresenter.ts
+++ b/app/src/utils/accounting/ledgerPresenter.ts
@@ -43,8 +43,15 @@ export const CATEGORY_BADGE: Record<LedgerCategory, string> = {
   Memo: 'bg-muted text-dimmed' // share-count note — grey
 }
 
+/**
+ * The pseudo-category the Fee pill filters on — not a {@link LedgerCategory} (a
+ * fee is a leg of a Transfer/Expense entry), so it's handled specially by
+ * {@link filterLedgerEntries} / {@link presentLedger} rather than via `categoryOf`.
+ */
+export const FEE_FILTER = 'Fee'
+
 /** Ledger filter categories shown as pills (in design order). */
-export const ledgerCategories: Array<LedgerCategory | 'All'> = [
+export const ledgerCategories: Array<LedgerCategory | 'All' | typeof FEE_FILTER> = [
   'All',
   'Investment',
   'Revenue',
@@ -52,7 +59,8 @@ export const ledgerCategories: Array<LedgerCategory | 'All'> = [
   'Transfer',
   'Payroll',
   'Expense',
-  'Dividend'
+  'Dividend',
+  FEE_FILTER
 ]
 
 /** The toggleable ledger table columns (keys match the table's cell slots). */
@@ -274,8 +282,7 @@ function rowsOf(entry: LedgerEntry): LedgerRow[] {
         accountMuted: false,
         accountDimmed: false,
         dr: money(entry.amountUsd),
-        cr: '',
-        isFee: false
+        cr: ''
       },
       continuationRow(
         FEE_ACCOUNT,
@@ -333,10 +340,11 @@ export function filterLedgerEntries(
   to?: Date | null
 ): LedgerEntry[] {
   const shown = filterByPeriod(entries, from, to)
-    .filter((e) => filter === 'All' || categoryOf(e) === filter)
+    .filter((e) => filter === 'All' || filter === FEE_FILTER || categoryOf(e) === filter)
     .slice()
     .sort((a, b) => b.timestamp - a.timestamp) // most recent first
-  return mergeBankFees(shown)
+  const merged = mergeBankFees(shown)
+  return filter === FEE_FILTER ? merged.filter(entryHasFee) : merged
 }
 
 /** Flatten postings into the table's two-rows-per-entry shape. */
@@ -353,21 +361,19 @@ function feeUsdOf(entry: LedgerEntry): number {
   return entry.mergedBankFee?.amountUsd ?? entry.amountUsd
 }
 
-/** One contextual line per fee-bearing entry — just its {@link FEE_ACCOUNT} leg. */
+/**
+ * One contextual line per fee-bearing entry — just the single isFee leg rowsOf
+ * emits (its own amount + movement), promoted to a lead row so the isolated line
+ * keeps its date / activity (a folded fee's leg is a blank continuation).
+ */
 export function ledgerFeeRows(entries: readonly LedgerEntry[]): LedgerRow[] {
-  return entries.filter(entryHasFee).map((entry) => {
-    // The single isFee leg rowsOf emits (its own amount + movement), promoted to a
-    // lead row so the isolated line keeps its date / activity — a folded fee's leg
-    // is a continuation, blank on those.
-    const feeRow = rowsOf(entry).find((r) => r.isFee) as LedgerRow
-    return {
-      ...feeRow,
-      isFirst: true,
-      date: fmtDateTime(entry.timestamp),
-      label: entryLabel(entry),
-      activity: activityOf(entry)
-    }
-  })
+  return entries.filter(entryHasFee).map((entry) => ({
+    ...(rowsOf(entry).find((r) => r.isFee) as LedgerRow),
+    isFirst: true,
+    date: fmtDateTime(entry.timestamp),
+    label: entryLabel(entry),
+    activity: activityOf(entry)
+  }))
 }
 
 /** Σ of the fee legs across the fee-bearing entries, formatted as USD. */
@@ -397,7 +403,9 @@ export function presentLedger(
   to?: Date | null
 ): LedgerView {
   const shown = filterLedgerEntries(entries, filter, from, to)
-  return { rows: ledgerRows(shown), total: ledgerTotal(shown), entryCount: shown.length }
+  const rows = filter === FEE_FILTER ? ledgerFeeRows(shown) : ledgerRows(shown)
+  const total = filter === FEE_FILTER ? ledgerFeeTotal(shown) : ledgerTotal(shown)
+  return { rows, total, entryCount: shown.length }
 }
 
 /**

--- a/app/src/utils/accounting/ledgerPresenter.ts
+++ b/app/src/utils/accounting/ledgerPresenter.ts
@@ -14,6 +14,9 @@ import type { TokenId } from '@/constant'
 /** The empty activity carried by a posting's continuation (credit) and total rows. */
 const NO_ACTIVITY: ActivityCell = { kind: 'plain', text: '' }
 
+/** Exact chart-of-accounts label for a protocol-fee leg; drives badge + filter. */
+export const FEE_ACCOUNT = 'Transaction Fee Expense'
+
 export type LedgerCategory =
   | 'Investment'
   | 'Revenue'
@@ -137,6 +140,8 @@ export interface LedgerRow {
   quantity: string
   /** USD rate of record (spec §2 "Taux"), 6-dp, e.g. `$0.080000` / `$1.000000`. */
   rate: string
+  /** True on a `Transaction Fee Expense` leg — drives the "Fee" badge and filter. */
+  isFee?: boolean
 }
 
 export interface LedgerView {
@@ -207,7 +212,7 @@ function movementOf(rawAmount: string, token: TokenId, rate?: number): Movement 
 /** A posting's second and later lines — the lead row alone carries date / action / activity. */
 function continuationRow(
   account: string,
-  amounts: { dr?: string; cr?: string; accountMuted?: boolean },
+  amounts: { dr?: string; cr?: string; accountMuted?: boolean; isFee?: boolean },
   movement: Movement = NO_MOVEMENT
 ): LedgerRow {
   return {
@@ -222,6 +227,7 @@ function continuationRow(
     accountDimmed: false,
     dr: amounts.dr ?? '',
     cr: amounts.cr ?? '',
+    isFee: amounts.isFee ?? false,
     ...movement
   }
 }
@@ -268,11 +274,12 @@ function rowsOf(entry: LedgerEntry): LedgerRow[] {
         accountMuted: false,
         accountDimmed: false,
         dr: money(entry.amountUsd),
-        cr: ''
+        cr: '',
+        isFee: false
       },
       continuationRow(
-        'Transaction Fee Expense',
-        { dr: money(fee.amountUsd) },
+        FEE_ACCOUNT,
+        { dr: money(fee.amountUsd), isFee: true },
         movementOf(fee.rawAmount, fee.token, fee.rate)
       ),
       continuationRow(entry.credit, {
@@ -291,7 +298,8 @@ function rowsOf(entry: LedgerEntry): LedgerRow[] {
       accountMuted: false,
       accountDimmed: false,
       dr: money(entry.amountUsd),
-      cr: ''
+      cr: '',
+      isFee: entry.debit === FEE_ACCOUNT
     })
   }
   if (entry.credit) {
@@ -334,6 +342,37 @@ export function filterLedgerEntries(
 /** Flatten postings into the table's two-rows-per-entry shape. */
 export function ledgerRows(entries: readonly LedgerEntry[]): LedgerRow[] {
   return entries.flatMap((entry) => rowsOf(entry))
+}
+
+/** True when an entry carries a {@link FEE_ACCOUNT} leg (folded or standalone). */
+export function entryHasFee(entry: LedgerEntry): boolean {
+  return entry.mergedBankFee != null || entry.debit === FEE_ACCOUNT
+}
+/** The USD amount of that leg — the folded fee, else the standalone fee itself. */
+function feeUsdOf(entry: LedgerEntry): number {
+  return entry.mergedBankFee?.amountUsd ?? entry.amountUsd
+}
+
+/** One contextual line per fee-bearing entry — just its {@link FEE_ACCOUNT} leg. */
+export function ledgerFeeRows(entries: readonly LedgerEntry[]): LedgerRow[] {
+  return entries.filter(entryHasFee).map((entry) => {
+    // The single isFee leg rowsOf emits (its own amount + movement), promoted to a
+    // lead row so the isolated line keeps its date / activity — a folded fee's leg
+    // is a continuation, blank on those.
+    const feeRow = rowsOf(entry).find((r) => r.isFee) as LedgerRow
+    return {
+      ...feeRow,
+      isFirst: true,
+      date: fmtDateTime(entry.timestamp),
+      label: entryLabel(entry),
+      activity: activityOf(entry)
+    }
+  })
+}
+
+/** Σ of the fee legs across the fee-bearing entries, formatted as USD. */
+export function ledgerFeeTotal(entries: readonly LedgerEntry[]): string {
+  return money(entries.filter(entryHasFee).reduce((sum, e) => sum + feeUsdOf(e), 0))
 }
 
 /**


### PR DESCRIPTION
# Description

Handled. Fees are now clearly marked in the ledger, you can filter the view to show only the fees, and that view can be printed and exported just like the others.


Closes #2299

## Type of change

- [x] New feature (non-breaking change which adds functionality)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
