### PR TITLE
fix: 🐛 restore the consolidated archive_and_hide migration

### DIFF
--- a/backend/prisma/migrations/20260513120000_member_teams_is_hidden/migration.sql
+++ b/backend/prisma/migrations/20260513120000_member_teams_is_hidden/migration.sql
@@ -1,6 +1,0 @@
--- Replace per-member visibility (isVisible) with isHidden (inverted meaning).
-ALTER TABLE "MemberTeamsData" ADD COLUMN "isHidden" BOOLEAN NOT NULL DEFAULT false;
-
-UPDATE "MemberTeamsData" SET "isHidden" = NOT "isVisible";
-
-ALTER TABLE "MemberTeamsData" DROP COLUMN "isVisible";

--- a/backend/prisma/migrations/20260527112240_archive_and_hide/migration.sql
+++ b/backend/prisma/migrations/20260527112240_archive_and_hide/migration.sql
@@ -1,5 +1,5 @@
 -- AlterTable
-ALTER TABLE "MemberTeamsData" ADD COLUMN     "isVisible" BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE "MemberTeamsData" ADD COLUMN     "isHidden" BOOLEAN NOT NULL DEFAULT false;
 
 -- AlterTable
 ALTER TABLE "Team" ADD COLUMN     "isArchived" BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
# Description

## Intial Issue Description

Production `api` deploys have been failing since 2026-07-28 11:13 UTC at `prisma migrate deploy`. The build succeeds; the container dies on startup.

Fixes #2374

## PR Summary Or Solution description

**Symptom.** The first failing deploy hit `P3018` / Postgres `42701`: `column "isArchived" of relation "Team" already exists`, while applying `20260507102622_team_archived`. Every later boot then failed earlier with `P3009`, because the failed row blocks the whole migration history. Production kept answering only because the 2026-07-15 deployment was still serving — it boots with `npm start` and never runs migrations, so the breakage stayed invisible from outside.

**Root cause.** A migration history regression from a merge resolution, not an application-code bug.

- 2026-05-27 — `55c93e538` consolidated `20260507102622_team_archived` and `20260513120000_member_teams_is_hidden` into a single `20260527112240_archive_and_hide`. That version shipped on `main` and was applied to production, where it is still recorded as applied in `_prisma_migrations`.
- `develop` kept carrying the two pre-consolidation folders.
- 2026-07-28 10:46 — `1dcbb0605` ("Merge branch 'main' into develop") resolved `backend/prisma/migrations/` in favour of the stale `develop` side: the consolidated folder disappeared, the two old ones came back, and that shipped through `release/v0.13.0` into `main`.

**Fix.** Restore `20260527112240_archive_and_hide` and delete the two stale folders, so the repository matches what production actually recorded. Git renders this as the exact inverse of the rename that was lost. The declared schema is unchanged and was never wrong: `Team.isArchived` and `MemberTeamsData.isHidden`, with no remaining reference to `isVisible` anywhere in the codebase.

The blocking row in production has already been cleared out of band with `npx prisma migrate resolve --rolled-back 20260507102622_team_archived`.

## Reviewer notes

- **This must reach `main` before any redeploy.** `main` still carries the two faulty folders; a deploy from it would retry `20260507102622_team_archived`, hit the same `42701`, and re-mark the migration as failed.
- **Local databases will break in the opposite direction.** Any database that already applied the two old migrations will now see `20260527112240_archive_and_hide` as pending and fail, since the columns exist. Resolution: `npx prisma migrate reset`, or `npx prisma migrate resolve --applied 20260527112240_archive_and_hide`.
- Worth internalising for next time: a migration folder *reappearing* in a merge diff is always a red flag. Production holds its own copy of the migration history, and it does not get rewritten along with the branch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features) — not applicable, this is a migration history correction with no code change
- [ ] Docs have been added / updated (for bug fixes / features) — not applicable
