### PR TITLE
refactor: ♻️ split the Safe address setup out of the SHER compensation toggle

### DIFF
--- a/app/src/components/sections/SherTokenView/InvestorActions/SetSafeAddressAction.vue
+++ b/app/src/components/sections/SherTokenView/InvestorActions/SetSafeAddressAction.vue
@@ -1,0 +1,125 @@
+<template>
+  <div v-if="safeDepositRouterAddress">
+    <UTooltip :text="safeAddressTooltip">
+      <ActionButton
+        icon="heroicons:link"
+        icon-bg="bg-indigo-50 dark:bg-indigo-950"
+        icon-color="text-indigo-700 dark:text-indigo-400"
+        title="Set Safe Address"
+        tone-class="border-indigo-200 bg-indigo-50/60 hover:border-indigo-300 hover:bg-indigo-100/70 disabled:border-indigo-200 disabled:bg-indigo-50/50 dark:border-indigo-900 dark:bg-indigo-950/30 dark:hover:border-indigo-800 dark:hover:bg-indigo-900/40 dark:disabled:border-indigo-900 dark:disabled:bg-indigo-950/30"
+        :badge="isSafeAddressSynced ? 'Set' : undefined"
+        :loading="isLoading"
+        :disabled="isWriteDisabled || !canManageSafeAddress || isSafeAddressSynced || isLoading"
+        data-test="set-safe-address-button"
+        @click="handleSetSafeAddress"
+      />
+    </UTooltip>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from 'vue'
+import { useConnection } from '@wagmi/vue'
+import { useToast } from '@nuxt/ui/composables'
+import ActionButton from '@/components/sections/SherTokenView/ActionButton.vue'
+import { useSetSafeAddress } from '@/composables/safeDepositRouter/writes'
+import {
+  useSafeDepositRouterAddress,
+  useSafeDepositRouterSafeAddress,
+  useSafeDepositRouterOwner
+} from '@/composables/safeDepositRouter/reads'
+import { useTeamStore } from '@/stores'
+import { parseError } from '@/utils'
+import { useTeamWriteGuard } from '@/composables/useTeamWriteGuard'
+
+const teamStore = useTeamStore()
+const { isWriteDisabled, archivedTooltip } = useTeamWriteGuard()
+const toast = useToast()
+const connection = useConnection()
+
+const safeDepositRouterAddress = useSafeDepositRouterAddress()
+
+const { data: owner, isLoading: isOwnerLoading } = useSafeDepositRouterOwner()
+const { data: contractSafeAddress, isLoading: isSafeAddressLoading } =
+  useSafeDepositRouterSafeAddress()
+
+const setSafeAddressWrite = useSetSafeAddress()
+
+const isReadLoading = computed(() => isOwnerLoading.value || isSafeAddressLoading.value)
+const isLoading = computed(() => isReadLoading.value || setSafeAddressWrite.isPending.value)
+
+const teamSafeAddress = computed(() => teamStore.getContractAddressByType('Safe'))
+
+// Check if connected user is the owner
+const canManageSafeAddress = computed(() => {
+  if (!connection.isConnected.value || !connection.address?.value) return false
+  if (!owner.value) return false
+  return connection.address.value.toLowerCase() === (owner.value as string).toLowerCase()
+})
+
+// The router already points at the team Safe — nothing to do
+const isSafeAddressSynced = computed(() => {
+  if (!contractSafeAddress.value || !teamSafeAddress.value) return false
+  return (contractSafeAddress.value as string).toLowerCase() === teamSafeAddress.value.toLowerCase()
+})
+
+const safeAddressTooltip = computed(() => {
+  if (archivedTooltip.value) return archivedTooltip.value
+  if (!canManageSafeAddress.value) return 'Only the owner can set the Safe address'
+  if (isSafeAddressSynced.value) return 'The Safe address is already up to date'
+  return 'Point the deposit router at the team Safe'
+})
+
+watch(
+  () => setSafeAddressWrite.error.value,
+  (error) => {
+    if (error) {
+      console.error('Error setting safe address:', error)
+      const errorMessage = parseError(error)
+
+      if (errorMessage.includes('User rejected') || errorMessage.includes('User denied')) {
+        toast.add({ title: 'Transaction cancelled by user', color: 'error' })
+      } else {
+        toast.add({ title: 'Failed to update Safe address', color: 'error' })
+      }
+    }
+  }
+)
+
+watch(
+  () => setSafeAddressWrite.isSuccess.value,
+  (success) => {
+    if (success) {
+      toast.add({ title: 'Safe address updated successfully', color: 'success' })
+    }
+  }
+)
+
+/**
+ * Set the team Safe address on the SafeDepositRouter.
+ * SHER compensation can only be enabled once this is done.
+ */
+async function handleSetSafeAddress() {
+  if (isWriteDisabled.value) return
+
+  if (!safeDepositRouterAddress.value) {
+    toast.add({ title: 'SafeDepositRouter address not found', color: 'error' })
+    return
+  }
+
+  if (!canManageSafeAddress.value) {
+    toast.add({ title: 'Only the owner can set the Safe address', color: 'error' })
+    return
+  }
+
+  if (!teamSafeAddress.value) {
+    toast.add({ title: 'Safe address not found', color: 'error' })
+    return
+  }
+
+  if (isSafeAddressSynced.value) return
+
+  toast.add({ title: 'Updating Safe address...', color: 'info' })
+  await setSafeAddressWrite.mutateAsync({ args: [teamSafeAddress.value] })
+}
+</script>

