### PR TITLE
feat: ✨ read accounting on-chain history directly from the blockchain

### DIFF
--- a/app/src/composables/accounting/__tests__/useCNCAccounting.spec.ts
+++ b/app/src/composables/accounting/__tests__/useCNCAccounting.spec.ts
@@ -1,9 +1,37 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
+
+// The on-chain feeds now come from the `use*EventsViaLogs` composables (getLogs
+// instead of Ponder). Mock each to an empty, non-loading result — the same
+// pattern the *Transactions.vue specs use — so this spec exercises the assembly
+// logic without touching the RPC. `refetch` resolves so the refresh test passes.
+const emptyLogsFeed = () => ({
+  result: ref(null),
+  loading: ref(false),
+  error: ref(null),
+  refetch: vi.fn().mockResolvedValue(undefined)
+})
+vi.mock('@/composables/bank/useBankEventsViaLogs', () => ({
+  useBankEventsViaLogs: () => emptyLogsFeed()
+}))
+vi.mock('@/composables/cashRemuneration/useCashRemunerationEventsViaLogs', () => ({
+  useCashRemunerationEventsViaLogs: () => emptyLogsFeed()
+}))
+vi.mock('@/composables/expense/useExpenseEventsViaLogs', () => ({
+  useExpenseEventsViaLogs: () => emptyLogsFeed()
+}))
+vi.mock('@/composables/investor/useInvestorEventsViaLogs', () => ({
+  useInvestorEventsViaLogs: () => emptyLogsFeed()
+}))
+vi.mock('@/composables/investor/useSafeDepositRouterEventsViaLogs', () => ({
+  useSafeDepositRouterEventsViaLogs: () => emptyLogsFeed()
+}))
+
 import { useCNCAccounting } from '../useCNCAccounting'
 
 // Relies on the global mocks (tests/setup/composables.setup.ts):
 //   • `useGetTeamQuery` → `mockTeamData` (one InvestorV1 pocket, an owner address)
-//   • Apollo `useQuery`  → an empty result ref (no on-chain events)
+//   • the on-chain feeds → the empty getLogs mocks above (no on-chain events)
 //   • the backend query hooks → mock responses (weekly claims may yield accruals)
 // So the composable assembles a valid, always-balanced set of books for team "1".
 

--- a/app/src/composables/accounting/useCNCAccounting.ts
+++ b/app/src/composables/accounting/useCNCAccounting.ts
@@ -4,8 +4,9 @@
  * Loads every feed a team's books need and exposes the consolidated ledger plus
  * the three financial statements to the UI from a single composable:
  *
- *   - **Ponder** — on-chain events for the team's Bank, CashRemuneration, Expense,
- *     InvestorV1 and SafeDepositRouter contracts (spec §3.1).
+ *   - **On-chain (getLogs)** — events for the team's Bank, CashRemuneration,
+ *     Expense, InvestorV1 and SafeDepositRouter contracts, reconstructed from the
+ *     RPC via the shared `use*EventsViaLogs` composables (no indexer dependency).
  *   - **Safe** — the team Safe's incoming native / ERC-20 transfers (spec §3.1).
  *   - **Backend DB** — the team's contracts, signed weekly claims and approved
  *     expenses, the off-chain accrual + category context (spec §3.2).
@@ -18,23 +19,17 @@
  * the ledger and never blocks the page or surfaces as a hard error.
  */
 import { computed, ref, toValue, watch, type ComputedRef, type MaybeRefOrGetter } from 'vue'
-import { useQuery as useApolloQuery } from '@vue/apollo-composable'
 import { useReadContract } from '@wagmi/vue'
-import type { DocumentNode } from 'graphql'
 import { type Address } from 'viem'
 import { SAFE_DEPOSIT_ROUTER_ABI } from '@/artifacts/abi/safe-deposit-router'
 import { formatSafeDepositRouterMultiplier } from '@/utils/safeDepositRouterUtil'
-import { FEE_COLLECTOR_ADDRESS, GRAPHQL_POLL_INTERVAL, SUPPORTED_TOKENS } from '@/constant'
+import { FEE_COLLECTOR_ADDRESS, SUPPORTED_TOKENS } from '@/constant'
 import type { ContractType } from '@/types/teamContract'
