### PR TITLE
refactor: ♻️ lay Accounting Summary cards out as a 3×2 grid

### DIFF
--- a/app/src/components/sections/AccountingView/AccountingSummary.vue
+++ b/app/src/components/sections/AccountingView/AccountingSummary.vue
@@ -38,7 +38,7 @@
     </div>
 
     <!-- Metric cards -->
-    <div class="grid grid-cols-2 gap-4 lg:grid-cols-5">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       <div
         v-for="card in summaryCards"
         :key="card.label"


### PR DESCRIPTION
# Description

The Accounting Summary section rendered its 6 metric cards as a row of 5 plus a single card on its own line, which looked unbalanced.

Closes #2303


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines