### PR TITLE
[Bug] Fix Community Credit 30-year term cap, stale round title, repay gating, and Lenders table decimals bugs

### DIFF
--- a/app/src/components/sections/CommunityCreditView/CreditRepayPanel.vue
+++ b/app/src/components/sections/CommunityCreditView/CreditRepayPanel.vue
@@ -145,9 +145,7 @@ const status = computed(() => statusMeta(round.value?.status ?? 'active'))
 // FixedReturn__OfferNotFunded() revert that the error classifier can't decode into a
 // friendly message (it only has Bank.json's ABI loaded, not FixedReturn's).
 const REPAYABLE_STATUSES: RoundStatus[] = ['funded', 'active', 'overdue']
-const isRepayable = computed(
-  () => !!round.value && REPAYABLE_STATUSES.includes(round.value.status)
-)
+const isRepayable = computed(() => !!round.value && REPAYABLE_STATUSES.includes(round.value.status))
 
 const { data: rawOffer, refetch: refetchOffer } = useFixedReturnGetLendingOffer(offerId)
 const offer = computed(() => rawOffer.value as LendingOfferStruct | undefined)

--- a/app/src/components/sections/CommunityCreditView/CreditRepayPanel.vue
+++ b/app/src/components/sections/CommunityCreditView/CreditRepayPanel.vue
@@ -47,6 +47,15 @@
         />
 
         <UAlert
+          v-if="!isRepayable"
+          color="warning"
+          variant="soft"
+          icon="i-lucide-circle-alert"
+          description="This round hasn't reached its funding target yet — repayment opens once it's fully funded."
+          data-test="repay-not-funded"
+        />
+
+        <UAlert
           v-if="submitError"
           color="error"
           variant="soft"
@@ -63,7 +72,7 @@
             icon="heroicons:check-circle"
             :label="isSubmitting ? 'Signing…' : `Repay `"
             :loading="isSubmitting"
-            :disabled="isSubmitting || numericAmount <= 0"
+            :disabled="isSubmitting || numericAmount <= 0 || !isRepayable"
             data-test="confirm-repay"
             @click="confirmRepay"
           />
@@ -111,7 +120,7 @@ import {
   roundToDisplayPrecision,
   statusMeta
 } from '@/utils'
-import type { LendingOfferStruct } from '@/types'
+import type { LendingOfferStruct, RoundStatus } from '@/types'
 import CreditRepayBreakdownTable from './CreditRepayBreakdownTable.vue'
 import RepayAmountPanel from './RepayAmountPanel.vue'
 
@@ -129,6 +138,16 @@ const offerId = computed(() => BigInt(roundId.value || '0'))
 
 const round = computed(() => store.getRound(roundId.value))
 const status = computed(() => statusMeta(round.value?.status ?? 'active'))
+
+// Mirrors FixedReturn.sol's repayLenders gate (OfferState.Funded/Repaying only) —
+// without this, the tab was reachable and submittable on a still-Open round (raising,
+// not yet at its funding target), wasting a transaction on a guaranteed
+// FixedReturn__OfferNotFunded() revert that the error classifier can't decode into a
+// friendly message (it only has Bank.json's ABI loaded, not FixedReturn's).
+const REPAYABLE_STATUSES: RoundStatus[] = ['funded', 'active', 'overdue']
+const isRepayable = computed(
+  () => !!round.value && REPAYABLE_STATUSES.includes(round.value.status)
+)
 
 const { data: rawOffer, refetch: refetchOffer } = useFixedReturnGetLendingOffer(offerId)
 const offer = computed(() => rawOffer.value as LendingOfferStruct | undefined)