--- a/app/src/components/sections/SherTokenView/InvestorActions/ToggleSherCompensationAction.vue
+++ b/app/src/components/sections/SherTokenView/InvestorActions/ToggleSherCompensationAction.vue
@@ -18,7 +18,7 @@
             : 'border-violet-200 bg-violet-50/60 hover:border-violet-300 hover:bg-violet-100/70 disabled:border-violet-200 disabled:bg-violet-50/50 dark:border-violet-900 dark:bg-violet-950/30 dark:hover:border-violet-800 dark:hover:bg-violet-900/40 dark:disabled:border-violet-900 dark:disabled:bg-violet-950/30'
         "
         :loading="isLoading"
-        :disabled="isWriteDisabled || !canManageDeposits || isLoading"
+        :disabled="isWriteDisabled || !canManageDeposits || isEnableBlocked || isLoading"
         data-test="toggle-sher-compensation-button"
         @click="handleToggleCompensation"
       />
@@ -27,14 +27,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, watch } from 'vue'
 import { useConnection } from '@wagmi/vue'
+import { useToast } from '@nuxt/ui/composables'
 import ActionButton from '@/components/sections/SherTokenView/ActionButton.vue'
-import {
-  useEnableDeposits,
-  useDisableDeposits,
-  useSetSafeAddress
-} from '@/composables/safeDepositRouter/writes'
+import { useEnableDeposits, useDisableDeposits } from '@/composables/safeDepositRouter/writes'
 import {
   useSafeDepositRouterAddress,
   useSafeDepositRouterSafeAddress,
@@ -45,16 +42,13 @@ import { useTeamStore } from '@/stores'
 import { parseError } from '@/utils'
 import { useTeamWriteGuard } from '@/composables/useTeamWriteGuard'
 
+const SAFE_ADDRESS_REQUIRED_MESSAGE = 'Set the Safe address on the deposit router first'
+
 const teamStore = useTeamStore()
 const { isWriteDisabled, archivedTooltip } = useTeamWriteGuard()
 const toast = useToast()
 
-const toggleCompensationTooltip = computed(() => archivedTooltip.value)
 const connection = useConnection()
-
-// Track if we're in the process of setting safe address before enabling
-const isSettingSafeAddress = ref(false)
-const safeAddressErrorShown = ref(false)
 
 // Get SafeDepositRouter address
 const safeDepositRouterAddress = useSafeDepositRouterAddress()
@@ -69,7 +63,6 @@ const { data: contractSafeAddress, isLoading: isSafeAddressLoading } =
 // Write functions
 const enableDepositsWrite = useEnableDeposits()
 const disableDepositsWrite = useDisableDeposits()
-const setSafeAddressWrite = useSetSafeAddress()
 
 // Combined loading state
 const isReadLoading = computed(
@@ -77,11 +70,7 @@ const isReadLoading = computed(
 )
 
 const isWriteLoading = computed(() => {
-  return (
-    enableDepositsWrite.isPending.value ||
-    disableDepositsWrite.isPending.value ||
-    setSafeAddressWrite.isPending.value
-  )
+  return enableDepositsWrite.isPending.value || disableDepositsWrite.isPending.value
 })
 
 const isLoading = computed(() => isReadLoading.value || isWriteLoading.value)
@@ -101,6 +90,16 @@ const isSafeAddressCorrect = computed(() => {
   return (contractSafeAddress.value as string).toLowerCase() === safeAddress.toLowerCase()
 })
 
+// Enabling requires the Safe address to be set first (see SetSafeAddressAction).
+// Disabling stays available regardless.
+const isEnableBlocked = computed(() => !depositsEnabled.value && !isSafeAddressCorrect.value)
+
+const toggleCompensationTooltip = computed(() => {
+  if (archivedTooltip.value) return archivedTooltip.value
+  if (isEnableBlocked.value) return SAFE_ADDRESS_REQUIRED_MESSAGE
+  return undefined
+})
+
 // ============================================================================
 // WATCH PATTERNS - Following established patterns
 // ============================================================================
@@ -118,7 +117,6 @@ watch(
       } else {
         toast.add({ title: 'Failed to enable SHER compensation', color: 'error' })
       }
-      isSettingSafeAddress.value = false
     }
   }
 )
