### PR TITLE
fix: 🐛 trim trailing zeros in General Ledger Rate column

### DIFF
--- a/app/src/utils/accounting/__tests__/ledgerRate.spec.ts
+++ b/app/src/utils/accounting/__tests__/ledgerRate.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { ledgerRows } from '@/utils/accounting/ledgerPresenter'
+import type { LedgerEntry } from '@/utils/accounting/ledgerEntry'
+
+/** A minimal priced posting whose lead row carries the given rate of record. */
+const entryWithRate = (rate: number): LedgerEntry => ({
+  id: `r-${rate}`,
+  timestamp: 100,
+  useCase: 'INTERNAL',
+  debit: 'Cash — Expense',
+  credit: 'Cash — Bank',
+  amountUsd: 10,
+  token: 'usdc',
+  rawAmount: '10000000',
+  memo: '',
+  enrichment: 'not-applicable',
+  rate
+})
+
+/** The rate string shown on a posting's lead row (the only row with a movement). */
+const rateOf = (rate: number): string => ledgerRows([entryWithRate(rate)])[0].rate
+
+describe('Rate column formatting (trailing zeros trimmed)', () => {
+  it('drops padding zeros so whole and short rates read cleanly', () => {
+    expect(rateOf(1)).toBe('$1')
+    expect(rateOf(0.2)).toBe('$0.2')
+    expect(rateOf(0.01)).toBe('$0.01')
+  })
+
+  it('keeps a value with real decimals, capped at 6 dp, never truncated below', () => {
+    expect(rateOf(1.4232711)).toBe('$1.423271') // 7th dp rounded, real decimals kept
+    expect(rateOf(0.080001)).toBe('$0.080001')
+  })
+})

--- a/app/src/utils/accounting/ledgerPresenter.ts
+++ b/app/src/utils/accounting/ledgerPresenter.ts
@@ -8,6 +8,7 @@ import { money, fmtDateTime, filterByPeriod, periodLabel, currencySymbol } from 
 import { wholeTokenAmount } from './toUsd'
 import { activityOf, entryLabel, type ActivityCell } from './describeEntry'
 import { mergeBankFees } from './mergeBankFees'
+import { formatAmountWithPrecision } from '@/utils/currencyUtil'
 import type { LedgerEntry, UseCase } from './ledgerEntry'
 import type { TokenId } from '@/constant'
 
@@ -146,7 +147,7 @@ export interface LedgerRow {
   currency: string
   /** Whole-token quantity moved (spec §2 "Quantité"), 6-dp, e.g. `0.070352`. */
   quantity: string
-  /** USD rate of record (spec §2 "Taux"), 6-dp, e.g. `$0.080000` / `$1.000000`. */
+  /** USD rate of record (spec §2 "Taux"), up to 6-dp with trailing zeros trimmed, e.g. `$0.08` / `$1`. */
   rate: string
   /** True on a `Transaction Fee Expense` leg — drives the "Fee" badge and filter. */
   isFee?: boolean
@@ -210,10 +211,10 @@ function movementOf(rawAmount: string, token: TokenId, rate?: number): Movement 
   return {
     currency: currencySymbol(token),
     quantity: whole.toLocaleString('en-US', { maximumFractionDigits: 6 }),
-    rate:
-      rate == null
-        ? ''
-        : '$' + rate.toLocaleString('en-US', { minimumFractionDigits: 6, maximumFractionDigits: 6 })
+    // Reuse the shared amount formatter (as Bank / Payroll do) so trailing zeros
+    // are trimmed — `1.000000` reads `1`, `0.200000` reads `0.2` — while a value
+    // with real decimals keeps them, capped at 6 dp.
+    rate: rate == null ? '' : '$' + formatAmountWithPrecision(rate, 0, 6)
   }
 }
 


### PR DESCRIPTION
# Description

The ledger presenter had its own fixed-decimal formatting for the rate (`minimumFractionDigits: 6`). This PR replaces it with the shared `formatAmountWithPrecision` helper from `currencyUtil` — the same helper Bank / Payroll views use — called with min `0` / max `6` decimals. Trailing zeros are now trimmed (`1.000000` → `1`, `0.200000` → `0.2`, `0.010000` → `0.01`) while values with real decimals are kept, still capped at 6 dp.

Fixes #2301


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
