### PR TITLE
feat ✨: book Community Credit (FixedReturn) in the accounting engine

### DIFF
--- a/app/src/composables/accounting/__tests__/useCNCAccounting.spec.ts
+++ b/app/src/composables/accounting/__tests__/useCNCAccounting.spec.ts
@@ -20,6 +20,9 @@ vi.mock('@/composables/cashRemuneration/useCashRemunerationEventsViaLogs', () =>
 vi.mock('@/composables/expense/useExpenseEventsViaLogs', () => ({
   useExpenseEventsViaLogs: () => emptyLogsFeed()
 }))
+vi.mock('@/composables/fixedReturn/useFixedReturnEventsViaLogs', () => ({
+  useFixedReturnEventsViaLogs: () => emptyLogsFeed()
+}))
 vi.mock('@/composables/investor/useInvestorEventsViaLogs', () => ({
   useInvestorEventsViaLogs: () => emptyLogsFeed()
 }))

--- a/app/src/composables/accounting/useCNCAccounting.ts
+++ b/app/src/composables/accounting/useCNCAccounting.ts
@@ -5,8 +5,9 @@
  * the three financial statements to the UI from a single composable:
  *
  *   - **On-chain (getLogs)** — events for the team's Bank, CashRemuneration,
- *     Expense, InvestorV1 and SafeDepositRouter contracts, reconstructed from the
- *     RPC via the shared `use*EventsViaLogs` composables (no indexer dependency).
+ *     Expense, FixedReturn (Community Credit), InvestorV1 and SafeDepositRouter
+ *     contracts, reconstructed from the RPC via the shared `use*EventsViaLogs`
+ *     composables (no indexer dependency).
  *   - **Safe** — the team Safe's incoming native / ERC-20 transfers (spec §3.1).
  *   - **Backend DB** — the team's contracts, signed weekly claims and approved
  *     expenses, the off-chain accrual + category context (spec §3.2).
@@ -27,6 +28,7 @@ import type { ContractType } from '@/types/teamContract'
 import { useBankEventsViaLogs } from '@/composables/bank/useBankEventsViaLogs'
 import { useCashRemunerationEventsViaLogs } from '@/composables/cashRemuneration/useCashRemunerationEventsViaLogs'
 import { useExpenseEventsViaLogs } from '@/composables/expense/useExpenseEventsViaLogs'
+import { useFixedReturnEventsViaLogs } from '@/composables/fixedReturn/useFixedReturnEventsViaLogs'
 import { useInvestorEventsViaLogs } from '@/composables/investor/useInvestorEventsViaLogs'
 import { useSafeDepositRouterEventsViaLogs } from '@/composables/investor/useSafeDepositRouterEventsViaLogs'
 import { useGetTeamQuery } from '@/queries/team.queries'
@@ -99,6 +101,7 @@ export function useCNCAccounting(
   const bankAddress = addressOf('Bank')
   const cashRemAddress = addressOf('CashRemunerationEIP712')
   const expenseAddress = addressOf('ExpenseAccountEIP712')
+  const fixedReturnAddress = addressOf('FixedReturn')
   const investorAddress = addressOfInvestor()
   const routerAddress = addressOf('SafeDepositRouter')
   const safeAddress = computed(
@@ -112,6 +115,7 @@ export function useCNCAccounting(
   const bank = useBankEventsViaLogs(bankAddress)
   const cashRem = useCashRemunerationEventsViaLogs(cashRemAddress)
   const expense = useExpenseEventsViaLogs(expenseAddress)
+  const fixedReturn = useFixedReturnEventsViaLogs(fixedReturnAddress)
   const investor = useInvestorEventsViaLogs(investorAddress)
   const router = useSafeDepositRouterEventsViaLogs(routerAddress)
 
@@ -179,6 +183,7 @@ export function useCNCAccounting(
     bankEvents: bank.result.value,
     cashRemunerationEvents: cashRem.result.value,
     expenseEvents: expense.result.value,
+    fixedReturnEvents: fixedReturn.result.value,
     investorEvents: investor.result.value,
     safeDepositRouterEvents: router.result.value,
     safeTransfers: safeTransfers.data.value,
@@ -226,6 +231,7 @@ export function useCNCAccounting(
       bank.loading.value ||
       cashRem.loading.value ||
       expense.loading.value ||
+      fixedReturn.loading.value ||
       investor.loading.value ||
       router.loading.value ||
       weeklyClaims.isLoading.value ||
@@ -242,6 +248,7 @@ export function useCNCAccounting(
         bank,
         cashRem,
         expense,
+        fixedReturn,
         investor,
         router,
         routerMultiplier,

--- a/app/src/utils/accounting/__tests__/assemble.fixedReturn.spec.ts
+++ b/app/src/utils/accounting/__tests__/assemble.fixedReturn.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * End-to-end assembly of a Community Credit (FixedReturn) round — the feed goes
+ * in raw and the ledger, income statement and balance sheet come out. The
+ * per-event mapping is covered in `fixedReturn.spec.ts`; what matters here is
+ * that the round reaches the statements and the books still balance.
+ */
+import { describe, it, expect } from 'vitest'
+import type { Address } from 'viem'
+import type { TeamContract, ContractType } from '@/types/teamContract'
+import { assembleCncAccounting, type CncAccountingInput } from '@/utils/accounting/assemble'
+import type { UsdRateOfRecord } from '@/utils/accounting/toUsd'
+import { USDC_ADDRESS } from '@/constant'
+import { ADDR } from './fixtures'
+
+const FIXED_RETURN = ADDR.credit as Address
+const DEPLOYER = ADDR.founder as Address
+
+const CONTRACTS: TeamContract[] = (
+  [
+    ['Bank', ADDR.bank],
+    ['Safe', ADDR.safe],
+    ['FixedReturn', FIXED_RETURN]
+  ] as [ContractType, string][]
+).map(([type, address]) => ({ type, address: address as Address, deployer: DEPLOYER, admins: [] }))
+
+/** Stub rate of record: native $2 (USDC is pegged $1 by toUsd). */
+const RATE: UsdRateOfRecord = (tokenId) => (tokenId === 'native' ? 2 : 1)
+
+const BASE: CncAccountingInput = {
+  contracts: CONTRACTS,
+  safeAddress: ADDR.safe,
+  founderAddresses: [ADDR.founder],
+  feeCollectorAddress: ADDR.feeCollector,
+  rateOfRecord: RATE
+}
+
+describe('assembleCncAccounting — Community Credit', () => {
+  it('runs a Community Credit round through to the statements', () => {
+    const emptyFixedReturn = {
+      fixedReturnLendingOfferRefundables: { items: [] },
+      fixedReturnPartialFundingAccepteds: { items: [] },
+      fixedReturnPrincipalRefundeds: { items: [] },
+      fixedReturnRefundsDistributeds: { items: [] },
+      fixedReturnRepaymentDistributeds: { items: [] },
+      fixedReturnOwnershipTransferreds: { items: [] },
+      fixedReturnTokenSupportAddeds: { items: [] },
+      fixedReturnTokenSupportRemoveds: { items: [] }
+    }
+    const a = assembleCncAccounting({
+      ...BASE,
+      fixedReturnEvents: {
+        ...emptyFixedReturn,
+        fixedReturnLendingOfferCreateds: {
+          items: [
+            {
+              id: 'fc1',
+              contractAddress: FIXED_RETURN,
+              offerId: '1',
+              token: USDC_ADDRESS,
+              fundingTarget: '100000000', // 100 USDC
+              timestamp: 100
+            }
+          ]
+        },
+        fixedReturnFundsLents: {
+          items: [
+            {
+              id: 'fl1',
+              contractAddress: FIXED_RETURN,
+              offerId: '1',
+              lender: ADDR.lender,
+              amount: '100000000',
+              timestamp: 110
+            }
+          ]
+        },
+        fixedReturnLendingOfferFundeds: {
+          items: [{ id: 'fd1', contractAddress: FIXED_RETURN, offerId: '1', timestamp: 110 }]
+        },
+        // Repaid in full: 100 principal + 5 fixed return.
+        fixedReturnLenderRepaids: {
+          items: [
+            {
+              id: 'rp1',
+              contractAddress: FIXED_RETURN,
+              offerId: '1',
+              lender: ADDR.lender,
+              amount: '105000000',
+              timestamp: 200
+            }
+          ]
+        }
+      }
+    })
+
+    // The borrowed cash reached Bank, then left again with the interest on top.
+    expect(a.summary.cash).toBe(-5)
+    // Principal in and out nets the liability to zero; only the return is a cost.
+    expect(a.balanceSheet.liabilities).toEqual([])
+    expect(a.incomeStatement.expenses).toContainEqual({ account: 'Interest Expense', amount: 5 })
+    expect(a.incomeStatement.netIncome).toBe(-5)
+    expect(a.generalLedger.balanced).toBe(true)
+    expect(a.balanceSheet.balanced).toBe(true)
+  })
+})

--- a/app/src/utils/accounting/__tests__/chartOfAccounts.spec.ts
+++ b/app/src/utils/accounting/__tests__/chartOfAccounts.spec.ts
@@ -18,9 +18,11 @@ describe('chart of accounts', () => {
       'Cash — Safe': 'ASSET',
       'Cash — Payroll': 'ASSET',
       'Cash — Expense': 'ASSET',
+      'Cash — Credit': 'ASSET',
       'Cash — FeeCollector': 'ASSET',
       'Trading account': 'ASSET',
       'Wage Payable': 'LIABILITY',
+      'Loan Payable': 'LIABILITY',
       'Shares to be issued': 'LIABILITY',
       'Owner Capital': 'EQUITY',
       'Investor Equity': 'EQUITY',
@@ -30,6 +32,7 @@ describe('chart of accounts', () => {
       'Payroll Expense': 'EXPENSE',
       'Share-based Compensation': 'EXPENSE',
       'Operating Expense': 'EXPENSE',
+      'Interest Expense': 'EXPENSE',
       'Dividend Expense': 'EXPENSE',
       'Trading Loss': 'EXPENSE',
       'Transaction Fee Expense': 'EXPENSE'
@@ -43,14 +46,21 @@ describe('chart of accounts', () => {
       'Cash — Safe',
       'Cash — Payroll',
       'Cash — Expense',
+      'Cash — Credit',
       'Cash — FeeCollector'
     ])
     cashPockets.forEach((pocket) => expect(classOf(pocket)).toBe('ASSET'))
   })
 
   it('excludes the Phase 2 gap accounts and treats fees as a move, not an account', () => {
-    const forbidden = ['Infrastructure Expense', 'Interest Expense', 'Protocol Fee Revenue', 'Fee']
+    const forbidden = ['Infrastructure Expense', 'Protocol Fee Revenue', 'Fee']
     forbidden.forEach((name) => expect(ACCOUNT_NAMES).not.toContain(name))
+  })
+
+  it('books the Community Credit accounts (FixedReturn feed)', () => {
+    expect(classOf('Cash — Credit')).toBe('ASSET')
+    expect(classOf('Loan Payable')).toBe('LIABILITY')
+    expect(classOf('Interest Expense')).toBe('EXPENSE')
   })
 
   it('exposes ACCOUNTS as { name, class } records matching the map', () => {

--- a/app/src/utils/accounting/__tests__/fixedReturn.spec.ts
+++ b/app/src/utils/accounting/__tests__/fixedReturn.spec.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest'
+import { mapFixedReturnEvents } from '@/utils/accounting/mappers/fixedReturn'
+import { makeCtx, ADDR } from './fixtures'
+
+const ctx = makeCtx()
+
+/** One USDC offer, created at t=100 — the token index every other event needs. */
+const offer = (offerId = '1', timestamp = 100) => ({
+  id: `created-${offerId}`,
+  contractAddress: ADDR.credit,
+  offerId,
+  token: ADDR.usdcToken,
+  fundingTarget: '10000000',
+  timestamp
+})
+
+const lent = (
+  id: string,
+  amount: string,
+  timestamp: number,
+  lender: string = ADDR.lender,
+  offerId = '1'
+) => ({ id, contractAddress: ADDR.credit, offerId, lender, amount, timestamp })
+
+const repaid = lent
+const refunded = lent
+
+describe('mapFixedReturnEvents', () => {
+  it('books a lender deposit as UC-CREDIT-01 (Cash — Credit → Loan Payable)', () => {
+    const [entry] = mapFixedReturnEvents(
+      {
+        lendingOfferCreateds: [offer()],
+        fundsLents: [lent('fl1', '4000000', 200)]
+      },
+      ctx
+    )
+    expect(entry).toMatchObject({
+      useCase: 'UC-CREDIT-01',
+      debit: 'Cash — Credit',
+      credit: 'Loan Payable',
+      amountUsd: 4, // 4 USDC × $1
+      token: 'usdc',
+      rawAmount: '4000000',
+      internal: false
+    })
+    expect(entry.counterparty?.toLowerCase()).toBe(ADDR.lender)
+  })
+
+  it('sweeps the accumulated principal to Bank as an internal UC-CREDIT-02 move', () => {
+    const entries = mapFixedReturnEvents(
+      {
+        lendingOfferCreateds: [offer()],
+        fundsLents: [lent('fl1', '4000000', 200), lent('fl2', '6000000', 300, ADDR.client)],
+        // Emitted in the same transaction as the deposit that hit the target.
+        lendingOfferFundeds: [
+          { id: 'fd1', contractAddress: ADDR.credit, offerId: '1', timestamp: 300 }
+        ]
+      },
+      ctx
+    )
+    const sweep = entries.find((e) => e.useCase === 'UC-CREDIT-02')
+    expect(sweep).toMatchObject({
+      debit: 'Cash — Bank',
+      credit: 'Cash — Credit',
+      rawAmount: '10000000', // both deposits, not just the last one
+      amountUsd: 10,
+      internal: true
+    })
+    // The credit pocket nets to zero: 4 + 6 in, 10 out.
+    const creditNet = entries.reduce(
+      (sum, e) =>
+        sum +
+        (e.debit === 'Cash — Credit' ? e.amountUsd : 0) -
+        (e.credit === 'Cash — Credit' ? e.amountUsd : 0),
+      0
+    )
+    expect(creditNet).toBe(0)
+  })
+
+  it('splits a repayment into its principal and interest legs, principal first', () => {
+    const entries = mapFixedReturnEvents(
+      {
+        lendingOfferCreateds: [offer()],
+        fundsLents: [lent('fl1', '10000000', 200)],
+        lendingOfferFundeds: [
+          { id: 'fd1', contractAddress: ADDR.credit, offerId: '1', timestamp: 200 }
+        ],
+        // Two installments totalling 11 USDC — 10 principal + 1 fixed return.
+        lenderRepaids: [repaid('rp1', '6000000', 400), repaid('rp2', '5000000', 500)]
+      },
+      ctx
+    )
+    const repayments = entries.filter((e) => e.useCase === 'UC-CREDIT-03')
+    expect(repayments).toHaveLength(3)
+    expect(repayments.map((e) => [e.id, e.debit, e.amountUsd])).toEqual([
+      ['rp1-principal', 'Loan Payable', 6],
+      // The second installment retires the last 4 of principal; the rest is interest.
+      ['rp2-principal', 'Loan Payable', 4],
+      ['rp2-interest', 'Interest Expense', 1]
+    ])
+    repayments.forEach((e) => expect(e.credit).toBe('Cash — Bank'))
+  })
+
+  it('clears Loan Payable once the lender has been made whole', () => {
+    const entries = mapFixedReturnEvents(
+      {
+        lendingOfferCreateds: [offer()],
+        fundsLents: [lent('fl1', '10000000', 200)],
+        lendingOfferFundeds: [
+          { id: 'fd1', contractAddress: ADDR.credit, offerId: '1', timestamp: 200 }
+        ],
+        lenderRepaids: [repaid('rp1', '11000000', 400)]
+      },
+      ctx
+    )
+    const payable = entries.reduce(
+      (sum, e) =>
+        sum +
+        (e.credit === 'Loan Payable' ? e.amountUsd : 0) -
+        (e.debit === 'Loan Payable' ? e.amountUsd : 0),
+      0
+    )
+    expect(payable).toBe(0)
+  })
+
+  it('books a refund on an unfunded offer as UC-CREDIT-04 (Loan Payable → Cash — Credit)', () => {
+    const entries = mapFixedReturnEvents(
+      {
+        lendingOfferCreateds: [offer()],
+        fundsLents: [lent('fl1', '4000000', 200)],
+        principalRefundeds: [refunded('pr1', '4000000', 900)]
+      },
+      ctx
+    )
+    expect(entries.at(-1)).toMatchObject({
+      useCase: 'UC-CREDIT-04',
+      debit: 'Loan Payable',
+      credit: 'Cash — Credit',
+      amountUsd: 4,
+      internal: false
+    })
+  })
+
+  it('replays out-of-order feeds chronologically so the sweep carries every deposit', () => {
+    const entries = mapFixedReturnEvents(
+      {
+        lendingOfferCreateds: [offer()],
+        // Newest first — the sweep must still see both deposits.
+        fundsLents: [lent('fl2', '6000000', 300, ADDR.client), lent('fl1', '4000000', 200)],
+        lendingOfferFundeds: [
+          { id: 'fd1', contractAddress: ADDR.credit, offerId: '1', timestamp: 300 }
+        ]
+      },
+      ctx
+    )
+    expect(entries.map((e) => e.id)).toEqual(['fl1', 'fl2', 'fd1'])
+    expect(entries.at(-1)?.rawAmount).toBe('10000000')
+  })
+
+  it('skips an offer whose creation event (and therefore its token) is missing', () => {
+    const entries = mapFixedReturnEvents({ fundsLents: [lent('fl1', '4000000', 200)] }, ctx)
+    expect(entries).toEqual([])
+  })
+
+  it('keeps two offers independent', () => {
+    const entries = mapFixedReturnEvents(
+      {
+        lendingOfferCreateds: [offer('1'), offer('2')],
+        fundsLents: [
+          lent('fl1', '4000000', 200, ADDR.lender, '1'),
+          lent('fl2', '3000000', 250, ADDR.lender, '2')
+        ],
+        lendingOfferFundeds: [
+          { id: 'fd1', contractAddress: ADDR.credit, offerId: '1', timestamp: 300 }
+        ]
+      },
+      ctx
+    )
+    const sweep = entries.find((e) => e.useCase === 'UC-CREDIT-02')
+    // Only offer #1's principal is swept — offer #2 is still open.
+    expect(sweep?.rawAmount).toBe('4000000')
+  })
+})

--- a/app/src/utils/accounting/__tests__/fixtures.ts
+++ b/app/src/utils/accounting/__tests__/fixtures.ts
@@ -19,7 +19,10 @@ export const ADDR = {
   client: '0x7777777777777777777777777777777777777777',
   member: '0x8888888888888888888888888888888888888888',
   usdcToken: '0x9999999999999999999999999999999999999999',
-  sherToken: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+  sherToken: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  /** The FixedReturn (Community Credit) pocket. */
+  credit: '0xdddddddddddddddddddddddddddddddddddddddd',
+  lender: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
 } as const
 
 const POCKETS: Record<string, AccountName> = {
@@ -27,6 +30,7 @@ const POCKETS: Record<string, AccountName> = {
   [ADDR.safe]: 'Cash — Safe',
   [ADDR.payroll]: 'Cash — Payroll',
   [ADDR.expense]: 'Cash — Expense',
+  [ADDR.credit]: 'Cash — Credit',
   [ADDR.feeCollector]: 'Cash — FeeCollector'
 }
 

--- a/app/src/utils/accounting/__tests__/internalAddresses.spec.ts
+++ b/app/src/utils/accounting/__tests__/internalAddresses.spec.ts
@@ -22,12 +22,13 @@ const contract = (type: TeamContract['type'], address: string): TeamContract => 
 })
 
 describe('INTERNAL_POCKET_CONTRACT_TYPES', () => {
-  it('lists the six money-pocket TeamContract types (FeeCollector excluded)', () => {
+  it('lists the seven money-pocket TeamContract types (FeeCollector excluded)', () => {
     expect([...INTERNAL_POCKET_CONTRACT_TYPES]).toEqual([
       'Safe',
       'Bank',
       'CashRemunerationEIP712',
       'ExpenseAccountEIP712',
+      'FixedReturn',
       'InvestorV1',
       'SafeDepositRouter'
     ])

--- a/app/src/utils/accounting/assemble.ts
+++ b/app/src/utils/accounting/assemble.ts
@@ -22,6 +22,7 @@ import type { SafeIncomingTransfer } from '@/types/safe'
 import type { BankEventsQuery } from '@/types/ponder/bank'
 import type { CashRemunerationEventsQuery } from '@/types/ponder/cash-remuneration'
 import type { ExpenseEventsQuery } from '@/types/ponder/expense'
+import type { FixedReturnEventsQuery } from '@/types/ponder/fixedReturn'
 import type {
   InvestorEventsQuery,
   SafeDepositRouterEventsQuery,
@@ -73,6 +74,7 @@ export interface CncAccountingInput {
   bankEvents?: BankEventsQuery | null
   cashRemunerationEvents?: CashRemunerationEventsQuery | null
   expenseEvents?: ExpenseEventsQuery | null
+  fixedReturnEvents?: FixedReturnEventsQuery | null
   investorEvents?: InvestorEventsQuery | null
   safeDepositRouterEvents?: SafeDepositRouterEventsQuery | null
   safeTransfers?: readonly SafeIncomingTransfer[] | null
@@ -210,6 +212,17 @@ function toLedgerSources(input: CncAccountingInput): LedgerSources {
       tokenTransfers: items(e.expenseTokenTransfers),
       ownerTreasuryWithdrawNatives: items(e.expenseOwnerTreasuryWithdrawNatives),
       ownerTreasuryWithdrawTokens: items(e.expenseOwnerTreasuryWithdrawTokens)
+    }
+  }
+
+  if (input.fixedReturnEvents) {
+    const f = input.fixedReturnEvents
+    sources.fixedReturn = {
+      lendingOfferCreateds: items(f.fixedReturnLendingOfferCreateds),
+      lendingOfferFundeds: items(f.fixedReturnLendingOfferFundeds),
+      fundsLents: items(f.fixedReturnFundsLents),
+      lenderRepaids: items(f.fixedReturnLenderRepaids),
+      principalRefundeds: items(f.fixedReturnPrincipalRefundeds)
     }
   }
 

--- a/app/src/utils/accounting/balanceSheet.ts
+++ b/app/src/utils/accounting/balanceSheet.ts
@@ -6,7 +6,7 @@
  * **Retained Earnings**:
  *
  *  - Assets       cash pockets (rolled up) + Trading account + any other asset
- *  - Liabilities  Wage Payable + Shares to be issued (net; 0 once settled)
+ *  - Liabilities  Wage Payable + Loan Payable + Shares to be issued (net; 0 once settled)
  *  - Equity       Owner Capital + Investor Equity + Retained Earnings (net income)
  *
  * The identity holds by construction: every posting is balanced and net income
@@ -23,12 +23,13 @@ import type { StatementLine } from './incomeStatement'
 import type { TokenId } from '@/constant'
 import { getTokenDecimals } from '@/utils/constantUtil'
 
-/** The five on-chain cash pockets that roll up into the single Cash line. */
+/** The on-chain cash pockets that roll up into the single Cash line. */
 const CASH_ACCOUNTS: ReadonlySet<AccountName> = new Set<AccountName>([
   'Cash — Bank',
   'Cash — Safe',
   'Cash — Payroll',
   'Cash — Expense',
+  'Cash — Credit',
   'Cash — FeeCollector'
 ])
 

--- a/app/src/utils/accounting/buildLedger.ts
+++ b/app/src/utils/accounting/buildLedger.ts
@@ -27,12 +27,13 @@
 import { classOf, type AccountName } from './chartOfAccounts'
 import type { LedgerEntry } from './ledgerEntry'
 
-/** The five on-chain cash pockets that roll up into total Cash. */
+/** The on-chain cash pockets that roll up into total Cash. */
 const CASH_ACCOUNTS: ReadonlySet<AccountName> = new Set<AccountName>([
   'Cash — Bank',
   'Cash — Safe',
   'Cash — Payroll',
   'Cash — Expense',
+  'Cash — Credit',
   'Cash — FeeCollector'
 ])
 

--- a/app/src/utils/accounting/chartOfAccounts.ts
+++ b/app/src/utils/accounting/chartOfAccounts.ts
@@ -7,8 +7,10 @@
  * keys off the {@link AccountName} union and {@link AccountClass} declared here.
  *
  * Scope notes (spec §5–§6):
- * - `Infrastructure Expense` / `Interest Expense` are intentionally **absent** —
- *   they are Phase 2 gaps with no data feed yet.
+ * - `Infrastructure Expense` is intentionally **absent** — a Phase 2 gap with no
+ *   data feed yet.
+ * - `Interest Expense` **is** booked: the FixedReturn (Community Credit) feed
+ *   supplies it, as the fixed return paid to lenders above their principal.
  * - `Network Fee Expense` (gas paid to validators) is likewise **absent**: gas is
  *   not indexed by any feed yet, so there is nothing to post.
  * - The Bank protocol fee (`FeePaid`) *is* booked, as a real cost leaving the
@@ -21,17 +23,19 @@ export type AccountClass = 'ASSET' | 'LIABILITY' | 'EQUITY' | 'INCOME' | 'EXPENS
 
 /**
  * Every account the CNC books touch. Cash is split per on-chain pocket
- * (Bank / Safe / Payroll / Expense / FeeCollector) — each is its own account
- * that rolls up into total Cash.
+ * (Bank / Safe / Payroll / Expense / Credit / FeeCollector) — each is its own
+ * account that rolls up into total Cash.
  */
 export const ACCOUNT_NAMES = [
   'Cash — Bank',
   'Cash — Safe',
   'Cash — Payroll',
   'Cash — Expense',
+  'Cash — Credit',
   'Cash — FeeCollector',
   'Trading account',
   'Wage Payable',
+  'Loan Payable',
   'Shares to be issued',
   'Owner Capital',
   'Investor Equity',
@@ -41,6 +45,7 @@ export const ACCOUNT_NAMES = [
   'Payroll Expense',
   'Share-based Compensation',
   'Operating Expense',
+  'Interest Expense',
   'Dividend Expense',
   'Trading Loss',
   'Transaction Fee Expense'
@@ -59,9 +64,11 @@ export const CHART_OF_ACCOUNTS: Readonly<Record<AccountName, AccountClass>> = {
   'Cash — Safe': 'ASSET',
   'Cash — Payroll': 'ASSET',
   'Cash — Expense': 'ASSET',
+  'Cash — Credit': 'ASSET',
   'Cash — FeeCollector': 'ASSET',
   'Trading account': 'ASSET',
   'Wage Payable': 'LIABILITY',
+  'Loan Payable': 'LIABILITY',
   'Shares to be issued': 'LIABILITY',
   'Owner Capital': 'EQUITY',
   'Investor Equity': 'EQUITY',
@@ -71,6 +78,7 @@ export const CHART_OF_ACCOUNTS: Readonly<Record<AccountName, AccountClass>> = {
   'Payroll Expense': 'EXPENSE',
   'Share-based Compensation': 'EXPENSE',
   'Operating Expense': 'EXPENSE',
+  'Interest Expense': 'EXPENSE',
   'Dividend Expense': 'EXPENSE',
   'Trading Loss': 'EXPENSE',
   'Transaction Fee Expense': 'EXPENSE'

--- a/app/src/utils/accounting/describeEntry.ts
+++ b/app/src/utils/accounting/describeEntry.ts
@@ -25,6 +25,10 @@ const ENTRY_LABEL: Record<UseCase, string> = {
   'UC-BANK-03': 'Treasury funding',
   'UC-SDR-01': 'Investor contribution',
   'UC-MEMBER-01': 'Member capital contribution',
+  'UC-CREDIT-01': 'Credit funds lent',
+  'UC-CREDIT-02': 'Credit principal to Bank',
+  'UC-CREDIT-03': 'Credit repayment',
+  'UC-CREDIT-04': 'Credit principal refund',
   'UC-CASH-02': 'Wage accrual',
   'UC-CASH-03': 'Wage settlement',
   'UC-EXP-01': 'Operating expense',
@@ -53,7 +57,11 @@ export type ActivityCell =
   | { kind: 'plain'; text: string }
 
 /** Internal pocket-to-pocket moves — rendered as two contract avatars (from → to). */
-const TRANSFER_USE_CASES: ReadonlySet<UseCase> = new Set<UseCase>(['INTERNAL', 'UC-BANK-03'])
+const TRANSFER_USE_CASES: ReadonlySet<UseCase> = new Set<UseCase>([
+  'INTERNAL',
+  'UC-BANK-03',
+  'UC-CREDIT-02'
+])
 
 /** Use cases that name a single party (member / investor / client) — avatar + predicate. */
 const ACTOR_USE_CASES: ReadonlySet<UseCase> = new Set<UseCase>([
@@ -63,6 +71,9 @@ const ACTOR_USE_CASES: ReadonlySet<UseCase> = new Set<UseCase>([
   'UC-BANK-02',
   'UC-SDR-01',
   'UC-MEMBER-01',
+  'UC-CREDIT-01',
+  'UC-CREDIT-03',
+  'UC-CREDIT-04',
   'UC-EXP-01',
   'UC-INV-01',
   'DEFAULT-D'
@@ -127,6 +138,16 @@ function predicate(entry: LedgerEntry): string {
       return `invested ${amount} in capital${sher}`
     case 'UC-MEMBER-01':
       return `invested ${amount} in capital${sher}`
+    case 'UC-CREDIT-01':
+      return `lent ${amount} to the community credit`
+    case 'UC-CREDIT-03':
+      // The two legs of one installment read differently — the split is what the
+      // interest leg's `Interest Expense` debit marks (see the FixedReturn mapper).
+      return entry.debit === 'Interest Expense'
+        ? `was paid ${amount} of interest on their loan`
+        : `was repaid ${amount} of loan principal`
+    case 'UC-CREDIT-04':
+      return `was refunded ${amount} of lent principal`
     case 'UC-EXP-01':
       return expensePredicate(entry, amount)
     case 'UC-INV-01':

--- a/app/src/utils/accounting/internalAddresses.ts
+++ b/app/src/utils/accounting/internalAddresses.ts
@@ -25,6 +25,7 @@ export const INTERNAL_POCKET_CONTRACT_TYPES = [
   'Bank',
   'CashRemunerationEIP712',
   'ExpenseAccountEIP712',
+  'FixedReturn',
   'InvestorV1',
   'SafeDepositRouter'
 ] as const satisfies readonly ContractType[]

--- a/app/src/utils/accounting/ledgerCategory.ts
+++ b/app/src/utils/accounting/ledgerCategory.ts
@@ -1,0 +1,101 @@
+/**
+ * The ledger's category vocabulary — the "Action" badge and the filter pills.
+ *
+ * Split from {@link ./ledgerPresenter} (which turns entries into table rows) the
+ * same way {@link ./ledgerCurrency} was, so each module stays focused; the
+ * presenter re-exports everything here, and callers can keep importing from it.
+ * Pure and unit-testable.
+ */
+import type { LedgerEntry, UseCase } from './ledgerEntry'
+
+/** Exact chart-of-accounts label for a protocol-fee leg; drives badge + filter. */
+export const FEE_ACCOUNT = 'Transaction Fee Expense'
+
+export type LedgerCategory =
+  | 'Investment'
+  | 'Credit'
+  | 'Revenue'
+  | 'Trading'
+  | 'Transfer'
+  | 'Payroll'
+  | 'Expense'
+  | 'Dividend'
+  | 'Memo'
+
+/**
+ * Soft badge classes per ledger category — one distinct theme colour each, so
+ * the "Action" column reads at a glance (static strings so Tailwind keeps them).
+ * Colours come from the project palette (see `assets/main.css`).
+ */
+export const CATEGORY_BADGE: Record<LedgerCategory, string> = {
+  Investment: 'bg-secondary/10 text-secondary', // capital in — blue
+  Credit: 'bg-accent/10 text-accent', // borrowed money — teal
+  Revenue: 'bg-success/10 text-success', // income earned — green
+  Trading: 'bg-info/10 text-info', // market activity — cyan
+  Transfer: 'bg-neutral/10 text-neutral', // internal move — neutral
+  Payroll: 'bg-warning/10 text-warning', // wage accrued / owed — amber
+  Expense: 'bg-error/10 text-error', // cost out — red
+  Dividend: 'bg-primary/10 text-primary', // profit distribution — green
+  Memo: 'bg-muted text-dimmed' // share-count note — grey
+}
+
+/**
+ * The pseudo-category the Fee pill filters on — not a {@link LedgerCategory} (a
+ * fee is a leg of a Transfer/Expense entry), so it's handled specially by
+ * `filterLedgerEntries` / `presentLedger` rather than via {@link categoryOf}.
+ */
+export const FEE_FILTER = 'Fee'
+
+/** Ledger filter categories shown as pills (in design order). */
+export const ledgerCategories: Array<LedgerCategory | 'All' | typeof FEE_FILTER> = [
+  'All',
+  'Investment',
+  'Credit',
+  'Revenue',
+  'Trading',
+  'Transfer',
+  'Payroll',
+  'Expense',
+  'Dividend',
+  FEE_FILTER
+]
+
+/** The display category a ledger entry falls under, from its use case. */
+export function categoryOf(entry: LedgerEntry): LedgerCategory {
+  const byUseCase: Partial<Record<UseCase, LedgerCategory>> = {
+    'UC-BANK-01': 'Investment',
+    'UC-SDR-01': 'Investment',
+    'UC-MEMBER-01': 'Investment',
+    'UC-CREDIT-01': 'Credit',
+    'UC-CREDIT-03': 'Credit',
+    'UC-CREDIT-04': 'Credit',
+    'UC-BANK-02': 'Revenue',
+    'CASH-IN': 'Revenue',
+    'UC-CASH-02': 'Payroll',
+    'UC-CASH-03': 'Payroll',
+    'UC-EXP-01': 'Expense',
+    'CASH-OUT': 'Expense',
+    'UC-INV-01': 'Dividend',
+    'DEFAULT-D': 'Investment',
+    FEE: 'Expense',
+    INTERNAL: 'Transfer',
+    'UC-BANK-03': 'Transfer',
+    // The funded-offer sweep is Credit → Bank: an internal move, not a credit event.
+    'UC-CREDIT-02': 'Transfer'
+  }
+  return byUseCase[entry.useCase] ?? 'Transfer'
+}
+
+/**
+ * Badge classes for a ledger entry's "Action" pill. Normally one colour per
+ * category, but the two payroll use cases are split so the journal shows at a
+ * glance whether a wage was merely **accrued** (submitted, still owed — amber)
+ * or **settled** (withdrawn, actually paid out — green).
+ */
+export function badgeClassOf(entry: LedgerEntry): string {
+  // A settled wage (UC-CASH-03 — withdrawn / actually paid out) reads as cyan,
+  // distinct from a wage merely accrued (UC-CASH-02 — submitted, still owed),
+  // which keeps the category's amber. Every other entry takes its category colour.
+  if (entry.useCase === 'UC-CASH-03') return 'bg-accent/10 text-accent'
+  return CATEGORY_BADGE[categoryOf(entry)]
+}

--- a/app/src/utils/accounting/ledgerEntry.ts
+++ b/app/src/utils/accounting/ledgerEntry.ts
@@ -32,6 +32,14 @@ export type UseCase =
   /** A team member funds the Safe to invest & get SHER — booked as a capital
    *  contribution (Cr Investor Equity) when no SafeDepositRouter event is present. */
   | 'UC-MEMBER-01'
+  /** A lender funds a Community Credit offer → the team borrows (Cr Loan Payable). */
+  | 'UC-CREDIT-01'
+  /** A fully (or partially) funded offer sweeps its principal to Bank — internal move. */
+  | 'UC-CREDIT-02'
+  /** Repayment installment pushed to a lender — principal leg and/or interest leg. */
+  | 'UC-CREDIT-03'
+  /** Principal refunded to a lender when an offer missed its funding target. */
+  | 'UC-CREDIT-04'
   /** Wage earned — accrual booked when the weekly claim is submitted. */
   | 'UC-CASH-02'
   /** Wage withdrawal settlement (cash leg and/or share leg). */

--- a/app/src/utils/accounting/ledgerPresenter.ts
+++ b/app/src/utils/accounting/ledgerPresenter.ts
@@ -11,63 +11,31 @@ import { mergeBankFees } from './mergeBankFees'
 import { flattenLedgerRows } from './payrollGrouping'
 import { filterLedgerByCurrency } from './ledgerCurrency'
 import { formatAmountWithPrecision } from '@/utils/currencyUtil'
-import type { LedgerEntry, UseCase } from './ledgerEntry'
+import {
+  badgeClassOf,
+  categoryOf,
+  FEE_ACCOUNT,
+  FEE_FILTER,
+  type LedgerCategory
+} from './ledgerCategory'
+import type { LedgerEntry } from './ledgerEntry'
 import type { TokenId } from '@/constant'
 
 // Currency derivation / filtering lives in its own module, re-exported here.
 export { entryCurrency, ledgerCurrencies, filterLedgerByCurrency } from './ledgerCurrency'
+// So do the category vocabulary and its badges — see ./ledgerCategory.
+export {
+  badgeClassOf,
+  categoryOf,
+  CATEGORY_BADGE,
+  FEE_ACCOUNT,
+  FEE_FILTER,
+  ledgerCategories,
+  type LedgerCategory
+} from './ledgerCategory'
 
 /** The empty activity carried by a posting's continuation (credit) and total rows. */
 const NO_ACTIVITY: ActivityCell = { kind: 'plain', text: '' }
-
-/** Exact chart-of-accounts label for a protocol-fee leg; drives badge + filter. */
-export const FEE_ACCOUNT = 'Transaction Fee Expense'
-
-export type LedgerCategory =
-  | 'Investment'
-  | 'Revenue'
-  | 'Trading'
-  | 'Transfer'
-  | 'Payroll'
-  | 'Expense'
-  | 'Dividend'
-  | 'Memo'
-
-/**
- * Soft badge classes per ledger category — one distinct theme colour each, so
- * the "Action" column reads at a glance (static strings so Tailwind keeps them).
- * Colours come from the project palette (see `assets/main.css`).
- */
-export const CATEGORY_BADGE: Record<LedgerCategory, string> = {
-  Investment: 'bg-secondary/10 text-secondary', // capital in — blue
-  Revenue: 'bg-success/10 text-success', // income earned — green
-  Trading: 'bg-info/10 text-info', // market activity — cyan
-  Transfer: 'bg-neutral/10 text-neutral', // internal move — neutral
-  Payroll: 'bg-warning/10 text-warning', // wage accrued / owed — amber
-  Expense: 'bg-error/10 text-error', // cost out — red
-  Dividend: 'bg-primary/10 text-primary', // profit distribution — green
-  Memo: 'bg-muted text-dimmed' // share-count note — grey
-}
-
-/**
- * The pseudo-category the Fee pill filters on — not a {@link LedgerCategory} (a
- * fee is a leg of a Transfer/Expense entry), so it's handled specially by
- * {@link filterLedgerEntries} / {@link presentLedger} rather than via `categoryOf`.
- */
-export const FEE_FILTER = 'Fee'
-
-/** Ledger filter categories shown as pills (in design order). */
-export const ledgerCategories: Array<LedgerCategory | 'All' | typeof FEE_FILTER> = [
-  'All',
-  'Investment',
-  'Revenue',
-  'Trading',
-  'Transfer',
-  'Payroll',
-  'Expense',
-  'Dividend',
-  FEE_FILTER
-]
 
 /** The toggleable ledger table columns (keys match the table's cell slots). */
 export type LedgerColumnKey =
@@ -162,41 +130,6 @@ export interface LedgerView {
   rows: LedgerRow[]
   total: string
   entryCount: number
-}
-
-/**
- * Badge classes for a ledger entry's "Action" pill. Normally one colour per
- * category, but the two payroll use cases are split so the journal shows at a
- * glance whether a wage was merely **accrued** (submitted, still owed — amber)
- * or **settled** (withdrawn, actually paid out — green).
- */
-export function badgeClassOf(entry: LedgerEntry): string {
-  // A settled wage (UC-CASH-03 — withdrawn / actually paid out) reads as cyan,
-  // distinct from a wage merely accrued (UC-CASH-02 — submitted, still owed),
-  // which keeps the category's amber. Every other entry takes its category colour.
-  if (entry.useCase === 'UC-CASH-03') return 'bg-accent/10 text-accent'
-  return CATEGORY_BADGE[categoryOf(entry)]
-}
-
-/** The display category a ledger entry falls under, from its use case. */
-export function categoryOf(entry: LedgerEntry): LedgerCategory {
-  const byUseCase: Partial<Record<UseCase, LedgerCategory>> = {
-    'UC-BANK-01': 'Investment',
-    'UC-SDR-01': 'Investment',
-    'UC-MEMBER-01': 'Investment',
-    'UC-BANK-02': 'Revenue',
-    'CASH-IN': 'Revenue',
-    'UC-CASH-02': 'Payroll',
-    'UC-CASH-03': 'Payroll',
-    'UC-EXP-01': 'Expense',
-    'CASH-OUT': 'Expense',
-    'UC-INV-01': 'Dividend',
-    'DEFAULT-D': 'Investment',
-    FEE: 'Expense',
-    INTERNAL: 'Transfer',
-    'UC-BANK-03': 'Transfer'
-  }
-  return byUseCase[entry.useCase] ?? 'Transfer'
 }
 
 /** The Devise / Quantité / Taux columns of one token move (spec §2). */

--- a/app/src/utils/accounting/mappers/context.ts
+++ b/app/src/utils/accounting/mappers/context.ts
@@ -36,13 +36,16 @@ export interface MapperContext {
   pocketOf: (address: string | null | undefined) => AccountName | null
 }
 
-/** Maps each CNC money-pocket contract type to its Cash account in the chart. */
+/** Maps each CNC money-pocket contract type to its Cash account in the chart.
+ * FixedReturn (Community Credit) holds lender deposits until the offer funds.
+ *SafeDepositRouter holds no balance — the cash it routes lands in the Safe.
+ */
 const POCKET_ACCOUNT_BY_TYPE: Partial<Record<ContractType, AccountName>> = {
   Safe: 'Cash — Safe',
   Bank: 'Cash — Bank',
   CashRemunerationEIP712: 'Cash — Payroll',
   ExpenseAccountEIP712: 'Cash — Expense',
-  // SafeDepositRouter holds no balance — the cash it routes lands in the Safe.
+  FixedReturn: 'Cash — Credit',
   SafeDepositRouter: 'Cash — Safe'
 }
 

--- a/app/src/utils/accounting/mappers/fixedReturn.ts
+++ b/app/src/utils/accounting/mappers/fixedReturn.ts
@@ -1,0 +1,306 @@
+/**
+ * FixedReturn (Community Credit) source mapper — the team **borrows** from its
+ * lenders and repays them principal + a fixed return.
+ *
+ * The four money-moving events of the contract, in lifecycle order:
+ *
+ *   `FundsLent`         UC-CREDIT-01  Dr Cash — Credit    · Cr Loan Payable
+ *   `LendingOfferFunded`UC-CREDIT-02  Dr Cash — Bank      · Cr Cash — Credit   (internal)
+ *   `LenderRepaid`      UC-CREDIT-03  Dr Loan Payable     · Cr Cash — Bank     (principal leg)
+ *                                     Dr Interest Expense · Cr Cash — Bank     (interest leg)
+ *   `PrincipalRefunded` UC-CREDIT-04  Dr Loan Payable     · Cr Cash — Credit
+ *
+ * Why each side is what it is:
+ * - Lender deposits accumulate **in the FixedReturn contract** while the offer is
+ *   Open, so they land in that contract's own cash pocket (`Cash — Credit`) and
+ *   raise a liability — borrowed money is never revenue.
+ * - On the deposit that hits the funding target (or on `acceptPartialFunding`,
+ *   which emits `LendingOfferFunded` too) the whole principal is swept to Bank
+ *   with a raw `safeTransfer`, which emits **no Bank event** — so the internal
+ *   move is booked here, from the credit side, and has no Bank-side twin.
+ * - Repayment runs `Bank → FixedReturn → lender` inside a single transaction
+ *   (`Bank.fundFixedReturnRepayment`, whose `FixedReturnRepaymentFunded` is not in
+ *   the Bank feed). The contract keeps no balance across it, so each `LenderRepaid`
+ *   credits `Cash — Bank` directly — booking the intermediate hop as well would
+ *   double-count the cash out.
+ *
+ * Splitting a repayment installment: `repayLenders` distributes cumulatively and
+ * makes no principal/interest distinction, so the split is reconstructed here —
+ * a lender's payments retire their principal first (Dr Loan Payable), and
+ * everything beyond it is the fixed return (Dr Interest Expense). That leaves
+ * `Loan Payable` at exactly zero once a lender has been made whole.
+ *
+ * Lifecycle events that move no money (`LendingOfferCreated`,
+ * `LendingOfferRefundable`, `PartialFundingAccepted`, `RepaymentDistributed`,
+ * `TokenSupportAdded/Removed`, `OwnershipTransferred`) produce no entry;
+ * `LendingOfferCreated` is still consumed, for the offer → token index. The two
+ * aggregate events (`RefundsDistributed` / `RepaymentDistributed`) are exactly
+ * the sum of their per-lender events, so booking them too would double-count.
+ */
+import type {
+  FixedReturnLendingOfferCreatedRow,
+  FixedReturnFundsLentRow,
+  FixedReturnLendingOfferFundedRow,
+  FixedReturnLenderRepaidRow,
+  FixedReturnPrincipalRefundedRow
+} from '@/types/ponder/fixedReturn'
+import type { TokenId } from '@/constant'
+import { makeEntry, type LedgerEntry } from '@/utils/accounting/ledgerEntry'
+import { atDate, type MapperContext } from './context'
+
+export interface FixedReturnMapperInput {
+  /** Offer creations — the offer → token index every other event needs. */
+  lendingOfferCreateds?: readonly FixedReturnLendingOfferCreatedRow[]
+  lendingOfferFundeds?: readonly FixedReturnLendingOfferFundedRow[]
+  fundsLents?: readonly FixedReturnFundsLentRow[]
+  lenderRepaids?: readonly FixedReturnLenderRepaidRow[]
+  principalRefundeds?: readonly FixedReturnPrincipalRefundedRow[]
+}
+
+const CREDIT = 'Cash — Credit' as const
+const BANK = 'Cash — Bank' as const
+const LOAN_PAYABLE = 'Loan Payable' as const
+
+/**
+ * One event of the credit timeline, normalized so the four feeds can be replayed
+ * in chronological order — the running principal balances below only hold if the
+ * lifecycle is walked forwards.
+ */
+type CreditEventKind = 'lent' | 'funded' | 'repaid' | 'refunded'
+
+interface CreditEvent {
+  kind: CreditEventKind
+  id: string
+  offerId: string
+  timestamp: number
+  /** Absent on `funded`, which carries only the offer id. */
+  lender?: string
+  /** Absent on `funded`, whose amount is the principal accumulated so far. */
+  amount?: string
+}
+
+/**
+ * Tie-break for events sharing a timestamp — they share a *transaction*:
+ * `lendFunds` emits `FundsLent` then `LendingOfferFunded`, and `refundLenders`
+ * emits every `PrincipalRefunded` in one call. Replaying in emission order keeps
+ * the running principal correct (a deposit must be counted before the sweep that
+ * moves it). Log index would say the same, but the row ids are strings and would
+ * sort `10` before `9`.
+ */
+const KIND_ORDER: Record<CreditEventKind, number> = {
+  lent: 0,
+  funded: 1,
+  refunded: 2,
+  repaid: 3
+}
+
+function chronological(events: CreditEvent[]): CreditEvent[] {
+  return events.sort((a, b) => a.timestamp - b.timestamp || KIND_ORDER[a.kind] - KIND_ORDER[b.kind])
+}
+
+/** Parse a stringified base-unit amount, tolerating a malformed value. */
+function toBigInt(raw: string | undefined): bigint {
+  try {
+    return BigInt(raw ?? '0')
+  } catch {
+    return 0n
+  }
+}
+
+/** `${offerId}|${lender}` — keys a lender's position within one offer. */
+function positionKey(offerId: string, lender: string): string {
+  return `${offerId}|${lender.toLowerCase()}`
+}
+
+/** Read-modify-write helper for the running per-key bigint balances. */
+function bump(balances: Map<string, bigint>, key: string, delta: bigint): void {
+  balances.set(key, (balances.get(key) ?? 0n) + delta)
+}
+
+/** Flatten the per-event feeds into one chronological timeline. */
+function toTimeline(input: FixedReturnMapperInput): CreditEvent[] {
+  return chronological([
+    ...(input.fundsLents ?? []).map((row) => ({
+      kind: 'lent' as const,
+      id: row.id,
+      offerId: row.offerId,
+      timestamp: row.timestamp,
+      lender: row.lender,
+      amount: row.amount
+    })),
+    ...(input.lendingOfferFundeds ?? []).map((row) => ({
+      kind: 'funded' as const,
+      id: row.id,
+      offerId: row.offerId,
+      timestamp: row.timestamp
+    })),
+    ...(input.lenderRepaids ?? []).map((row) => ({
+      kind: 'repaid' as const,
+      id: row.id,
+      offerId: row.offerId,
+      timestamp: row.timestamp,
+      lender: row.lender,
+      amount: row.amount
+    })),
+    ...(input.principalRefundeds ?? []).map((row) => ({
+      kind: 'refunded' as const,
+      id: row.id,
+      offerId: row.offerId,
+      timestamp: row.timestamp,
+      lender: row.lender,
+      amount: row.amount
+    }))
+  ])
+}
+
+/**
+ * Map the FixedReturn feed to ledger entries by replaying the credit lifecycle.
+ *
+ * An offer whose `LendingOfferCreated` is missing from the feed is **skipped**:
+ * that event is the only carrier of the offer's token, and valuing a base-unit
+ * amount against a guessed token would post a wildly wrong USD figure. The feed
+ * is scanned from the contract's deploy block, so in practice it is always there.
+ */
+export function mapFixedReturnEvents(
+  input: FixedReturnMapperInput,
+  ctx: MapperContext
+): LedgerEntry[] {
+  const tokenByOffer = new Map<string, TokenId>()
+  for (const row of input.lendingOfferCreateds ?? []) {
+    tokenByOffer.set(row.offerId, ctx.tokenIdOf(row.token))
+  }
+
+  /** Principal sitting in the contract for an offer, not yet swept or refunded. */
+  const heldByOffer = new Map<string, bigint>()
+  /** Principal a lender has outstanding on an offer — what repayment retires first. */
+  const owedToLender = new Map<string, bigint>()
+
+  const entries: LedgerEntry[] = []
+
+  for (const event of toTimeline(input)) {
+    const token = tokenByOffer.get(event.offerId)
+    if (!token) continue
+    const at = atDate(event.timestamp)
+    const usd = (raw: bigint): number => ctx.toUsd(raw, token, at)
+    const key = event.lender ? positionKey(event.offerId, event.lender) : ''
+
+    switch (event.kind) {
+      case 'lent': {
+        const amount = toBigInt(event.amount)
+        if (amount <= 0n) break
+        bump(heldByOffer, event.offerId, amount)
+        bump(owedToLender, key, amount)
+        entries.push(
+          makeEntry({
+            id: event.id,
+            timestamp: event.timestamp,
+            useCase: 'UC-CREDIT-01',
+            debit: CREDIT,
+            credit: LOAN_PAYABLE,
+            amountUsd: usd(amount),
+            token,
+            rawAmount: amount.toString(),
+            counterparty: event.lender,
+            memo: `Funds lent to Community Credit offer #${event.offerId}`
+          })
+        )
+        break
+      }
+
+      case 'funded': {
+        // The whole principal raised so far leaves the contract for Bank in the
+        // same transaction — both sides are CNC pockets, so it is an internal move.
+        const swept = heldByOffer.get(event.offerId) ?? 0n
+        if (swept <= 0n) break
+        heldByOffer.set(event.offerId, 0n)
+        entries.push(
+          makeEntry({
+            id: event.id,
+            timestamp: event.timestamp,
+            useCase: 'UC-CREDIT-02',
+            debit: BANK,
+            credit: CREDIT,
+            amountUsd: usd(swept),
+            token,
+            rawAmount: swept.toString(),
+            internal: true,
+            memo: `Community Credit offer #${event.offerId} principal swept to Bank`
+          })
+        )
+        break
+      }
+
+      // The two legs suffix the source id, which puts them out of reach of
+      // `txHashOf` (it parses `${txHash}-${logIndex}`). Harmless today — they
+      // credit Cash — Bank, but `Bank.fundFixedReturnRepayment` skims no protocol
+      // fee, so there is never a fee to fold in. Revisit if that ever changes.
+      case 'repaid': {
+        const amount = toBigInt(event.amount)
+        if (amount <= 0n) break
+        const outstanding = owedToLender.get(key) ?? 0n
+        const principal = amount < outstanding ? amount : outstanding
+        const interest = amount - principal
+        if (principal > 0n) {
+          owedToLender.set(key, outstanding - principal)
+          entries.push(
+            makeEntry({
+              id: `${event.id}-principal`,
+              timestamp: event.timestamp,
+              useCase: 'UC-CREDIT-03',
+              debit: LOAN_PAYABLE,
+              credit: BANK,
+              amountUsd: usd(principal),
+              token,
+              rawAmount: principal.toString(),
+              counterparty: event.lender,
+              memo: `Principal repaid on Community Credit offer #${event.offerId}`
+            })
+          )
+        }
+        if (interest > 0n) {
+          entries.push(
+            makeEntry({
+              id: `${event.id}-interest`,
+              timestamp: event.timestamp,
+              useCase: 'UC-CREDIT-03',
+              debit: 'Interest Expense',
+              credit: BANK,
+              amountUsd: usd(interest),
+              token,
+              rawAmount: interest.toString(),
+              counterparty: event.lender,
+              memo: `Fixed return paid on Community Credit offer #${event.offerId}`
+            })
+          )
+        }
+        break
+      }
+
+      case 'refunded': {
+        // The offer missed its target: the principal never left the contract, so
+        // it goes straight back to the lender and clears the liability.
+        const amount = toBigInt(event.amount)
+        if (amount <= 0n) break
+        bump(heldByOffer, event.offerId, -amount)
+        bump(owedToLender, key, -amount)
+        entries.push(
+          makeEntry({
+            id: event.id,
+            timestamp: event.timestamp,
+            useCase: 'UC-CREDIT-04',
+            debit: LOAN_PAYABLE,
+            credit: CREDIT,
+            amountUsd: usd(amount),
+            token,
+            rawAmount: amount.toString(),
+            counterparty: event.lender,
+            memo: `Principal refunded on unfunded Community Credit offer #${event.offerId}`
+          })
+        )
+        break
+      }
+    }
+  }
+
+  return entries
+}

--- a/app/src/utils/accounting/mappers/index.ts
+++ b/app/src/utils/accounting/mappers/index.ts
@@ -12,6 +12,7 @@ import { mapBankEvents, type BankMapperInput } from './bank'
 import { mapFees, type FeeMapperInput } from './fees'
 import { mapCashRemunerationEvents, type CashRemunerationMapperInput } from './cashRemuneration'
 import { mapExpenseAccountEvents, type ExpenseMapperInput } from './expenseAccount'
+import { mapFixedReturnEvents, type FixedReturnMapperInput } from './fixedReturn'
 import { mapInvestorEvents, type InvestorMapperInput } from './investor'
 import { mapSafeTransfers, type SafeMapperInput } from './safe'
 import { mapSafeDepositRouterEvents, type SafeDepositRouterMapperInput } from './safeDepositRouter'
@@ -25,6 +26,7 @@ export * from './bank'
 export * from './fees'
 export * from './cashRemuneration'
 export * from './expenseAccount'
+export * from './fixedReturn'
 export * from './investor'
 export * from './safe'
 export * from './safeDepositRouter'
@@ -35,6 +37,7 @@ export interface LedgerSources {
   fees?: FeeMapperInput
   cashRemuneration?: CashRemunerationMapperInput
   expenseAccount?: ExpenseMapperInput
+  fixedReturn?: FixedReturnMapperInput
   investor?: InvestorMapperInput
   safe?: SafeMapperInput
   safeDepositRouter?: SafeDepositRouterMapperInput
@@ -59,6 +62,7 @@ export function mapAllSources(
   if (sources.expenseAccount) {
     entries.push(...mapExpenseAccountEvents(sources.expenseAccount, ctx, offChain.expenses))
   }
+  if (sources.fixedReturn) entries.push(...mapFixedReturnEvents(sources.fixedReturn, ctx))
   if (sources.investor) entries.push(...mapInvestorEvents(sources.investor, ctx))
   if (sources.safe) entries.push(...mapSafeTransfers(sources.safe, ctx))
   if (sources.safeDepositRouter) {


### PR DESCRIPTION
# Description

## Intial Issue Description

Closes #2361

The CNC accounting engine reconstructs the three financial statements from the team's on-chain feeds — Bank, CashRemuneration, Expense, InvestorV1, SafeDepositRouter — but not from **FixedReturn (Community Credit)**. Everything a team borrows from its lenders, and everything it repays them, was invisible: understated cash, no debt at all, overstated net income.

## PR Summary Or Solution description

FixedReturn becomes a first-class accounting source, handled exactly like the other contracts.

**Chart of accounts** — three new accounts: `Cash — Credit` (the pocket holding lender deposits while an offer is Open, rolling up into the Cash line), `Loan Payable`, and `Interest Expense`. The latter was previously listed as a Phase 2 gap "with no data feed yet"; this feed is that data feed.

**Mapper** — the four money-moving events:

| Event | Use case | Posting |
| --- | --- | --- |
| `FundsLent` | UC-CREDIT-01 | Dr `Cash — Credit` · Cr `Loan Payable` |
| `LendingOfferFunded` | UC-CREDIT-02 | Dr `Cash — Bank` · Cr `Cash — Credit` (internal) |
| `LenderRepaid` | UC-CREDIT-03 | Dr `Loan Payable` · Cr `Cash — Bank` (principal leg)<br>Dr `Interest Expense` · Cr `Cash — Bank` (interest leg) |
| `PrincipalRefunded` | UC-CREDIT-04 | Dr `Loan Payable` · Cr `Cash — Credit` |

Two figures are not carried by the events, so the mapper replays the lifecycle chronologically to derive them:

- the principal swept on a funded offer is the deposits accumulated so far — the sweep is a raw `safeTransfer` that emits no Bank event, so the internal move is booked from the credit side and has no Bank-side twin;
- `repayLenders` distributes cumulatively with no principal/interest distinction, so the split is reconstructed: a lender's payments retire their principal first, everything beyond it is the fixed return. That leaves `Loan Payable` at exactly zero once a lender is made whole.

An offer whose `LendingOfferCreated` is missing from the feed is skipped — that event is the only carrier of the offer's token, and valuing base units against a guessed token would post a wildly wrong USD figure.

**UI** — credit postings get their own `Credit` category, badge and filter pill, with per-use-case activity labels (the two legs of one installment read differently). The funded sweep stays a `Transfer`: it is a Credit → Bank internal move, not a credit event. The category vocabulary moved out of `ledgerPresenter` into its own `ledgerCategory` module — the same split `ledgerCurrency` already had — and is re-exported, so callers are unaffected.

## Contribution

Six atomic commits, one per layer: chart of accounts → internal pocket registration → mapper → pipeline wiring → journal presentation → tests. Lock files and local chain artifacts are deliberately left out of this PR.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

Code quality gate on `app/`: `build`, `type-check`, `lint`, `format` and `test:unit` all pass (297 accounting tests).