@@ -129,7 +127,6 @@ watch(
   (success) => {
     if (success) {
       toast.add({ title: 'SHER compensation enabled successfully', color: 'success' })
-      isSettingSafeAddress.value = false
     }
   }
 )
@@ -161,59 +158,6 @@ watch(
   }
 )
 
-// Watch for set safe address errors
-watch(
-  () => setSafeAddressWrite.error.value,
-  (error) => {
-    if (error) {
-      console.error('Error setting safe address:', error)
-      const errorMessage = parseError(error)
-
-      if (errorMessage.includes('User rejected') || errorMessage.includes('User denied')) {
-        toast.add({ title: 'Transaction cancelled by user', color: 'error' })
-      } else {
-        toast.add({ title: 'Failed to update Safe address', color: 'error' })
-      }
-      isSettingSafeAddress.value = false
-    }
-  }
-)
-
-// Watch for set safe address success - automatically enable deposits after
-watch(
-  () => setSafeAddressWrite.isSuccess.value,
-  (success) => {
-    if (success && isSettingSafeAddress.value) {
-      toast.add({ title: 'Safe address updated successfully', color: 'success' })
-
-      // Auto-enable deposits after successful Safe address update
-      setTimeout(() => {
-        handleEnableDeposits()
-      }, 1000)
-    }
-  }
-)
-
-/**
- * Update Safe address in contract
- */
-async function updateSafeAddress() {
-  const safeAddress = teamStore.getContractAddressByType('Safe')
-
-  if (!safeAddress) {
-    if (!safeAddressErrorShown.value) {
-      toast.add({ title: 'Safe address not found', color: 'error' })
-      safeAddressErrorShown.value = true
-    }
-    isSettingSafeAddress.value = false
-    return
-  }
-
-  safeAddressErrorShown.value = false
-  toast.add({ title: 'Updating Safe address...', color: 'info' })
-  await setSafeAddressWrite.mutateAsync({ args: [safeAddress] })
-}
-
 /**
  * Enable deposits
  */
@@ -229,8 +173,8 @@ async function handleDisableDeposits() {
 }
 
 /**
- * Toggle SHER token compensation
- * If enabling and Safe address is not set, automatically set it first
+ * Toggle SHER token compensation.
+ * Enabling requires the Safe address to already be set on the router.
  */
 async function handleToggleCompensation() {
   if (isWriteDisabled.value) return
@@ -251,15 +195,11 @@ async function handleToggleCompensation() {
     return
   }
 
-  // If enabling and Safe address is not correct, set it first
   if (!isSafeAddressCorrect.value) {
-    isSettingSafeAddress.value = true
-    await updateSafeAddress()
-    // The watch on setSafeAddress success will automatically call handleEnableDeposits
+    toast.add({ title: SAFE_ADDRESS_REQUIRED_MESSAGE, color: 'error' })
     return
   }
 
-  // If Safe address is already correct, enable directly
   await handleEnableDeposits()
 }
 </script>