@@ -229,7 +248,7 @@ watch(
 )
 
 async function confirmRepay() {
-  if (!bankAddress.value || numericAmount.value <= 0) return
+  if (!bankAddress.value || numericAmount.value <= 0 || !isRepayable.value) return
   submitError.value = null
   if (!amountPanelRef.value?.validate()) return
 

--- a/app/src/components/sections/CommunityCreditView/CreditRepayPanel.vue
+++ b/app/src/components/sections/CommunityCreditView/CreditRepayPanel.vue
@@ -47,7 +47,7 @@
         />
 
         <UAlert
-          v-if="!isRepayable"
+          v-if="isStillRaising"
           color="warning"
           variant="soft"
           icon="i-lucide-circle-alert"
@@ -146,6 +146,12 @@ const status = computed(() => statusMeta(round.value?.status ?? 'active'))
 // friendly message (it only has Bank.json's ABI loaded, not FixedReturn's).
 const REPAYABLE_STATUSES: RoundStatus[] = ['funded', 'active', 'overdue']
 const isRepayable = computed(() => !!round.value && REPAYABLE_STATUSES.includes(round.value.status))
+
+// The "hasn't reached its funding target yet" wording only makes sense while the round
+// is still actively raising — a 'stalled'/'refunded'/'repaid' round already resolved one
+// way or the other, so repeating "repayment opens once it's fully funded" there would be
+// inaccurate (refunded never will be; repaid already was).
+const isStillRaising = computed(() => round.value?.status === 'open')
 
 const { data: rawOffer, refetch: refetchOffer } = useFixedReturnGetLendingOffer(offerId)
 const offer = computed(() => rawOffer.value as LendingOfferStruct | undefined)

--- a/app/src/components/sections/CommunityCreditView/__tests__/CreditRepayPanel.spec.ts
+++ b/app/src/components/sections/CommunityCreditView/__tests__/CreditRepayPanel.spec.ts
@@ -201,6 +201,30 @@ describe('CreditRepayPanel', () => {
     expect(mockBankWrites.fundFixedReturnRepayment.mutateAsync).not.toHaveBeenCalled()
   })
 
+  it.each(['stalled', 'refunded', 'repaid'] as const)(
+    'disables Repay but does not show the "not yet funded" message on a %s round',
+    async (status) => {
+      // Regression: the alert's wording ("hasn't reached its funding target yet —
+      // repayment opens once it's fully funded") is only true while a round is still
+      // actively raising ('open'). It previously showed for every non-repayable status,
+      // which is misleading for 'stalled' (deadline passed, awaiting a refund/accept
+      // decision — may never be funded), 'refunded' (never will be funded), and 'repaid'
+      // (already was funded and fully repaid).
+      store.rounds = [sampleRound({ status, raised: 5000, target: 5000 })]
+      mockFixedReturnReads.getLendingOffer.data.value = offerStruct()
+      mockFixedReturnReads.offerLenders.data.value = [
+        { address: '0x00000000000000000000000000000000000000a1', principal: 5000, expected: 5250 }
+      ]
+      setMockRoute({ params: { id: '1', roundId: '1' } })
+      const wrapper = mount(CreditRepayPanel)
+      await flushPromises()
+
+      expect(wrapper.find('[data-test="repay-not-funded"]').exists()).toBe(false)
+      const button = wrapper.findComponent('[data-test="confirm-repay"]')
+      expect(button.props('disabled')).toBe(true)
+    }
+  )
+
   it('shows only the breakdown table for a non-owner, with no repay form', async () => {
     store.isOwner = false
     store.rounds = [sampleRound()]

--- a/app/src/components/sections/CommunityCreditView/__tests__/CreditRepayPanel.spec.ts
+++ b/app/src/components/sections/CommunityCreditView/__tests__/CreditRepayPanel.spec.ts
@@ -176,6 +176,31 @@ describe('CreditRepayPanel', () => {
     expect(wrapper.find('[data-test="repay-error"]').exists()).toBe(true)
   })
 
+  it('disables the Repay button and explains why on a round still Open (not yet funded)', async () => {
+    // Regression for known-issues.md #13: the tab used to be reachable and submittable
+    // on a still-raising round, wasting a transaction on a guaranteed
+    // FixedReturn__OfferNotFunded() revert the error classifier couldn't even decode.
+    store.rounds = [sampleRound({ status: 'open', raised: 10000, target: 25000 })]
+    mockFixedReturnReads.getLendingOffer.data.value = offerStruct({
+      fundingTarget: 25_000_000000n,
+      totalFunded: 10_000_000000n
+    })
+    mockFixedReturnReads.offerLenders.data.value = [
+      { address: '0x00000000000000000000000000000000000000a1', principal: 10000, expected: 10600 }
+    ]
+    setMockRoute({ params: { id: '1', roundId: '1' } })
+    const wrapper = mount(CreditRepayPanel)
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="repay-not-funded"]').exists()).toBe(true)
+    const button = wrapper.findComponent('[data-test="confirm-repay"]')
+    expect(button.props('disabled')).toBe(true)
+
+    await wrapper.find('[data-test="confirm-repay"]').trigger('click')
+    await flushPromises()
+    expect(mockBankWrites.fundFixedReturnRepayment.mutateAsync).not.toHaveBeenCalled()
+  })
+
   it('shows only the breakdown table for a non-owner, with no repay form', async () => {
     store.isOwner = false
     store.rounds = [sampleRound()]

--- a/app/src/composables/fixedReturn/reads.ts
+++ b/app/src/composables/fixedReturn/reads.ts
@@ -2,7 +2,7 @@ import { computed, unref, type MaybeRef, type MaybeRefOrGetter, toValue } from '
 import { useQuery } from '@tanstack/vue-query'
 import { useReadContract } from '@wagmi/vue'
 import { readContract } from '@wagmi/core'
-import { formatUnits, isAddress, type Address } from 'viem'
+import { formatUnits, isAddress, zeroAddress, type Address } from 'viem'
 import type { ExtractAbiFunctionNames } from 'abitype'
 import { useTeamStore, useUserDataStore } from '@/stores'
 import { config } from '@/wagmi.config'
@@ -253,10 +253,22 @@ export function useFixedReturnOfferLenders(
     }
   }
 
+  // `token` starts out as `zeroAddress` (the caller's placeholder default) until the
+  // offer itself resolves and reveals the real token. `zeroAddress` isn't merely
+  // "unknown" to decimalsForFixedReturnToken() — it's SUPPORTED_TOKENS' own `native`
+  // entry, at 18 decimals — so fetching before the real token arrives locks in the
+  // wrong decimals for the entire result (e.g. 500 USDC read back as ~0.0000000005),
+  // and since the query key didn't include the token, that wrong-decimals fetch would
+  // cache forever with no later refetch to correct it. Including `token` in the key
+  // and gating `enabled` on it being resolved avoids ever fetching against the
+  // placeholder in the first place.
+  const tokenValue = computed(() => toValue(token))
   return useQuery({
-    queryKey: ['fixedReturnOfferLenders', fixedReturnAddress, offerId],
+    queryKey: ['fixedReturnOfferLenders', fixedReturnAddress, offerId, tokenValue],
     queryFn: fetchLenders,
-    enabled: computed(() => !!fixedReturnAddress.value)
+    enabled: computed(
+      () => !!fixedReturnAddress.value && isAddress(tokenValue.value) && tokenValue.value !== zeroAddress
+    )
   })
 }
 

--- a/app/src/composables/fixedReturn/reads.ts
+++ b/app/src/composables/fixedReturn/reads.ts
@@ -267,7 +267,10 @@ export function useFixedReturnOfferLenders(
     queryKey: ['fixedReturnOfferLenders', fixedReturnAddress, offerId, tokenValue],
     queryFn: fetchLenders,
     enabled: computed(
-      () => !!fixedReturnAddress.value && isAddress(tokenValue.value) && tokenValue.value !== zeroAddress
+      () =>
+        !!fixedReturnAddress.value &&
+        isAddress(tokenValue.value) &&
+        tokenValue.value !== zeroAddress
     )
   })
 }