-import type { BankEventsQuery } from '@/types/ponder/bank'
-import type { CashRemunerationEventsQuery } from '@/types/ponder/cash-remuneration'
-import type { ExpenseEventsQuery } from '@/types/ponder/expense'
-import type { InvestorEventsQuery, SafeDepositRouterEventsQuery } from '@/types/ponder/investor'
-import { GET_BANK_EVENTS } from '@/queries/ponder/bank.queries'
-import { GET_CASH_REMUNERATION_EVENTS } from '@/queries/ponder/cash-remuneration.queries'
-import { GET_EXPENSE_EVENTS } from '@/queries/ponder/expense.queries'
-import { GET_INVESTOR_EVENTS } from '@/queries/ponder/investor.queries'
-import { GET_SAFE_DEPOSIT_ROUTER_EVENTS } from '@/queries/ponder/safe-deposit-router.queries'
+import { useBankEventsViaLogs } from '@/composables/bank/useBankEventsViaLogs'
+import { useCashRemunerationEventsViaLogs } from '@/composables/cashRemuneration/useCashRemunerationEventsViaLogs'
+import { useExpenseEventsViaLogs } from '@/composables/expense/useExpenseEventsViaLogs'
+import { useInvestorEventsViaLogs } from '@/composables/investor/useInvestorEventsViaLogs'
+import { useSafeDepositRouterEventsViaLogs } from '@/composables/investor/useSafeDepositRouterEventsViaLogs'
 import { useGetTeamQuery } from '@/queries/team.queries'
 import { useGetTeamWeeklyClaimsQuery } from '@/queries/weeklyClaim.queries'
 import { useGetExpensesQuery } from '@/queries/expense.queries'
@@ -93,7 +88,7 @@ export function useCNCAccounting(
   const team = useGetTeamQuery({ pathParams: { teamId } })
   const contracts = computed(() => team.data.value?.teamContracts ?? [])
 
-  /** Resolve a contract's lower-cased address by type (Ponder stores lowercase). */
+  /** Resolve a contract's lower-cased address by type (logs/args compare lowercase). */
   const addressOf = (type: ContractType): ComputedRef<string> =>
     computed(() => contracts.value.find((c) => c.type === type)?.address?.toLowerCase() ?? '')
 
@@ -106,32 +101,15 @@ export function useCNCAccounting(
     () => team.data.value?.safeAddress ?? contracts.value.find((c) => c.type === 'Safe')?.address
   )
 
-  // ── Ponder: one event query per deployed contract, enabled only when present.
-  // Variables/options follow the app's established Apollo pattern (reactive refs
-  // inside the objects, as in BankTransactions.vue) so the query fires once the
-  // contract address resolves from the team. ──
-  const ponderQuery = <T>(document: DocumentNode, address: ComputedRef<string>) =>
-    useApolloQuery<T>(
-      document,
-      { contractAddress: address, limit: EVENT_LIMIT },
-      {
-        enabled: computed(() => Boolean(address.value)),
-        pollInterval: GRAPHQL_POLL_INTERVAL,
-        fetchPolicy: 'cache-and-network'
-      }
-    )
-
-  const bank = ponderQuery<BankEventsQuery>(GET_BANK_EVENTS, bankAddress)
-  const cashRem = ponderQuery<CashRemunerationEventsQuery>(
-    GET_CASH_REMUNERATION_EVENTS,
-    cashRemAddress
-  )
-  const expense = ponderQuery<ExpenseEventsQuery>(GET_EXPENSE_EVENTS, expenseAddress)
-  const investor = ponderQuery<InvestorEventsQuery>(GET_INVESTOR_EVENTS, investorAddress)
-  const router = ponderQuery<SafeDepositRouterEventsQuery>(
-    GET_SAFE_DEPOSIT_ROUTER_EVENTS,
-    routerAddress
-  )
+  // ── On-chain events via getLogs: one composable per deployed contract, each
+  // enabled only when its address resolves from the team. Every composable scans
+  // the contract from its deploy block and returns the exact same shape the Ponder
+  // queries did, so everything downstream (mappers, assemble) is unchanged. ──
+  const bank = useBankEventsViaLogs(bankAddress)
+  const cashRem = useCashRemunerationEventsViaLogs(cashRemAddress)
+  const expense = useExpenseEventsViaLogs(expenseAddress)
+  const investor = useInvestorEventsViaLogs(investorAddress)
+  const router = useSafeDepositRouterEventsViaLogs(routerAddress)
 
   // ── Contract read: the router's live SHER multiplier. The `MultiplierUpdated`
   // events historise *changes*, but the initial multiplier is set in the

--- a/app/src/composables/eventsViaLogs.ts
+++ b/app/src/composables/eventsViaLogs.ts
@@ -150,9 +150,12 @@ export function useContractEventsViaLogs<T>(opts: EventsViaLogsOptions<T>) {
   })
 
   // Mirror @vue/apollo-composable's shape so it drops into the *Transactions.vue.