--- a/app/src/components/sections/SherTokenView/InvestorActions/__tests__/SetSafeAddressAction.spec.ts
+++ b/app/src/components/sections/SherTokenView/InvestorActions/__tests__/SetSafeAddressAction.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { nextTick } from 'vue'
+import SetSafeAddressAction from '../SetSafeAddressAction.vue'
+import {
+  mockParseError,
+  mockSafeDepositRouterAddress,
+  mockSafeDepositRouterReads,
+  mockSafeDepositRouterWrites,
+  mockTeamStore,
+  mockToast,
+  mockUseConnection,
+  renderWithProviders
+} from '@/tests/mocks'
+
+const TEAM_SAFE_ADDRESS = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+const OTHER_ADDRESS = '0x1111111111111111111111111111111111111111'
+
+describe('SetSafeAddressAction.vue', () => {
+  const createWrapper = () => renderWithProviders(SetSafeAddressAction)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockParseError.mockReturnValue('Parsed error message')
+
+    mockSafeDepositRouterAddress.value = TEAM_SAFE_ADDRESS
+    mockSafeDepositRouterReads.owner.data.value = '0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa'
+    mockSafeDepositRouterReads.safeAddress.data.value = OTHER_ADDRESS
+    mockUseConnection.isConnected.value = true
+    mockUseConnection.address.value = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa'
+
+    mockSafeDepositRouterWrites.setSafeAddress.mutateAsync.mockResolvedValue(undefined)
+  })
+
+  it('does not render when safe deposit router address is missing', () => {
+    mockSafeDepositRouterAddress.value = ''
+    const wrapper = createWrapper()
+
+    expect(wrapper.find('[data-test="set-safe-address-button"]').exists()).toBe(false)
+  })
+
+  it('sets the team safe address on the router', async () => {
+    const wrapper = createWrapper()
+
+    await wrapper.findComponent({ name: 'ActionButton' }).vm.$emit('click')
+    await nextTick()
+
+    expect(mockSafeDepositRouterWrites.setSafeAddress.mutateAsync).toHaveBeenCalledWith({
+      args: [TEAM_SAFE_ADDRESS]
+    })
+  })
+
+  it('blocks and warns when the connected account is not the owner', async () => {
+    mockUseConnection.address.value = '0x0000000000000000000000000000000000000001'
+    const wrapper = createWrapper()
+
+    await wrapper.findComponent({ name: 'ActionButton' }).vm.$emit('click')
+    await nextTick()
+
+    expect(mockSafeDepositRouterWrites.setSafeAddress.mutateAsync).not.toHaveBeenCalled()
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Only the owner can set the Safe address', color: 'error' })
+    )
+  })
+
+  it('warns when the team has no Safe address', async () => {
+    mockTeamStore.getContractAddressByType = vi.fn(
+      () => ''
+    ) as unknown as typeof mockTeamStore.getContractAddressByType
+    const wrapper = createWrapper()
+
+    await wrapper.findComponent({ name: 'ActionButton' }).vm.$emit('click')
+    await nextTick()
+
+    expect(mockSafeDepositRouterWrites.setSafeAddress.mutateAsync).not.toHaveBeenCalled()
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Safe address not found', color: 'error' })
+    )
+  })
+
+  it('is disabled and badged once the safe address matches the team safe', async () => {
+    mockSafeDepositRouterReads.safeAddress.data.value = TEAM_SAFE_ADDRESS
+    const wrapper = createWrapper()
+
+    expect(wrapper.findComponent({ name: 'ActionButton' }).props('badge')).toBe('Set')
+    expect(
+      wrapper.find('[data-test="set-safe-address-button"]').attributes('disabled')
+    ).toBeDefined()
+
+    await wrapper.findComponent({ name: 'ActionButton' }).vm.$emit('click')
+    await nextTick()
+
+    expect(mockSafeDepositRouterWrites.setSafeAddress.mutateAsync).not.toHaveBeenCalled()
+  })
+
+  it('reports a failed safe address update', async () => {
+    const wrapper = createWrapper()
+    mockSafeDepositRouterWrites.setSafeAddress.error.value = new Error('boom')
+    await nextTick()
+
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Failed to update Safe address', color: 'error' })
+    )
+    wrapper.unmount()
+  })
+
+  it('reports a user-rejected safe address update', async () => {
+    mockParseError.mockReturnValue('User denied signature')
+    const wrapper = createWrapper()
+    mockSafeDepositRouterWrites.setSafeAddress.error.value = new Error('boom')
+    await nextTick()
+
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Transaction cancelled by user', color: 'error' })
+    )
+    wrapper.unmount()
+  })
+
+  it('reports a successful safe address update', async () => {
+    const wrapper = createWrapper()
+    mockSafeDepositRouterWrites.setSafeAddress.isSuccess.value = true
+    await nextTick()
+
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Safe address updated successfully', color: 'success' })
+    )
+    wrapper.unmount()
+  })
+})