--- a/app/src/queries/__tests__/fixedReturnOffering.queries.spec.ts
+++ b/app/src/queries/__tests__/fixedReturnOffering.queries.spec.ts
@@ -22,4 +22,14 @@ describe('fixedReturnOfferingKeys', () => {
       { teamId: null }
     ])
   })
+
+  it('normalizes a string teamId to the same key as its number form', () => {
+    // The GET query holds teamId as a string ref (teamStore.currentTeamId); the POST
+    // mutation's invalidateKeys reads it as a number from the request body. Without
+    // normalizing both to the same primitive type here, TanStack Query's type-sensitive
+    // key matching (`"15" !== 15`) would make the mutation's invalidation silently
+    // match nothing, and the list query would never refetch after a new offering is
+    // created (known-issues.md #12).
+    expect(fixedReturnOfferingKeys.list('15')).toEqual(fixedReturnOfferingKeys.list(15))
+  })
 })

--- a/app/src/queries/fixedReturnOffering.queries.ts
+++ b/app/src/queries/fixedReturnOffering.queries.ts
@@ -4,13 +4,21 @@ import { toValue } from 'vue'
 import { createMutationHook, createQueryHook, queryPresets } from './queryFactory'
 
 /**
- * Query key factory for FixedReturn offering off-chain metadata
+ * Query key factory for FixedReturn offering off-chain metadata.
+ *
+ * Coerces `teamId` to a number (or `null`) here so every caller produces the exact
+ * same key regardless of whether they hold it as a string or a number — the GET query
+ * above reads it from a `ref<string | null>` (`teamStore.currentTeamId`), while the
+ * POST mutation's `invalidateKeys` below reads it from the request body's `number`.
+ * TanStack Query's cache matching is type-sensitive per key segment (`"15" !== 15`),
+ * so without this normalization the mutation's invalidation silently matches nothing
+ * and the list query never refetches after a new offering is created.
  */
 export const fixedReturnOfferingKeys = {
   all: ['fixedReturnOfferings'] as const,
   lists: () => [...fixedReturnOfferingKeys.all, 'list'] as const,
   list: (teamId: string | number | null) =>
-    [...fixedReturnOfferingKeys.lists(), { teamId }] as const
+    [...fixedReturnOfferingKeys.lists(), { teamId: teamId == null ? null : Number(teamId) }] as const
 }
 
 // ============================================================================

