### PR TITLE
feat: ✨ add a multi-select currency filter to the General Ledger

### DIFF
--- a/app/src/components/CurrencyFilterSelect.vue
+++ b/app/src/components/CurrencyFilterSelect.vue
@@ -1,0 +1,92 @@
+<template>
+  <UPopover v-model:open="open" :content="{ align: 'end' }">
+    <UButton
+      color="neutral"
+      variant="outline"
+      size="sm"
+      icon="i-heroicons-banknotes"
+      trailing-icon="i-heroicons-chevron-down"
+      class="justify-start"
+      :ui="{
+        trailingIcon: open
+          ? 'ms-auto rotate-180 transition-transform'
+          : 'ms-auto transition-transform'
+      }"
+    >
+      <span class="truncate">{{ summary }}</span>
+    </UButton>
+
+    <template #content>
+      <div class="max-h-80 min-w-44 overflow-y-auto p-1">
+        <button
+          type="button"
+          class="hover:bg-elevated flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm"
+          @click="toggleAll"
+        >
+          <UIcon
+            :name="allSelected ? 'i-heroicons-check' : 'i-heroicons-minus'"
+            class="size-4 shrink-0"
+            :class="allSelected ? 'text-primary' : 'text-transparent'"
+          />
+          All currencies
+        </button>
+        <USeparator class="my-1" />
+        <button
+          v-for="currency in currencies"
+          :key="currency"
+          type="button"
+          class="hover:bg-elevated flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm"
+          @click="toggle(currency)"
+        >
+          <UIcon
+            :name="isSelected(currency) ? 'i-heroicons-check' : 'i-heroicons-minus'"
+            class="size-4 shrink-0"
+            :class="isSelected(currency) ? 'text-primary' : 'text-transparent'"
+          />
+          {{ currency }}
+        </button>
+      </div>
+    </template>
+  </UPopover>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+// Multi-select currency filter for the General ledger — mirrors
+// ColumnVisibilitySelect's style and "All" behaviour, over the currencies
+// present in the data currently in view.
+const props = defineProps<{
+  modelValue: string[]
+  currencies: string[]
+}>()
+const emit = defineEmits<{ 'update:modelValue': [value: string[]] }>()
+
+const open = ref(false)
+
+const allSelected = computed(() => props.modelValue.length === props.currencies.length)
+
+const summary = computed(() => {
+  if (allSelected.value) return 'All currencies'
+  if (props.modelValue.length === 0) return 'No currencies'
+  if (props.modelValue.length === 1) return props.modelValue[0]
+  return `${props.modelValue.length} currencies`
+})
+
+function isSelected(currency: string): boolean {
+  return props.modelValue.includes(currency)
+}
+
+function toggleAll(): void {
+  // Already all selected → clear, so the user can pick a fresh subset.
+  emit('update:modelValue', allSelected.value ? [] : [...props.currencies])
+}
+
+function toggle(currency: string): void {
+  const next = [...props.modelValue]
+  const index = next.indexOf(currency)
+  if (index >= 0) next.splice(index, 1)
+  else next.push(currency)
+  emit('update:modelValue', next)
+}
+</script>