+  // `refetch` is exposed so consumers (e.g. useCNCAccounting's refresh) can force
+  // a re-scan the same way they did with the Apollo queries.
   return {
     result: query.data,
     loading: query.isPending,
-    error: query.error
+    error: query.error,
+    refetch: query.refetch
   }
 }

--- a/app/src/utils/accounting/__tests__/enrichment.spec.ts
+++ b/app/src/utils/accounting/__tests__/enrichment.spec.ts
@@ -85,6 +85,49 @@ describe('enrichEntries', () => {
     expect(entry.memo).toContain('#42')
   })
 
+  it('pairs each settlement to the claim it actually paid (by amount), not the nearest week', () => {
+    // Two claims settled on the same day: 5h and 10h at 10 usdc/h → 50 and 100 usdc.
+    // Both withdrawals are dated in the later week, so "nearest week" would collapse
+    // them onto the 10h claim; amount-matching must keep each on its own claim.
+    const wage = { ratePerHour: [{ type: 'usdc', amount: 10 }], maximumHoursPerWeek: 40 }
+    const fiveHours = {
+      memberAddress: ADDR.member,
+      weekStart: new Date(1_700_000_000 * 1000).toISOString(),
+      minutesWorked: 300,
+      wage,
+      claims: []
+    } as unknown as WeeklyClaim
+    const tenHours = {
+      memberAddress: ADDR.member,
+      weekStart: new Date(1_700_600_000 * 1000).toISOString(),
+      minutesWorked: 600,
+      wage,
+      claims: []
+    } as unknown as WeeklyClaim
+
+    const settle = (id: string, rawAmount: string): LedgerEntry =>
+      makeEntry({
+        id,
+        timestamp: 1_700_650_000, // both near the 10h week
+        useCase: 'UC-CASH-03',
+        debit: 'Wage Payable',
+        credit: 'Cash — Payroll',
+        amountUsd: 0,
+        token: 'usdc',
+        rawAmount,
+        counterparty: ADDR.member,
+        memo: 'Wage withdrawal — cash settlement',
+        enrichment: 'needs-off-chain-data'
+      })
+
+    const [fivePaid, tenPaid] = enrichEntries(
+      [settle('s5', '50000000'), settle('s10', '100000000')],
+      { weeklyClaims: [fiveHours, tenHours] }
+    )
+    expect(fivePaid.minutesWorked).toBe(300)
+    expect(tenPaid.minutesWorked).toBe(600)
+  })
+
   it('keeps the needs-off-chain-data flag when no portal record matches', () => {
     const [entry] = enrichEntries([payrollEntry()], { weeklyClaims: [] })
     expect(entry.enrichment).toBe('needs-off-chain-data')

--- a/app/src/utils/accounting/enrichment.ts
+++ b/app/src/utils/accounting/enrichment.ts
@@ -18,6 +18,7 @@ import { getAddress, isAddress, type Address } from 'viem'
 import type { TokenId } from '@/constant'
 import type { Wage, WeeklyClaim } from '@/types/cash-remuneration'
 import type { ExpenseResponse } from '@/types/expense-account'
+import { buildClaimRatesWithOvertime } from '@/utils/wageUtil'
 import type { LedgerEntry } from './ledgerEntry'
 
 export interface EnrichmentSources {
@@ -57,6 +58,59 @@ function nearest<T>(
   return rows.reduce((best, row) =>
     Math.abs(dateOf(row) - target) < Math.abs(dateOf(best) - target) ? row : best
   )
+}
+
+/**
+ * The claim's signed payout total, in base units, for the token a withdrawal
+ * settled — the reliable key for pairing a settlement to its claim. Reuses the
+ * canonical wage calc (the one the claim is signed and paid with), so it equals
+ * the on-chain amount exactly. `null` when the claim has no rate in that token.
+ */
+function claimTokenTotal(claim: WeeklyClaim, token: TokenId): bigint | null {
+  const rates = claim.wage?.ratePerHour
+  if (!rates?.length) return null
+  try {
+    const totals = buildClaimRatesWithOvertime({
+      totalMinutesWorked: claim.minutesWorked,
+      maximumHoursPerWeek: claim.wage.maximumHoursPerWeek,
+      ratePerHour: rates,
+      overtimeRatePerHour: claim.wage.overtimeRatePerHour
+    })
+    return totals.find((r) => (r.type as TokenId) === token)?.totalAmount ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Take the claim that backs a payroll settlement out of the member's pool, so it
+ * can never match a second withdrawal. Several claims often settle on the same
+ * day, so date proximity alone collapses them onto the most recent one; we prefer
+ * the claim whose signed total in the withdrawn token equals the amount actually
+ * withdrawn, and only fall back to the nearest by week when no amount matches.
+ */
+function takePayrollClaim(
+  pool: WeeklyClaim[] | undefined,
+  entry: LedgerEntry
+): WeeklyClaim | undefined {
+  if (!pool?.length) return undefined
+  let amount: bigint | null = null
+  try {
+    amount = BigInt(entry.rawAmount)
+  } catch {
+    amount = null
+  }
+  const exact =
+    amount != null && amount > 0n
+      ? pool.filter((c) => claimTokenTotal(c, entry.token) === amount)
+      : []
+  const candidates = exact.length ? exact : pool
+  const chosen = nearest(candidates, entry.timestamp, (c) => new Date(c.weekStart).getTime())
+  if (chosen) {
+    const idx = pool.indexOf(chosen)
+    if (idx >= 0) pool.splice(idx, 1)
+  }
+  return chosen
 }
 
 /** Human label for a wage rate, e.g. "12 usdc/h". */
@@ -112,9 +166,7 @@ export function enrichEntries(
     if (!member) return entry
 
     if (entry.useCase === 'UC-CASH-03') {
-      const claim = nearest(claimsByMember.get(member), entry.timestamp, (c) =>
-        new Date(c.weekStart).getTime()
-      )
+      const claim = takePayrollClaim(claimsByMember.get(member), entry)
       return enrichPayroll(entry, claim)
     }
     if (entry.useCase === 'UC-EXP-01') {


### PR DESCRIPTION
# Description

## Initial Issue Description

Fixes #2331 — the accounting page depended on a separate indexing service to read a team's on-chain history. When that service was down or lagging, the books came up incomplete or empty.

## PR Summary 

The accounting data layer now rebuilds each team's on-chain history **directly from the blockchain** instead of querying the indexing service. Per contract it reads the event logs from the deploy block, decodes them against the contract's multi-version ABI, dates each event from its block, and returns the **exact same shape** the indexer queries did — so every mapper and the statement engine are untouched. All five sources are migrated (Bank, CashRemuneration, Expense, InvestorV1, SafeDepositRouter), plus the global FeeCollector fees. The data-source swap lives in `useCNCAccounting`; the reusable base is `useContractEventsViaLogs`, which now also exposes `refetch` so a manual refresh re-scans the chain.



## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- New unit test reproducing the same-day multi-claim settlement pairing.
- `app/` accounting suites pass: 263 accounting-util tests + 16 accounting-composable tests green.