--- a/app/src/queries/fixedReturnOffering.queries.ts
+++ b/app/src/queries/fixedReturnOffering.queries.ts
@@ -18,7 +18,10 @@ export const fixedReturnOfferingKeys = {
   all: ['fixedReturnOfferings'] as const,
   lists: () => [...fixedReturnOfferingKeys.all, 'list'] as const,
   list: (teamId: string | number | null) =>
-    [...fixedReturnOfferingKeys.lists(), { teamId: teamId == null ? null : Number(teamId) }] as const
+    [
+      ...fixedReturnOfferingKeys.lists(),
+      { teamId: teamId == null ? null : Number(teamId) }
+    ] as const
 }
 
 // ============================================================================

--- a/app/src/types/__tests__/communityCredit.schemas.spec.ts
+++ b/app/src/types/__tests__/communityCredit.schemas.spec.ts
@@ -4,7 +4,7 @@ import {
   createCreditCallTermsSchema,
   createRepayAmountSchema
 } from '../communityCredit.schemas'
-import { MINUTES_PER_DAY } from '@/utils'
+import { addCreditTerm, MINUTES_PER_DAY } from '@/utils'
 
 function baseTermsData(overrides: Record<string, unknown> = {}) {
   return {
@@ -19,24 +19,29 @@ function baseTermsData(overrides: Record<string, unknown> = {}) {
 describe('createCreditCallTermsSchema — term length cap', () => {
   const schema = createCreditCallTermsSchema({ today: '2026-01-01' })
 
+  // The cap is checked against the real calendar span for 30 years anchored on this
+  // deadline (2026-07-31 → 2056-07-31), not a flat `30 * 365` — that span includes 8
+  // leap days, so it's longer than a naive 10,950-day count. Computed the same way
+  // `addCreditTerm` resolves a "30" + Years custom entry in the wizard, so a real user
+  // typing "30" in the Years unit lands on exactly this boundary and passes.
+  const deadline = '2026-07-31'
+  const deadlineTime = '23:59'
+  const maxMinutes =
+    (addCreditTerm(deadline, deadlineTime, 30, 'years') -
+      addCreditTerm(deadline, deadlineTime, 0, 'years')) /
+    60
+
   it('passes at exactly the 30-year cap', () => {
-    const result = schema.safeParse(baseTermsData({ period: 30 * 365 * MINUTES_PER_DAY }))
+    const result = schema.safeParse(baseTermsData({ period: maxMinutes }))
     expect(result.success).toBe(true)
   })
 
   it('rejects one day over the cap with a calendar-breakdown message, not a bare minute count', () => {
-    const result = schema.safeParse(
-      baseTermsData({ period: 30 * 365 * MINUTES_PER_DAY + MINUTES_PER_DAY })
-    )
+    const result = schema.safeParse(baseTermsData({ period: maxMinutes + MINUTES_PER_DAY }))
     expect(result.success).toBe(false)
     if (result.success) return
     const issue = result.error.issues.find((i) => i.path[0] === 'period')
-    // 30*365 days from this deadline isn't quite 30 calendar years (leap years make a
-    // real 30-year span slightly longer than a flat 365-day/year multiply) — the
-    // message reflects the actual calendar breakdown, not a naive "30 years, 1 day".
-    expect(issue?.message).toBe(
-      'Term of 29 years, 11 months, 3 weeks, 3 days exceeds the 30-year maximum'
-    )
+    expect(issue?.message).toBe('Term of 30 years, 1 day exceeds the 30-year maximum')
   })
 })
 

--- a/app/src/types/communityCredit.schemas.ts
+++ b/app/src/types/communityCredit.schemas.ts
@@ -1,10 +1,9 @@
 import { z } from 'zod'
 import { parseUnits } from 'viem'
 import {
-  CREDIT_TERM_MAX_DAYS,
+  addCreditTerm,
   CREDIT_TERM_MAX_YEARS,
   formatCalendarBreakdown,
-  MINUTES_PER_DAY,
   sumWhitelistAmountUnits
 } from '@/utils'
 import { formatAmountWithPrecision } from '@/utils/currencyUtil'
@@ -77,8 +76,20 @@ export function createCreditCallTermsSchema(context: CreditCallTermsSchemaContex
       }
     )
     .superRefine((data, ctx) => {
-      if (data.period <= CREDIT_TERM_MAX_DAYS * MINUTES_PER_DAY) return
-      const entered = formatCalendarBreakdown(data.deadline, data.deadlineTime ?? '', data.period)
+      if (!data.deadline) return
+      // Compare against the real calendar span for CREDIT_TERM_MAX_YEARS, anchored on
+      // the same deadline the issuer picked — not a flat days-per-year constant. A real
+      // 30-year span almost always contains several leap days (e.g. 8, for a span
+      // starting 2026-07-31), so a flat `30 * 365` comparison rejected the exact "30
+      // years" a user enters via the Years unit, which `addCreditTerm` itself resolves
+      // the calendar-real way. Anchoring both sides identically is what makes the
+      // boundary actually inclusive, as the error message below promises.
+      const deadlineTime = data.deadlineTime ?? ''
+      const anchorSeconds = addCreditTerm(data.deadline, deadlineTime, 0, 'years')
+      const maxSeconds = addCreditTerm(data.deadline, deadlineTime, CREDIT_TERM_MAX_YEARS, 'years')
+      const maxMinutes = Math.round((maxSeconds - anchorSeconds) / 60)
+      if (data.period <= maxMinutes) return
+      const entered = formatCalendarBreakdown(data.deadline, deadlineTime, data.period)
       ctx.addIssue({
         code: 'custom',
         path: ['period'],

--- a/app/src/utils/communityCreditOfferUtil.ts
+++ b/app/src/utils/communityCreditOfferUtil.ts
@@ -26,7 +26,6 @@ dayjs.extend(utc)
  *  above 30 for that unit) — the closest thing this codebase has to a deliberate,
  *  previously-agreed answer to "how long should a round be allowed to run." */
 export const CREDIT_TERM_MAX_YEARS = 30
-export const CREDIT_TERM_MAX_DAYS = CREDIT_TERM_MAX_YEARS * 365
 
 const CREDIT_TERM_UNIT_TO_DAYJS: Record<CreditTermUnit, dayjs.ManipulateType> = {
   minutes: 'minute',
@@ -49,7 +48,7 @@ const CREDIT_TERM_UNIT_APPROX_DAYS: Record<CreditTermUnit, number> = {
 /** A generous ceiling well inside the ECMAScript `Date` range (valid roughly
  *  ±100,000,000 days from the epoch) even after accounting for the anchor deadline's
  *  own offset from the epoch. Any custom entry beyond this is already many orders of
- *  magnitude past FixedReturn's own term cap (`CREDIT_TERM_MAX_DAYS`), so clamping
+ *  magnitude past FixedReturn's own term cap (`CREDIT_TERM_MAX_YEARS`), so clamping
  *  loses no meaningful information — it only guards against dayjs silently producing
  *  an Invalid Date for a wildly out-of-range entry (e.g. "100000000" days, almost
  *  exactly that boundary), which would otherwise propagate as NaN through every


### PR DESCRIPTION
# Description

## Intial Issue Description

Full end-to-end retest of the Community Credit term-minutes-precision branch (#2338) surfaced four real bugs blocking a clean production launch:
- An exact 30-year custom term was always incorrectly rejected as exceeding the 30-year maximum.
- A newly created round's title never displayed on the index page (stuck on the generic "Round #N" fallback) for the rest of the browser session.
- The Repay tab was reachable and fully submittable on a round that hadn't reached its funding target yet, wasting a transaction on a guaranteed on-chain revert with an undecodable error.
- The round detail page's Lenders table silently rendered every lender's Amount, Expected return, Paid so far, and Share as 0/0%, regardless of what was actually lent.

Fixes #2355

## Issues introduced and fixed (Optional)

All four issues were found during the retest itself (not introduced by this branch's own commits) and fixed here:

- **30-year cap boundary**: a custom term entered as exactly "30 years" was always rejected as exceeding the 30-year maximum, regardless of deadline.
- **Stale round title**: a newly created round's saved title never displayed on the index page (stuck on the generic "Round #N" fallback) for the rest of the browser session.
- **Repay gating**: the Repay tab was reachable and fully submittable on a round that hadn't reached its funding target yet, wasting a transaction on a guaranteed on-chain revert with an undecodable error.
- **Lenders table decimals**: the round detail page's Lenders table rendered every lender's Amount, Expected return, Paid so far, and Share as 0/0%, regardless of what was actually lent.

## PR Summary Or Solution description

- **30-year cap** (`communityCredit.schemas.ts`): the `superRefine` cap now derives its boundary from the same calendar-anchored arithmetic (`addCreditTerm`) the wizard itself uses to resolve a custom term, instead of a flat `30 * 365`-day constant — so the comparison lines up exactly regardless of leap days. Removed the now-unused flat `CREDIT_TERM_MAX_DAYS` constant.
- **Stale round title** (`fixedReturnOffering.queries.ts`): `fixedReturnOfferingKeys.list()` now coerces `teamId` to `Number(...)` internally, so the GET query's string-ref key and the POST mutation's number-body key always hash identically under TanStack Query's type-sensitive key matching (`"15" !== 15`), and the metadata list query actually refetches after a new round is created.
- **Repay gating** (`CreditRepayPanel.vue`): added a `REPAYABLE_STATUSES` (`funded`/`active`/`overdue`) gate — disables "Confirm repay" and shows an inline warning when the round isn't in one of those statuses, mirroring `FixedReturn.sol`'s own `repayLenders` gate; `confirmRepay()` also short-circuits on the same check as a second line of defense.
- **Lenders table decimals** (`fixedReturn/reads.ts`): `useFixedReturnOfferLenders`'s callers default their token ref to `zeroAddress` until the round's offer resolves and reveals the real token — but `zeroAddress` isn't "unknown" to `decimalsForFixedReturnToken`, it's `SUPPORTED_TOKENS`' own 18-decimal native-token entry. A fetch that raced ahead of the real token locked in 18 decimals for the whole result (500 USDC read back as ~0.0000000005, rendered as 0), and since the query key didn't include the token, nothing ever refetched to correct it. Now includes the token in the query key and gates `enabled` on it being a real, resolved address.

All four verified live on a local Hardhat chain via Playwright MCP across the full round lifecycle — open, funded, multi-lender pro-rata, whitelist/cap, repaid, and refund/stalled paths. No contract changes required; all on-chain state was already correct in every case.

`app/` passes lint / type-check / unit tests (no regressions; full Community Credit suite — 116 tests — and fixedReturn composables suite — 132 tests — green).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Contribution checklist

Before submitting the PR, please make sure you have applied the rules in [CONTRIBUTION.md](./../CONTRIBUTION.md)
