### PR TITLE
perf: ⚡️ reduce redundant blockchain requests on the accounting page

### DIFF
--- a/app/src/composables/eventsViaLogs.ts
+++ b/app/src/composables/eventsViaLogs.ts
@@ -5,7 +5,8 @@
  *   - getLogs on the contract from the deploy start block,
  *   - decode against a multi-version union ABI (a beacon proxy's logs span every
  *     implementation it ran, so we need all versions),
- *   - one getBlock per unique block for timestamps (logs don't carry them),
+ *   - a getBlock per *uncached* block for timestamps (logs don't carry them; a
+ *     process-wide cache dedupes blocks across feeds and refetches),
  *   - iterate the decoded logs through a caller-supplied `mapEvent`.
  *
  * Optionally, `extraLogs` fetches a second, already-filtered log set (e.g. the
@@ -24,6 +25,17 @@ import { currentChainId } from '@/constant'
 // so scan from block 0; a Polygon-only start block there yields an empty range.
 const POLYGON_START_BLOCK = 79743826n
 export const START_BLOCK = currentChainId === 137 ? POLYGON_START_BLOCK : 0n
+
+/**
+ * Shared block-number → Unix-seconds cache. A mined block's timestamp never
+ * changes, so it is memoised process-wide and reused across every contract feed
+ * and every refetch: a block that several feeds touch (or the same feed re-scans)
+ * is fetched from the RPC only once, instead of one `getBlock` per contract and
+ * again on each re-scan. Keyed by chain so it stays correct if the active chain
+ * changes within a session.
+ */
+const blockTimestampCache = new Map<string, number>()
+const blockCacheKey = (blockNumber: bigint): string => `${currentChainId}-${blockNumber}`
 
 /** Concatenate several ABIs into a single event ABI, deduped by signature. */
 export function unionEventAbi(abis: unknown[]): Abi {
@@ -105,17 +117,23 @@ export function useContractEventsViaLogs<T>(opts: EventsViaLogsOptions<T>) {
       const decoded = parseEventLogs({ abi: opts.eventAbi, logs: rawLogs, strict: false })
       const extra = opts.extraLogs ? await opts.extraLogs(client, contract) : []
 
-      // One getBlock per unique block (contract + extra logs) for timestamps.
+      // Timestamps for each unique block the logs touch (logs carry none). Only
+      // blocks missing from the shared cache are fetched; with the transport's
+      // batching those `getBlock` calls collapse into a single JSON-RPC POST.
       const blockNumbers = [
         ...new Set(
           [...decoded, ...extra].map((l) => l.blockNumber).filter((b): b is bigint => b != null)
         )
       ]
-      const blocks = await Promise.all(
-        blockNumbers.map((blockNumber) => client.getBlock({ blockNumber }))
+      const uncached = blockNumbers.filter((n) => !blockTimestampCache.has(blockCacheKey(n)))
+      const fetched = await Promise.all(
+        uncached.map((blockNumber) => client.getBlock({ blockNumber }))
       )
-      const tsByBlock = new Map(blocks.map((b) => [b.number, Number(b.timestamp)]))
-      const tsOf = (blockNumber: bigint | null) => tsByBlock.get(blockNumber ?? 0n) ?? 0
+      for (const block of fetched) {
+        blockTimestampCache.set(blockCacheKey(block.number), Number(block.timestamp))
+      }
+      const tsOf = (blockNumber: bigint | null) =>
+        blockNumber == null ? 0 : (blockTimestampCache.get(blockCacheKey(blockNumber)) ?? 0)
 
       const out = opts.empty()
 

--- a/app/src/wagmi.config.ts
+++ b/app/src/wagmi.config.ts
@@ -20,25 +20,32 @@ const isE2E = import.meta.env.VITE_E2E === 'true'
  * priority) and the public endpoints (drpc, publicnode) are the safety net.
  * These are current-state reads (`eth_call`/`getBalance`), so publicnode's log
  * pruning is irrelevant here.
+ *
+ * `batch: true` collapses every RPC call fired in the same tick into a single
+ * JSON-RPC POST. Feeds that fan out many calls at once — e.g. the accounting
+ * event scan's one `getBlock` per block — then cost one HTTP round-trip instead
+ * of N, without changing any call site.
  */
 const polygonRpcUrl = import.meta.env.VITE_APP_POLYGON_RPC_URL
+
+const batched = { batch: true } as const
 
 export const config = createConfig({
   chains: [mainnet, sepolia, polygon, hardhat, polygonAmoy],
   connectors: isE2E ? [e2eMockConnector()] : [injected()],
   transports: {
     [mainnet.id]: fallback([
-      http(),
-      http('https://eth.drpc.org'),
-      http('https://ethereum-rpc.publicnode.com')
+      http(undefined, batched),
+      http('https://eth.drpc.org', batched),
+      http('https://ethereum-rpc.publicnode.com', batched)
     ]),
-    [sepolia.id]: http('https://sepolia.drpc.org'),
+    [sepolia.id]: http('https://sepolia.drpc.org', batched),
     [polygon.id]: fallback([
-      ...(polygonRpcUrl ? [http(polygonRpcUrl)] : []),
-      http('https://polygon.drpc.org'),
-      http('https://polygon-bor-rpc.publicnode.com')
+      ...(polygonRpcUrl ? [http(polygonRpcUrl, batched)] : []),
+      http('https://polygon.drpc.org', batched),
+      http('https://polygon-bor-rpc.publicnode.com', batched)
     ]),
-    [polygonAmoy.id]: http(),
-    [hardhat.id]: http()
+    [polygonAmoy.id]: http(undefined, batched),
+    [hardhat.id]: http(undefined, batched)
   }
 })


### PR DESCRIPTION
# Description

Fixes #2333 — loading the accounting page fired a large burst of blockchain requests: one per block to read block times, repeated on every refresh and duplicated across contracts.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `app/` type-check, lint and format clean.
- Accounting composable + util suites pass (no change to results).