--- a/app/src/components/sections/SherTokenView/InvestorActions/__tests__/ToggleSherCompensationAction.spec.ts
+++ b/app/src/components/sections/SherTokenView/InvestorActions/__tests__/ToggleSherCompensationAction.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { nextTick } from 'vue'
 import ToggleSherCompensationAction from '../ToggleSherCompensationAction.vue'
 import {
@@ -6,7 +6,6 @@ import {
   mockSafeDepositRouterAddress,
   mockSafeDepositRouterReads,
   mockSafeDepositRouterWrites,
-  mockTeamStore,
   mockUseConnection,
   renderWithProviders
 } from '@/tests/mocks'
@@ -15,7 +14,6 @@ describe('ToggleSherCompensationAction.vue', () => {
   const createWrapper = () => renderWithProviders(ToggleSherCompensationAction)
 
   beforeEach(() => {
-    vi.useRealTimers()
     vi.clearAllMocks()
     mockParseError.mockReturnValue('Parsed error message')
 
@@ -28,11 +26,6 @@ describe('ToggleSherCompensationAction.vue', () => {
 
     mockSafeDepositRouterWrites.enableDeposits.mutateAsync.mockResolvedValue(undefined)
     mockSafeDepositRouterWrites.disableDeposits.mutateAsync.mockResolvedValue(undefined)
-    mockSafeDepositRouterWrites.setSafeAddress.mutateAsync.mockResolvedValue(undefined)
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('does not render when safe deposit router address is missing', () => {
@@ -87,7 +80,7 @@ describe('ToggleSherCompensationAction.vue', () => {
     expect(mockSafeDepositRouterWrites.disableDeposits.mutateAsync).toHaveBeenCalledTimes(1)
   })
 
-  it('enables deposits directly when safe address is correct', async () => {
+  it('enables deposits when safe address is already set', async () => {
     mockSafeDepositRouterReads.depositsEnabled.data.value = false
     mockSafeDepositRouterReads.safeAddress.data.value = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
     const wrapper = createWrapper()
@@ -98,51 +91,25 @@ describe('ToggleSherCompensationAction.vue', () => {
     expect(mockSafeDepositRouterWrites.enableDeposits.mutateAsync).toHaveBeenCalledTimes(1)
   })
 
-  it('updates safe address before enabling when safe address mismatches', async () => {
+  it('never writes the safe address itself when it mismatches', async () => {
     mockSafeDepositRouterReads.depositsEnabled.data.value = false
     mockSafeDepositRouterReads.safeAddress.data.value = '0x1111111111111111111111111111111111111111'
     const wrapper = createWrapper()
 
-    await wrapper.findComponent({ name: 'ActionButton' }).vm.$emit('click')
-    await nextTick()
-
-    expect(mockSafeDepositRouterWrites.setSafeAddress.mutateAsync).toHaveBeenCalledTimes(1)
-    expect(mockSafeDepositRouterWrites.enableDeposits.mutateAsync).not.toHaveBeenCalled()
-  })
-
-  it('updateSafeAddress returns early when safe address is missing', async () => {
-    mockTeamStore.getContractAddressByType = vi.fn(
-      () => ''
-    ) as unknown as typeof mockTeamStore.getContractAddressByType
-    mockSafeDepositRouterReads.depositsEnabled.data.value = false
-    mockSafeDepositRouterReads.safeAddress.data.value = '0x1111111111111111111111111111111111111111'
-    const wrapper = createWrapper()
-
-    await wrapper.findComponent({ name: 'ActionButton' }).vm.$emit('click')
     await wrapper.findComponent({ name: 'ActionButton' }).vm.$emit('click')
     await nextTick()
 
     expect(mockSafeDepositRouterWrites.setSafeAddress.mutateAsync).not.toHaveBeenCalled()
-    expect(wrapper.exists()).toBe(true)
+    expect(mockSafeDepositRouterWrites.enableDeposits.mutateAsync).not.toHaveBeenCalled()
   })
 
-  it('setSafeAddress success while setting triggers delayed enable', async () => {
-    vi.useFakeTimers()
+  it('disables the button while the safe address is not set', () => {
     mockSafeDepositRouterReads.depositsEnabled.data.value = false
     mockSafeDepositRouterReads.safeAddress.data.value = '0x1111111111111111111111111111111111111111'
-
     const wrapper = createWrapper()
 
-    await wrapper.findComponent({ name: 'ActionButton' }).vm.$emit('click')
-    await nextTick()
-    mockSafeDepositRouterWrites.setSafeAddress.isSuccess.value = true
-    await nextTick()
-
-    vi.runAllTimers()
-    await nextTick()
-
-    expect(mockSafeDepositRouterWrites.enableDeposits.mutateAsync).toHaveBeenCalled()
-    wrapper.unmount()
+    const button = wrapper.find('[data-test="toggle-sher-compensation-button"]')
+    expect(button.attributes('disabled')).toBeDefined()
   })
 
   it('watch enable error path executes', async () => {
@@ -165,14 +132,6 @@ describe('ToggleSherCompensationAction.vue', () => {
   it('watch disable error path executes', async () => {
     const wrapper = createWrapper()
     mockSafeDepositRouterWrites.disableDeposits.error.value = new Error('boom')
-    await nextTick()
-    expect(wrapper.exists()).toBe(true)
-    wrapper.unmount()
-  })
-
-  it('watch setSafeAddress error path executes', async () => {
-    const wrapper = createWrapper()
-    mockSafeDepositRouterWrites.setSafeAddress.error.value = new Error('boom')
     await nextTick()
     expect(wrapper.exists()).toBe(true)
     wrapper.unmount()

--- a/app/src/components/sections/SherTokenView/InvestorsActions.vue
+++ b/app/src/components/sections/SherTokenView/InvestorsActions.vue
@@ -20,7 +20,7 @@
       "
     >
       <div class="grid grid-cols-2 gap-2.5 md:grid-cols-3 xl:grid-cols-6">
-        <USkeleton v-for="i in 6" :key="i" class="h-20 rounded-lg" :data-test="`skeleton-${i}`" />
+        <USkeleton v-for="i in 7" :key="i" class="h-20 rounded-lg" :data-test="`skeleton-${i}`" />
       </div>
     </template>
     <template v-else>
@@ -39,6 +39,7 @@
           :investors-address="investorAddress"
           :bank-address="bankAddress"
         />
+        <SetSafeAddressAction />
         <ToggleSherCompensationAction />
         <SetCompensationMultiplierAction />
         <InvestInSafeAction />
@@ -55,6 +56,7 @@ import AddressToolTip from '@/components/AddressToolTip.vue'
 import DistributeMintAction from './InvestorActions/DistributeMintAction.vue'
 import MintTokenAction from './InvestorActions/MintTokenAction.vue'
 import PayDividendsAction from './InvestorActions/PayDividendsAction.vue'
+import SetSafeAddressAction from './InvestorActions/SetSafeAddressAction.vue'
 import ToggleSherCompensationAction from './InvestorActions/ToggleSherCompensationAction.vue'
 import SetCompensationMultiplierAction from './InvestorActions/SetCompensationMultiplierAction.vue'
 import InvestInSafeAction from './InvestorActions/InvestInSafeAction.vue'

--- a/app/src/composables/accounting/useCNCAccounting.ts
+++ b/app/src/composables/accounting/useCNCAccounting.ts
@@ -127,7 +127,7 @@ export function useCNCAccounting(
   const routerMultiplier = useReadContract({
     address: computed(() => (routerAddress.value ? (routerAddress.value as Address) : undefined)),
     abi: SAFE_DEPOSIT_ROUTER_ABI,
-    functionName: 'multiplier',
+    functionName: 'getMultiplier',
     query: { enabled: computed(() => Boolean(routerAddress.value)) }
   })
 

--- a/app/src/composables/safeDepositRouter/reads.ts
+++ b/app/src/composables/safeDepositRouter/reads.ts
@@ -7,13 +7,13 @@ import { SAFE_DEPOSIT_ROUTER_ABI } from '@/artifacts/abi/safe-deposit-router'
 const SAFE_DEPOSIT_ROUTER_FUNCTION_NAMES = {
   PAUSED: 'paused',
   OWNER: 'owner',
-  DEPOSITS_ENABLED: 'depositsEnabled',
-  SAFE_ADDRESS: 'safeAddress',
-  OFFICER_ADDRESS: 'officerAddress',
-  MULTIPLIER: 'multiplier',
+  DEPOSITS_ENABLED: 'getDepositsEnabled',
+  SAFE_ADDRESS: 'getSafeAddress',
+  OFFICER_ADDRESS: 'getOfficerAddress',
+  MULTIPLIER: 'getMultiplier',
   MIN_MULTIPLIER: 'MIN_MULTIPLIER',
   IS_TOKEN_SUPPORTED: 'isTokenSupported',
-  TOKEN_DECIMALS: 'tokenDecimals',
+  TOKEN_DECIMALS: 'getTokenDecimals',
   CALCULATE_COMPENSATION: 'calculateCompensation'
 } as const
 


### PR DESCRIPTION
# Description

## Intial Issue Description

Fixes #2368

"Enable SHER Compensation" was a single button firing **two** on-chain transactions: `setSafeAddress(teamSafe)`, then a `setTimeout(…, 1000)` that auto-triggered `enableDeposits()` once the first succeeded. Two wallet prompts behind one click, chained on a timer and a local `isSettingSafeAddress` flag rather than on the actual contract state — and no clean way to retry a single step when the second transaction failed or was rejected.

## PR Summary Or Solution description

Split into two independent actions.

**`SetSafeAddressAction.vue`** (new) — writes the team Safe address to the `SafeDepositRouter`, and nothing else. Once the router already points at the team Safe, it is disabled and carries a "Set" badge. Owner-only, and it respects the archived-team write guard like its siblings.

**`ToggleSherCompensationAction.vue`** — now only calls `enableDeposits` / `disableDeposits`. Removed: `useSetSafeAddress`, the `isSettingSafeAddress` / `safeAddressErrorShown` flags, the `setTimeout` auto-enable, and the two watches that drove that chaining. Enabling is gated on the Safe address already matching the team Safe (button disabled, tooltip "Set the Safe address on the deposit router first"; a forced click toasts the same message instead of sending a transaction). **Disabling stays available regardless** of the Safe address state, so an admin can always turn compensation off.

The actions grid goes from 6 to 7 tiles; the loading skeleton count follows.

Both components now import `useToast` explicitly from `@nuxt/ui/composables` rather than relying on the auto-import, which is what makes the toast assertions in the specs possible.

### Reviewer notes

- The "is the Safe address set?" check is the pre-existing `isSafeAddressCorrect` predicate: the router's `safeAddress()` compared case-insensitively against `teamStore.getContractAddressByType('Safe')`. So a router pointing at a *different* Safe is treated the same as an unset one — it needs to be re-pointed at the team Safe before compensation can be enabled. That matches the behaviour the old auto-chaining had.
- No contract or ABI change; this is purely the app-side flow.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