--- a/app/src/components/__tests__/CurrencyFilterSelect.spec.ts
+++ b/app/src/components/__tests__/CurrencyFilterSelect.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import CurrencyFilterSelect from '@/components/CurrencyFilterSelect.vue'
+
+const currencies = ['POL', 'USDC', 'SHER']
+
+function mountSelect(modelValue: string[]) {
+  return mount(CurrencyFilterSelect, { props: { modelValue, currencies } })
+}
+
+/** The trigger shows the summary; the menu entries are the `type="button"` ones. */
+const trigger = (w: VueWrapper) =>
+  w.findAll('button').find((b) => b.attributes('type') !== 'button')!
+const options = (w: VueWrapper) =>
+  w.findAll('button').filter((b) => b.attributes('type') === 'button')
+
+describe('CurrencyFilterSelect', () => {
+  it('summarizes the current selection on the trigger', () => {
+    expect(trigger(mountSelect(['POL', 'USDC', 'SHER'])).text()).toContain('All currencies')
+    expect(trigger(mountSelect([])).text()).toContain('No currencies')
+    expect(trigger(mountSelect(['USDC'])).text()).toContain('USDC')
+    expect(trigger(mountSelect(['POL', 'USDC'])).text()).toContain('2 currencies')
+  })
+
+  it('toggles a single currency off', async () => {
+    const wrapper = mountSelect(['POL', 'USDC', 'SHER'])
+    await options(wrapper)?.[2]?.trigger('click') // "USDC"
+    expect(wrapper.emitted('update:modelValue')?.[0]?.[0]).toEqual(['POL', 'SHER'])
+  })
+
+  it('toggles a single currency on', async () => {
+    const wrapper = mountSelect(['POL'])
+    await options(wrapper)?.[2]?.trigger('click') // "USDC"
+    expect(wrapper.emitted('update:modelValue')?.[0]?.[0]).toEqual(['POL', 'USDC'])
+  })
+
+  it('clears via "All currencies" when everything is selected', async () => {
+    const wrapper = mountSelect(['POL', 'USDC', 'SHER'])
+    await options(wrapper)?.[0]?.trigger('click') // "All currencies"
+    expect(wrapper.emitted('update:modelValue')?.[0]?.[0]).toEqual([])
+  })
+
+  it('selects every currency via "All currencies" when some are hidden', async () => {
+    const wrapper = mountSelect(['POL'])
+    await options(wrapper)?.[0]?.trigger('click') // "All currencies"
+    expect(wrapper.emitted('update:modelValue')?.[0]?.[0]).toEqual(['POL', 'USDC', 'SHER'])
+  })
+})

--- a/app/src/components/sections/AccountingView/GeneralLedger.vue
+++ b/app/src/components/sections/AccountingView/GeneralLedger.vue
@@ -23,12 +23,17 @@
             />
           </div>
 
-          <!-- Reporting period + show/hide columns -->
+          <!-- Reporting period + currency filter + show/hide columns -->
           <div class="flex flex-wrap items-center justify-end gap-2.5">
             <AccountingDatePicker
               v-model="period"
               mode="range"
               storage-key="cnc-accounting-ledger-period"
+            />
+            <CurrencyFilterSelect
+              v-if="showCurrencyFilter"
+              v-model="selectedCurrencies"
+              :currencies="availableCurrencies"
             />
             <ColumnVisibilitySelect v-model="visibleColumns" :items="columnItems" />
           </div>
@@ -59,6 +64,7 @@ import AccountingExportBar from './AccountingExportBar.vue'
 import TablePagination from '@/components/TablePagination.vue'
 import AccountingDatePicker from '@/components/AccountingDatePicker.vue'
 import ColumnVisibilitySelect from '@/components/ColumnVisibilitySelect.vue'
+import CurrencyFilterSelect from '@/components/CurrencyFilterSelect.vue'
 import { usePagination } from '@/composables/usePagination'
 import { defaultValueForMode, isAllTimeRange, type Range } from '@/utils/datePicker'
 import { useAccountingContext } from '@/composables/accounting/useAccountingContext'
@@ -68,6 +74,8 @@ import { exportFilename } from '@/utils/accounting/exportNaming'
 import type { SectionSpec } from '@/utils/accounting/exportSpec'
 import {
   filterLedgerEntries,
+  filterLedgerByCurrency,
+  ledgerCurrencies,
   ledgerRows,
   ledgerTotal,
   ledgerCategories,
@@ -102,21 +110,59 @@ const acc = useAccountingContext()
 // Filter once, paginate by entry (a posting spans two rows), then flatten the
 // current page into table rows. The "Total movements" figure stays the grand
 // total across the whole filtered book, not just the page.
+const isFeeFilter = computed(() => filter.value === FEE_FILTER)
+
+// After category + date + fee, before currency — so the currency options reflect
+// the data in view and recompute when those upstream filters change (spec §4).
 const filtered = computed(() =>
   filterLedgerEntries(acc.entries.value, filter.value, period.value.start, period.value.end)
 )
-const isFeeFilter = computed(() => filter.value === FEE_FILTER)
-const total = computed(() => filtered.value.length)
+
+// The distinct currencies currently in view. The selector is shown only when at
+// least two are present (a single-currency ledger needs no filter).
+const availableCurrencies = computed(() => ledgerCurrencies(filtered.value, isFeeFilter.value))
+const showCurrencyFilter = computed(() => availableCurrencies.value.length >= 2)
+
+// Selected currencies (defaults to all). Reconciled whenever the available set
+// changes: keep what's still present, falling back to "all" when nothing valid
+// remains — so switching another filter never leaves a stale, empty selection.
+const selectedCurrencies = ref<string[]>([])
+watch(
+  availableCurrencies,
+  (avail) => {
+    const kept = selectedCurrencies.value.filter((c) => avail.includes(c))
+    selectedCurrencies.value = kept.length ? kept : [...avail]
+  },
+  { immediate: true }
+)
+
+// The currencies to actually filter by, or null when there's nothing to narrow
+// (selector hidden, or every currency selected). Shared by the view and export.
+const activeCurrencies = computed<string[] | null>(() => {
+  if (!showCurrencyFilter.value) return null
+  if (selectedCurrencies.value.length >= availableCurrencies.value.length) return null
+  return selectedCurrencies.value
+})
+
+const filteredByCurrency = computed(() =>
+  activeCurrencies.value === null
+    ? filtered.value
+    : filterLedgerByCurrency(filtered.value, activeCurrencies.value, isFeeFilter.value)
+)
+
+const total = computed(() => filteredByCurrency.value.length)
 const grandTotal = computed(() =>
-  isFeeFilter.value ? ledgerFeeTotal(filtered.value) : ledgerTotal(filtered.value)
+  isFeeFilter.value
+    ? ledgerFeeTotal(filteredByCurrency.value)
+    : ledgerTotal(filteredByCurrency.value)
 )
 
 const { page, pageSize, reset } = usePagination(() => total.value, { key: 'ledger' })
-watch([filter, period], reset, { deep: true })
+watch([filter, period, selectedCurrencies], reset, { deep: true })
 
 const pageRows = computed(() => {
   const start = (page.value - 1) * pageSize.value
-  const slice = filtered.value.slice(start, start + pageSize.value)
+  const slice = filteredByCurrency.value.slice(start, start + pageSize.value)
   return isFeeFilter.value ? ledgerFeeRows(slice) : ledgerRows(slice)
 })
 
@@ -142,7 +188,8 @@ const spec = (): SectionSpec => ({
   filter: filter.value,
   from: dateSelected.value ? period.value.start : null,
   to: dateSelected.value ? period.value.end : null,
-  columns: visibleColumns.value
+  columns: visibleColumns.value,
+  ...(activeCurrencies.value ? { currencies: activeCurrencies.value } : {})
 })
 // The filename mirrors the export scope: the active category, plus the period
 // when a real range is set (all-time needs no date suffix).

--- a/app/src/utils/accounting/__tests__/ledgerCurrency.spec.ts
+++ b/app/src/utils/accounting/__tests__/ledgerCurrency.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import {
+  entryCurrency,
+  ledgerCurrencies,
+  filterLedgerByCurrency,
+  filterLedgerEntries,
+  presentLedger,
+  FEE_ACCOUNT,
+  FEE_FILTER
+} from '@/utils/accounting/ledgerPresenter'
+import type { LedgerEntry } from '@/utils/accounting/ledgerEntry'
+
+const base = {
+  useCase: 'INTERNAL' as const,
+  debit: 'Cash — Expense' as const,
+  credit: 'Cash — Bank' as const,
+  amountUsd: 10,
+  rawAmount: '10000000',
+  memo: '',
+  enrichment: 'not-applicable' as const
+}
+
+const usdtEntry: LedgerEntry = { ...base, id: 'usdt', timestamp: 300, token: 'usdt' }
+const usdcEntry: LedgerEntry = { ...base, id: 'usdc', timestamp: 200, token: 'usdc' }
+const usdcEntry2: LedgerEntry = { ...base, id: 'usdc-2', timestamp: 100, token: 'usdc' }
+
+// A transfer whose in-tx Bank fee was skimmed in a different token than the move.
+const feeInSher: LedgerEntry = {
+  ...base,
+  id: 'xfer-fee',
+  timestamp: 400,
+  token: 'usdc',
+  mergedBankFee: { amountUsd: 0.05, rawAmount: '50000000000000000', token: 'sher' }
+}
+
+describe('entryCurrency', () => {
+  it('reads the entry token by default, the fee leg token under the Fee filter', () => {
+    expect(entryCurrency(usdtEntry)).toBe('USDT')
+    expect(entryCurrency(usdcEntry)).toBe('USDC')
+    // Fee-filter mode surfaces the fee leg's currency, not the transfer's.
+    expect(entryCurrency(feeInSher)).toBe('USDC')
+    expect(entryCurrency(feeInSher, true)).toBe('SHER')
+  })
+})
+
+describe('ledgerCurrencies', () => {
+  it('lists the distinct currencies in view, sorted, de-duplicated', () => {
+    expect(ledgerCurrencies([usdtEntry, usdcEntry, usdcEntry2])).toEqual(['USDC', 'USDT'])
+  })
+
+  it('collapses to a single currency when only one is present', () => {
+    expect(ledgerCurrencies([usdcEntry, usdcEntry2])).toEqual(['USDC'])
+  })
+
+  it('is empty for no entries', () => {
+    expect(ledgerCurrencies([])).toEqual([])
+  })
+})
+
+describe('filterLedgerByCurrency', () => {
+  it('keeps only entries whose currency is selected', () => {
+    const kept = filterLedgerByCurrency([usdtEntry, usdcEntry, usdcEntry2], ['USDC'])
+    expect(kept.map((e) => e.id)).toEqual(['usdc', 'usdc-2'])
+  })
+
+  it('keeps none for an empty selection (mirrors the multi-select)', () => {
+    expect(filterLedgerByCurrency([usdtEntry, usdcEntry], [])).toHaveLength(0)
+  })
+})
+
+describe('currency filter threaded through the funnel', () => {
+  const all = [usdtEntry, usdcEntry, usdcEntry2]
+
+  it('filterLedgerEntries narrows by currency alongside category + date', () => {
+    const rows = filterLedgerEntries(all, 'All', null, null, ['USDT'])
+    expect(rows.map((e) => e.id)).toEqual(['usdt'])
+  })
+
+  it('a null / absent currency selection leaves the set untouched', () => {
+    expect(filterLedgerEntries(all, 'All')).toHaveLength(3)
+    expect(filterLedgerEntries(all, 'All', null, null, null)).toHaveLength(3)
+  })
+
+  it('presentLedger honours the currency selection for the export path', () => {
+    const view = presentLedger(all, 'All', null, null, ['USDC'])
+    expect(view.entryCount).toBe(2)
+    expect(view.rows.every((r) => !r.isFee)).toBe(true)
+  })
+})
+
+describe('currency filter under the Fee filter', () => {
+  const standaloneFee: LedgerEntry = {
+    ...base,
+    id: 'fee-1',
+    timestamp: 500,
+    useCase: 'FEE',
+    debit: FEE_ACCOUNT,
+    credit: 'Cash — Bank',
+    amountUsd: 0.5,
+    token: 'usdc'
+  }
+
+  it('groups fee-bearing entries by their fee leg currency', () => {
+    // feeInSher's fee leg is SHER; the standalone fee is USDC.
+    const view = presentLedger([standaloneFee, feeInSher], FEE_FILTER, null, null, ['SHER'])
+    expect(view.entryCount).toBe(1)
+    expect(view.rows[0].currency).toBe('SHER')
+  })
+})

--- a/app/src/utils/accounting/exportSpec.ts
+++ b/app/src/utils/accounting/exportSpec.ts
@@ -26,4 +26,9 @@ export interface SectionSpec {
   filter?: string
   /** General Ledger visible columns. */
   columns?: LedgerColumnKey[]
+  /**
+   * General Ledger currency selection — the subset of currencies in view. Unset
+   * (or all currencies) means no currency narrowing.
+   */
+  currencies?: string[]
 }

--- a/app/src/utils/accounting/ledgerCurrency.ts
+++ b/app/src/utils/accounting/ledgerCurrency.ts
@@ -1,0 +1,42 @@
+/**
+ * Currency derivation + filtering for the general ledger — split from
+ * {@link ./ledgerPresenter} so each module stays focused. Drives the
+ * General-ledger currency selector (spec §2 "Devise"): which currencies are in
+ * view and narrowing the entries to a chosen subset. Pure and unit-testable.
+ */
+import { currencySymbol } from './presenter'
+import type { LedgerEntry } from './ledgerEntry'
+
+/**
+ * The currency symbol an entry is filtered / grouped by in the ledger — the fee
+ * leg's token under the Fee filter (that's the row rendered), otherwise the
+ * entry's own token.
+ */
+export function entryCurrency(entry: LedgerEntry, isFeeFilter = false): string {
+  const token = isFeeFilter ? (entry.mergedBankFee?.token ?? entry.token) : entry.token
+  return currencySymbol(token)
+}
+
+/**
+ * The distinct currencies present across the given entries, sorted, feeding the
+ * General-ledger currency selector — recomputed as the upstream category / date /
+ * fee filters change, so it always reflects the data currently in view.
+ */
+export function ledgerCurrencies(entries: readonly LedgerEntry[], isFeeFilter = false): string[] {
+  const seen = new Set<string>()
+  for (const entry of entries) seen.add(entryCurrency(entry, isFeeFilter))
+  return [...seen].sort()
+}
+
+/**
+ * Narrow entries to the selected currencies (an empty selection keeps none,
+ * mirroring the multi-select). Applied after the category / date / fee filter so
+ * the currency filter combines with them.
+ */
+export function filterLedgerByCurrency(
+  entries: readonly LedgerEntry[],
+  currencies: readonly string[],
+  isFeeFilter = false
+): LedgerEntry[] {
+  return entries.filter((e) => currencies.includes(entryCurrency(e, isFeeFilter)))
+}

--- a/app/src/utils/accounting/ledgerPresenter.ts
+++ b/app/src/utils/accounting/ledgerPresenter.ts
@@ -8,9 +8,13 @@ import { money, fmtDateTime, filterByPeriod, periodLabel, currencySymbol } from 
 import { wholeTokenAmount } from './toUsd'
 import { activityOf, entryLabel, type ActivityCell } from './describeEntry'
 import { mergeBankFees } from './mergeBankFees'
+import { filterLedgerByCurrency } from './ledgerCurrency'
 import { formatAmountWithPrecision } from '@/utils/currencyUtil'
 import type { LedgerEntry, UseCase } from './ledgerEntry'
 import type { TokenId } from '@/constant'
+
+// Currency derivation / filtering lives in its own module, re-exported here.
+export { entryCurrency, ledgerCurrencies, filterLedgerByCurrency } from './ledgerCurrency'
 
 /** The empty activity carried by a posting's continuation (credit) and total rows. */
 const NO_ACTIVITY: ActivityCell = { kind: 'plain', text: '' }
@@ -329,23 +333,26 @@ function rowsOf(entry: LedgerEntry): LedgerRow[] {
 }
 
 /**
- * The ledger entries narrowed by category + inclusive date window, sorted
- * chronologically, with each Bank fee folded into its transfer ({@link
- * mergeBankFees}). Split out so a paginated view can slice by **entry** (not by
- * row — a posting spans two-plus rows) before flattening into table rows.
+ * The ledger entries narrowed by category + inclusive date window (+ an optional
+ * currency selection), sorted chronologically, with each Bank fee folded into its
+ * transfer ({@link mergeBankFees}). Split out so a paginated view can slice by
+ * **entry** (not by row — a posting spans two-plus rows) before flattening into
+ * table rows.
  */
 export function filterLedgerEntries(
   entries: readonly LedgerEntry[],
   filter: string,
   from?: Date | null,
-  to?: Date | null
+  to?: Date | null,
+  currencies?: readonly string[] | null
 ): LedgerEntry[] {
   const shown = filterByPeriod(entries, from, to)
     .filter((e) => filter === 'All' || filter === FEE_FILTER || categoryOf(e) === filter)
     .slice()
     .sort((a, b) => b.timestamp - a.timestamp) // most recent first
   const merged = mergeBankFees(shown)
-  return filter === FEE_FILTER ? merged.filter(entryHasFee) : merged
+  const scoped = filter === FEE_FILTER ? merged.filter(entryHasFee) : merged
+  return currencies ? filterLedgerByCurrency(scoped, currencies, filter === FEE_FILTER) : scoped
 }
 
 /** Flatten postings into the table's two-rows-per-entry shape. */
@@ -356,10 +363,6 @@ export function ledgerRows(entries: readonly LedgerEntry[]): LedgerRow[] {
 /** True when an entry carries a {@link FEE_ACCOUNT} leg (folded or standalone). */
 export function entryHasFee(entry: LedgerEntry): boolean {
   return entry.mergedBankFee != null || entry.debit === FEE_ACCOUNT
-}
-/** The USD amount of that leg — the folded fee, else the standalone fee itself. */
-function feeUsdOf(entry: LedgerEntry): number {
-  return entry.mergedBankFee?.amountUsd ?? entry.amountUsd
 }
 
 /**
@@ -377,9 +380,13 @@ export function ledgerFeeRows(entries: readonly LedgerEntry[]): LedgerRow[] {
   }))
 }
 
-/** Σ of the fee legs across the fee-bearing entries, formatted as USD. */
+/**
+ * Σ of the fee legs across the fee-bearing entries, formatted as USD — each
+ * leg's amount is the folded fee, else the standalone fee posting itself.
+ */
 export function ledgerFeeTotal(entries: readonly LedgerEntry[]): string {
-  return money(entries.filter(entryHasFee).reduce((sum, e) => sum + feeUsdOf(e), 0))
+  const legUsd = (e: LedgerEntry) => e.mergedBankFee?.amountUsd ?? e.amountUsd
+  return money(entries.filter(entryHasFee).reduce((sum, e) => sum + legUsd(e), 0))
 }
 
 /**
@@ -396,14 +403,15 @@ export function ledgerTotal(entries: readonly LedgerEntry[]): string {
   )
 }
 
-/** General-ledger rows narrowed by category + inclusive date window. */
+/** General-ledger rows narrowed by category + inclusive date window (+ currency). */
 export function presentLedger(
   entries: readonly LedgerEntry[],
   filter: string,
   from?: Date | null,
-  to?: Date | null
+  to?: Date | null,
+  currencies?: readonly string[] | null
 ): LedgerView {
-  const shown = filterLedgerEntries(entries, filter, from, to)
+  const shown = filterLedgerEntries(entries, filter, from, to, currencies)
   const rows = filter === FEE_FILTER ? ledgerFeeRows(shown) : ledgerRows(shown)
   const total = filter === FEE_FILTER ? ledgerFeeTotal(shown) : ledgerTotal(shown)
   return { rows, total, entryCount: shown.length }

--- a/app/src/utils/accountingExport.ts
+++ b/app/src/utils/accountingExport.ts
@@ -140,6 +140,7 @@ interface LedgerSheetOptions {
   from?: Date | null
   to?: Date | null
   columns?: LedgerColumnKey[]
+  currencies?: string[]
 }
 
 function ledgerSheet(
@@ -147,7 +148,13 @@ function ledgerSheet(
   resolveName?: ResolveName,
   opts: LedgerSheetOptions = {}
 ): SheetRows {
-  const { rows, total } = presentLedger(acc.entries, opts.filter ?? 'All', opts.from, opts.to)
+  const { rows, total } = presentLedger(
+    acc.entries,
+    opts.filter ?? 'All',
+    opts.from,
+    opts.to,
+    opts.currencies
+  )
   const cols = resolveLedgerColumns(opts.columns)
   return [
     // Title row spells out the active category / period; the tab keeps its short name.
@@ -191,7 +198,8 @@ function sectionSheet(
           filter: spec.filter,
           from: spec.from,
           to: spec.to,
-          columns: spec.columns
+          columns: spec.columns,
+          currencies: spec.currencies
         })
     }
   })()

--- a/app/src/utils/accountingPdf.ts
+++ b/app/src/utils/accountingPdf.ts
@@ -154,6 +154,7 @@ interface LedgerTableOptions {
   from?: Date | null
   to?: Date | null
   columns?: LedgerColumnKey[]
+  currencies?: string[]
 }
 
 function ledgerTable(
@@ -161,7 +162,13 @@ function ledgerTable(
   resolveName?: ResolveName,
   opts: LedgerTableOptions = {}
 ): AccountingPdfTable {
-  const { rows, total } = presentLedger(acc.entries, opts.filter ?? 'All', opts.from, opts.to)
+  const { rows, total } = presentLedger(
+    acc.entries,
+    opts.filter ?? 'All',
+    opts.from,
+    opts.to,
+    opts.currencies
+  )
   const cols = resolveLedgerColumns(opts.columns)
   const body = rows.map((r) => cols.map((c) => LEDGER_PDF_CELL[c.value].pick(r, resolveName)))
   // Carry the same movement total the table footer shows, so a filtered export
@@ -195,7 +202,8 @@ function sectionTable(
         filter: spec.filter,
         from: spec.from,
         to: spec.to,
-        columns: spec.columns
+        columns: spec.columns,
+        currencies: spec.currencies
       })
   }
 }


### PR DESCRIPTION
# Description

## Initial Issue Description


The General Ledger can list entries in several currencies at once (POL, USDC, SHER, …) but offered no way to narrow the table to a specific currency.

Closes #2305


## Type of change

- [x] New feature (non-breaking change which adds functionality)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (`ledgerCurrency.spec.ts`, `CurrencyFilterSelect.spec.ts`)
- [ ] Docs have been added / updated (N/A)