### PR TITLE
refactor: ♻️ standardize display formatting behind a single utils/format module

### DIFF
--- a/.github/copilot-instructions/README.md
+++ b/.github/copilot-instructions/README.md
@@ -22,9 +22,13 @@ For every feature create documentation in the `/docs` folder using Markdown file
 
 Try to keep each feature documentation short, and use mermaid for diagrams where applicable.
 
+### Display Formatting
+
+Never format a value for display by hand — no `Intl.*`, `toLocaleString`, `toFixed`, or dayjs pattern strings outside the canonical module. Ask `@/utils/format` (app) / `~/utils/format` (dashboard) for a named style. ESLint enforces it. See [`formatting-standards.md`](./formatting-standards.md).
+
 ### Date Manipulation
 
-For Date Manipulation, always use dayjs library.
+For Date Manipulation, always use dayjs library — and for *displaying* a date, through the named helpers in [`formatting-standards.md`](./formatting-standards.md) rather than a pattern string at the call site.
 
 ### Context7 MCP Integration
 
@@ -83,6 +87,7 @@ Make all interfaces accessible for everyone, including users with disabilities
 ### Core Development Guidelines
 
 - [`vue-component-standards.md`](./vue-component-standards.md) - Vue.js component development standards
+- [`formatting-standards.md`](./formatting-standards.md) - Canonical display formatting (money, tokens, dates, addresses)
 
 ### Testing Guidelines
 

--- a/.github/copilot-instructions/formatting-standards.md
+++ b/.github/copilot-instructions/formatting-standards.md
@@ -1,0 +1,123 @@
+# Display Formatting Standards
+
+**One rule: never format a value by hand. Ask the canonical module for a named style.**
+
+- `app/` → `import { formatUsd } from '@/utils/format'`
+- `dashboard/` → `import { formatUsd } from '~/utils/format'`
+
+ESLint enforces this. The rationale, the API, and what to do when the module doesn't cover your case are below.
+
+---
+
+## Why this exists
+
+Before this module, `app/src` alone carried:
+
+- **four** ways to render a date — `dayjs` with 14 distinct pattern strings, `toLocaleString('en-US')`, `Intl.DateTimeFormat`, and a hand-rolled `String.replace` on `dd/MM/yyyy`;
+- **five strictly identical** transaction-date helpers, one per domain (`formatBankTransactionDate`, `formatExpenseTransactionDate`, …), each `new Date(ts * 1000).toLocaleString('en-US')`;
+- **three** money conventions with different decimal policies, only one of which avoided rendering a negative zero as `$-0.00`;
+- **five** address truncations, two using `…` where the rest used `...`, so the same address looked like two different values in two tables.
+
+That is not a tidiness problem. [#2376](https://github.com/globe-and-citizen/cnc-portal/pull/2376) shipped to production: a `maximumFractionDigits: 0` default plus raw `toLocaleString` at the call sites rounded every fractional Community Credit amount to a whole number, so a `0.2 USDC` position displayed as `0`.
+
+A formatter is a **product decision** — how much precision a user is trusted with, whether zero means zero or unknown, whether a figure is reconcilable against a block explorer. Decisions like that belong in one reviewed place, not re-derived per call site.
+
+---
+
+## The API
+
+Same surface in both front-ends (`app/src/utils/format/`, `dashboard/app/utils/format/`).
+
+### Money and numbers
+
+| Helper | Renders | Use for |
+| --- | --- | --- |
+| `formatUsd(value, { decimals = 2 })` | `$1,234.50`, `-$12.30` | Any USD figure. Fixed decimals, so columns align. `decimals: 6` for unit prices. |
+| `formatToken(value, symbol, { maxDecimals = 4 })` | `1,234.5 USDC` | Token amounts. Variable precision — trailing zeros trimmed. |
+| `formatNumber(value, { minDecimals = 0, maxDecimals = 4 })` | `1,234.5` | Counts, quantities, anything unitless. |
+| `formatCompact(value, { currency = 'USD' })` | `$1.2M` | Tiles and chart axes, where magnitude is the message. |
+| `formatPercent(ratio, { decimals = 2, signed })` | `12.50%`, `+5.0%` | Takes a **ratio, not percentage points**: `0.125` → `12.5%`. |
+
+### Dates
+
+| Helper | Renders | Use for |
+| --- | --- | --- |
+| `formatDate(value)` | `Jan 8, 2026` | The default for a date shown on its own. |
+| `formatDateTime(value)` | `Jan 8, 2026, 14:05:32` | Chronologically ordered rows — same-day entries must stay distinguishable. |
+| `formatDateShort(value)` | `Jan 8` | Chart axes, dense tables where the year is established. |
+| `formatMonthYear(value)` | `January 2026` | Period headers. |
+| `formatDateIso(value)` | `2026-01-08` | Filenames, CSV columns, API payloads — never UI copy. |
+| `formatDateUtc(value)` | `2026-01-08 14:05 UTC` | Anything a user lines up against a block explorer or a deadline. |
+| `formatDateRelative(value)` | `3 min ago` | Freshness cues. Falls back to `formatDate` past a week. |
+| `formatDuration(minutes)` | `1 h 30 min` | Elapsed spans. Never `01:30`, which reads as a clock time. |
+| `fromUnix(seconds)` | a `Dayjs` | On-chain timestamps. **Use this instead of `* 1000`.** |
+
+A bare `number` passed to a date formatter is **milliseconds** (the JavaScript convention). Contract timestamps are seconds — `formatDate(fromUnix(ts))`, not `formatDate(ts * 1000)`.
+
+### Addresses and hashes
+
+| Helper | Renders |
+| --- | --- |
+| `formatAddress(address, { lead = 6, tail = 4 })` | `0x4b6f...6F70` |
+| `formatTxHash(hash)` | same shape, named for the intent |
+
+Values already short enough to read whole come back untouched. Display only — never feed a truncated value into a contract call or a comparison.
+
+---
+
+## Conventions the module encodes
+
+**Locale is pinned to `en-US`.** Not the browser's: a `1,234.50` that becomes `1.234,50` for one teammate makes screenshots, exports and support threads unreadable, and the surrounding copy is English-only anyway.
+
+**Nothing renderable → `EMPTY_VALUE` (`—`), never `0`.** A zero is a claim about the data. Rendering `$0.00` for a balance that is merely still loading is how an empty wallet gets reported as a bug.
+
+**A value that rounds to zero renders as a clean zero.** `-0.004` at cent precision is `$0.00`, not `-$0.00`.
+
+**Money is fixed-precision, tokens are not.** `$5` and `$5.20` in the same column is a misread waiting to happen, so USD pads. `0.0001 SHER` and `0.00 SHER` are different claims, so tokens trim.
+
+---
+
+## What ESLint blocks
+
+Outside `utils/format/`, these are errors (in `<script>` **and** in `<template>`):
+
+| Banned | Instead |
+| --- | --- |
+| `new Intl.NumberFormat(...)`, `new Intl.DateTimeFormat(...)` | the helper for the style you want |
+| `.toLocaleString()`, `.toLocaleDateString()`, `.toLocaleTimeString()` | same |
+| `.toFixed(n)` | `formatNumber` / `formatUsd` for display — see below for on-chain amounts |
+| `.format('MMM D, YYYY')` — a literal dayjs pattern | a named date helper |
+
+`.format(value)` with a non-literal argument stays allowed: that's a formatter instance being called, not a pattern being invented.
+
+Specs are exempt — a test may assert against a natively formatted expectation.
+
+### `toFixed` before `parseUnits` is a bug, not a style issue
+
+```ts
+parseUnits(amount.toFixed(decimals), decimals) // ❌ silently changes the amount transacted
+```
+
+Rounding a value *before* converting it on-chain means the user signs a different number than the one they entered. Pass the unrounded value. Formatting is what you do to show a number to a human — never to prepare one for a contract.
+
+---
+
+## When the module doesn't cover your case
+
+**Extend it.** Add the named style to `utils/format/`, with a test and a one-line doc comment saying when to reach for it. Then use it in both front-ends.
+
+Do **not** add a file to the `formattingLegacyFiles` allowlist in `eslint.config.js` / `eslint.config.mjs`. That list is migration debt from [#2383](https://github.com/globe-and-citizen/cnc-portal/issues/2383) and only ever shrinks — a ceiling constant fails lint at config load if it grows. A new entry means the codebase gained a convention in the same week it spent a PR removing them.
+
+If a one-off truly is one-off, a scoped `// eslint-disable-next-line no-restricted-syntax -- <reason>` on the line itself is the escape hatch. The reason is mandatory; "legacy" is not a reason.
+
+**Keep the two implementations identical.** `app/` and `dashboard/` render the same figures for the same teams. There is no shared package to hold the module yet, so duplication is the price — any change lands in both.
+
+---
+
+## Review checklist
+
+- [ ] No `Intl.*`, `toLocaleString`, `toFixed`, or literal dayjs pattern outside `utils/format/`
+- [ ] On-chain amounts reach `parseUnits` unrounded
+- [ ] Unknown / loading values render `—`, not `0`
+- [ ] A new named style landed in **both** front-ends, with a test
+- [ ] `formattingLegacyFiles` did not grow

--- a/.github/copilot-instructions/review-checklist.md
+++ b/.github/copilot-instructions/review-checklist.md
@@ -12,6 +12,7 @@ Before submitting code for review, ensure the following items are completed:
 - [ ] **Type Safety**: No `any` types used unless absolutely necessary
 - [ ] **Import Organization**: Imports are organized (external → internal → relative)
 - [ ] **Console Logs**: No unnecessary console.log statements in production code
+- [ ] **Display Formatting**: Values are rendered through `utils/format` — no `Intl.*`, `toLocaleString`, `toFixed`, or dayjs pattern string at the call site, and no on-chain amount rounded before `parseUnits`. See [`formatting-standards.md`](./formatting-standards.md)
 
 ### Vue.js Component Standards
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ Then ask whether to do it now (scoped to this PR), defer (open a tracking issue)
 - **Atomic commits** — commit each logical change as it lands. Don't squash an entire PR into one commit at the end.
 - Issues, PRs, commit messages, and user-facing UI strings/toasts are **English**.
 - Vue components: `<script setup lang="ts">` Composition API. Pinia for global state, TanStack Query for server state.
+- **Display formatting**: never format by hand. Money, token amounts, dates, addresses go through the canonical module — `@/utils/format` in `app/`, `~/utils/format` in `dashboard/`. `Intl.*`, `toLocaleString`, `toFixed` and dayjs pattern strings are ESLint errors outside it. See `.github/copilot-instructions/formatting-standards.md`.
 - TypeScript strict mode across frontend and backend.
 
 ## Public-repo hygiene

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -237,6 +237,115 @@ const v3WriteRestrictedImports = {
   ]
 }
 
+// Formatting standardization (issue #2383).
+//
+// `src/utils/format/` is the single canonical implementation of every display
+// formatter (money, token amounts, dates, addresses). Everything else asks it
+// for a *named* style instead of re-deriving one from the raw primitives.
+//
+// The primitives below are banned outside that module because each one grew a
+// different convention in every file that reached for it: 14 dayjs pattern
+// strings for the same date, three `Intl.NumberFormat` precision policies for
+// the same amount, two ellipsis characters for the same address. #2376 is what
+// that costs in production — a `maximumFractionDigits: 0` default rounded every
+// fractional Community Credit amount to a whole number, so `0.2 USDC` displayed
+// as `0`.
+
+const formattingMessage =
+  'Use the canonical formatters from `@/utils/format` (formatUsd, formatToken, formatNumber, formatPercent, formatDate, formatDateTime, formatAddress, …) instead of formatting by hand. See .github/copilot-instructions/formatting-standards.md and issue #2383.'
+
+const bannedIntlFormatter = {
+  selector: "NewExpression[callee.object.name='Intl']",
+  message: formattingMessage
+}
+
+const bannedToLocale = {
+  selector: 'CallExpression[callee.property.name=/^toLocale(String|DateString|TimeString)$/]',
+  message: formattingMessage
+}
+
+// `toFixed` is banned for display *and* as an input to `parseUnits` — rounding a
+// value before converting it on-chain silently changes the amount transacted.
+const bannedToFixed = {
+  selector: "CallExpression[callee.property.name='toFixed']",
+  message: `${formattingMessage} For on-chain amounts, pass the unrounded value straight to \`parseUnits\` — never \`parseUnits(x.toFixed(d), d)\`.`
+}
+
+// `.format('MMM D, YYYY')` — a literal pattern string is the dayjs shape. Calls
+// like `formatter.format(value)` pass a value, not a literal, and stay allowed.
+const bannedDatePattern = {
+  selector: "CallExpression[callee.property.name='format'][arguments.0.type='Literal']",
+  message: formattingMessage
+}
+
+const formattingSelectors = [bannedIntlFormatter, bannedToLocale, bannedToFixed, bannedDatePattern]
+
+// Migration debt for the formatting guard — every file that still formats by
+// hand. This list only ever shrinks: PR 2 and PR 3 of #2383 drain it.
+//
+// If you're about to add an entry, you're adding a new convention to a codebase
+// that just spent a PR removing them. Either the canonical module covers your
+// case, or it should — extend `src/utils/format/` rather than whitelisting a
+// file here. The ceiling below fails `npm run lint` at config load if the list
+// grows; lower it as entries leave.
+const formattingLegacyFiles = [
+  'src/components/RateDotList.vue',
+  'src/components/TransactionChildRow.vue',
+  'src/components/TransactionDetailModal.vue',
+  'src/components/forms/ApproveExpenseSummaryForm.vue',
+  'src/components/forms/TokenAmount.vue',
+  'src/components/forms/TransferForm.vue',
+  'src/components/sections/AdministrationView/ElectionStats.vue',
+  'src/components/sections/AdministrationView/PastBoDElectionCard.vue',
+  'src/components/sections/CashRemunerationView/DeleteClaimModal.vue',
+  'src/components/sections/ClaimHistoryView/ClaimHistoryDailyBreakdown.vue',
+  'src/components/sections/ClaimHistoryView/ClaimHistoryWeekNavigator.vue',
+  'src/components/sections/ClaimHistoryView/WeeklyRecap.vue',
+  'src/components/sections/CommunityCreditView/CreditCallTermsStep.vue',
+  'src/components/sections/CommunityCreditView/CreditRepayPanel.vue',
+  'src/components/sections/DashboardView/CompanyOverview.vue',
+  'src/components/sections/ExpenseAccountView/ExpenseAccountTable.vue',
+  'src/components/sections/ExpenseAccountView/ExpenseMonthSpent.vue',
+  'src/components/sections/ExpenseAccountView/MyApprovedExpenseSection.vue',
+  'src/components/sections/ProposalsView/ProposalsCard.vue',
+  'src/components/sections/SherTokenView/InvestorsTransactions.vue',
+  'src/components/sections/SherTokenView/forms/MintRecapCard.vue',
+  'src/components/sections/VestingView/VestingFlow.vue',
+  'src/components/sections/VestingView/VestingSummary.vue',
+  'src/components/sections/WeeklyClaimView/WeeklyClaim.vue',
+  'src/composables/useClaimForm.ts',
+  'src/composables/vesting/useVestingDateRange.ts',
+  'src/stores/communityCredit.ts',
+  'src/utils/abiDecodeUtil.ts',
+  'src/utils/accounting/ledgerPresenter.ts',
+  'src/utils/accounting/mappers/expenseAccount.ts',
+  'src/utils/accounting/presenter.ts',
+  'src/utils/accounting/toUsd.ts',
+  'src/utils/accountingPdf.ts',
+  'src/utils/bankTransactionUtil.ts',
+  'src/utils/cashRemunerationTransactionUtil.ts',
+  'src/utils/communityCreditUtil.ts',
+  'src/utils/contractManagementUtil.ts',
+  'src/utils/currencyUtil.ts',
+  'src/utils/datePicker.ts',
+  'src/utils/dayUtils.ts',
+  'src/utils/expenseTransactionUtil.ts',
+  'src/utils/fixedReturnTransactionUtil.ts',
+  'src/utils/generalUtil.ts',
+  'src/utils/investorsTransactionUtil.ts',
+  'src/utils/safe.ts',
+  'src/utils/safeDepositRouterUtil.ts'
+]
+
+const FORMATTING_LEGACY_MAX = 46
+if (formattingLegacyFiles.length > FORMATTING_LEGACY_MAX) {
+  throw new Error(
+    `formattingLegacyFiles has ${formattingLegacyFiles.length} entries (ceiling ${FORMATTING_LEGACY_MAX}). ` +
+      'Format through `@/utils/format` instead of whitelisting a new file — see ' +
+      '.github/copilot-instructions/formatting-standards.md.'
+  )
+}
+
 export default [
   {
     // TODO turn this rule into an error by march 2025
@@ -372,6 +481,25 @@ export default [
     ],
     rules: {
       'no-restricted-imports': ['error', v3WriteRestrictedImports]
+    }
+  },
+  {
+    name: 'app/formatting-standards',
+    files: ['src/**/*.{ts,tsx,vue}'],
+    ignores: [
+      // The canonical implementation — the one place the primitives belong.
+      'src/utils/format/**',
+      // Specs may assert against natively formatted expectations.
+      '**/__tests__/**',
+      '**/*.spec.{ts,tsx}',
+      ...formattingLegacyFiles
+    ],
+    rules: {
+      // Two rules, one selector list: the core rule only walks `<script>`,
+      // `vue/no-restricted-syntax` covers `<template>` expressions — and a
+      // `{{ x.toFixed(2) }}` in a template is exactly the drift we're stopping.
+      'no-restricted-syntax': ['error', ...formattingSelectors],
+      'vue/no-restricted-syntax': ['error', ...formattingSelectors]
     }
   },
   skipFormatting

--- a/app/src/utils/format/__tests__/address.spec.ts
+++ b/app/src/utils/format/__tests__/address.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { formatAddress, formatTxHash } from '@/utils/format/address'
+
+const ADDRESS = '0x4b6f7A1d2C3e4F5a6B7c8D9e0F1a2B3c4D5e6F70'
+
+describe('formatAddress', () => {
+  it('keeps the leading 0x prefix and the trailing characters', () => {
+    expect(formatAddress(ADDRESS)).toBe('0x4b6f...6F70')
+  })
+
+  it('uses a single ellipsis form across the app', () => {
+    expect(formatAddress(ADDRESS)).toContain('...')
+    expect(formatAddress(ADDRESS)).not.toContain('…')
+  })
+
+  it('leaves values short enough to read whole untouched', () => {
+    expect(formatAddress('0x123456')).toBe('0x123456')
+    expect(formatAddress('0x12345678')).toBe('0x12345678')
+  })
+
+  it('honours a custom truncation window', () => {
+    expect(formatAddress(ADDRESS, { lead: 10, tail: 6 })).toBe('0x4b6f7A1d...5e6F70')
+  })
+
+  it('returns an empty string for a missing value', () => {
+    expect(formatAddress(undefined)).toBe('')
+    expect(formatAddress(null)).toBe('')
+    expect(formatAddress('')).toBe('')
+  })
+})
+
+describe('formatTxHash', () => {
+  it('truncates the same way as an address', () => {
+    const hash = `${ADDRESS}0000000000000000000000ab`
+    expect(formatTxHash(hash)).toBe('0x4b6f...00ab')
+  })
+})

--- a/app/src/utils/format/__tests__/date.spec.ts
+++ b/app/src/utils/format/__tests__/date.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  formatDate,
+  formatDateIso,
+  formatDateRelative,
+  formatDateShort,
+  formatDateTime,
+  formatDateUtc,
+  formatDuration,
+  formatMonthYear,
+  fromUnix
+} from '@/utils/format/date'
+import { EMPTY_VALUE } from '@/utils/format/shared'
+
+// 2026-01-08T14:05:32Z
+const UNIX_SECONDS = 1_767_881_132
+const ISO = '2026-01-08T14:05:32.000Z'
+
+describe('fromUnix', () => {
+  it('reads on-chain seconds, not milliseconds', () => {
+    expect(fromUnix(UNIX_SECONDS).toISOString()).toBe(ISO)
+    expect(fromUnix(BigInt(UNIX_SECONDS)).toISOString()).toBe(ISO)
+  })
+})
+
+describe('date styles', () => {
+  it('renders each named style', () => {
+    expect(formatDate(ISO)).toBe('Jan 8, 2026')
+    expect(formatDateShort(ISO)).toBe('Jan 8')
+    expect(formatMonthYear(ISO)).toBe('January 2026')
+    expect(formatDateIso(ISO)).toBe('2026-01-08')
+    expect(formatDateUtc(ISO)).toBe('2026-01-08 14:05 UTC')
+  })
+
+  it('keeps the time of day so same-day rows stay ordered', () => {
+    expect(formatDateTime(new Date(ISO).getTime())).toContain('Jan 8, 2026')
+  })
+
+  it('accepts a Date, a millisecond number and a Dayjs alike', () => {
+    expect(formatDate(new Date(ISO))).toBe('Jan 8, 2026')
+    expect(formatDate(new Date(ISO).getTime())).toBe('Jan 8, 2026')
+    expect(formatDate(fromUnix(UNIX_SECONDS))).toBe('Jan 8, 2026')
+  })
+
+  it('renders the empty placeholder for values it cannot display', () => {
+    expect(formatDate(null)).toBe(EMPTY_VALUE)
+    expect(formatDate(undefined)).toBe(EMPTY_VALUE)
+    expect(formatDate('')).toBe(EMPTY_VALUE)
+    expect(formatDate('not a date')).toBe(EMPTY_VALUE)
+    expect(formatDateUtc('not a date')).toBe(EMPTY_VALUE)
+  })
+})
+
+describe('formatDateRelative', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const at = (offsetMs: number) => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(ISO))
+    return new Date(new Date(ISO).getTime() - offsetMs).toISOString()
+  }
+
+  it('describes recent instants relatively', () => {
+    expect(formatDateRelative(at(5_000))).toBe('just now')
+    expect(formatDateRelative(at(3 * 60_000))).toBe('3 min ago')
+    expect(formatDateRelative(at(5 * 3_600_000))).toBe('5 h ago')
+    expect(formatDateRelative(at(2 * 86_400_000))).toBe('2 d ago')
+  })
+
+  it('falls back to an absolute date past a week', () => {
+    expect(formatDateRelative(at(10 * 86_400_000))).toBe('Dec 29, 2025')
+  })
+
+  it('falls back to an absolute date for the future', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(ISO))
+    expect(formatDateRelative('2026-03-01T00:00:00.000Z')).toBe('Mar 1, 2026')
+  })
+})
+
+describe('formatDuration', () => {
+  it('renders elapsed time, never a clock time', () => {
+    expect(formatDuration(90)).toBe('1 h 30 min')
+    expect(formatDuration(45)).toBe('45 min')
+    expect(formatDuration(0)).toBe('0 min')
+    expect(formatDuration(60 * 24 * 3 + 4 * 60)).toBe('3 d 4 h')
+  })
+
+  it('keeps the sign of a negative span', () => {
+    expect(formatDuration(-90)).toBe('-1 h 30 min')
+  })
+
+  it('renders the empty placeholder for values it cannot display', () => {
+    expect(formatDuration(null)).toBe(EMPTY_VALUE)
+    expect(formatDuration(NaN)).toBe(EMPTY_VALUE)
+  })
+})

--- a/app/src/utils/format/__tests__/number.spec.ts
+++ b/app/src/utils/format/__tests__/number.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatCompact,
+  formatNumber,
+  formatPercent,
+  formatToken,
+  formatUsd
+} from '@/utils/format/number'
+import { EMPTY_VALUE } from '@/utils/format/shared'
+
+describe('formatNumber', () => {
+  it('adds thousands separators and trims trailing zeros', () => {
+    expect(formatNumber(1234.5)).toBe('1,234.5')
+    expect(formatNumber(1_000_000)).toBe('1,000,000')
+  })
+
+  it('keeps fractional amounts instead of rounding them to zero', () => {
+    expect(formatNumber(0.2)).toBe('0.2')
+    expect(formatNumber(0.0001)).toBe('0.0001')
+  })
+
+  it('parses decimal strings coming out of formatUnits', () => {
+    expect(formatNumber('1234.5')).toBe('1,234.5')
+  })
+
+  it('pads to minDecimals and rounds past maxDecimals', () => {
+    expect(formatNumber(5, { minDecimals: 2 })).toBe('5.00')
+    expect(formatNumber(1.23456, { maxDecimals: 2 })).toBe('1.23')
+  })
+
+  it('renders the empty placeholder for values it cannot display', () => {
+    expect(formatNumber(null)).toBe(EMPTY_VALUE)
+    expect(formatNumber(undefined)).toBe(EMPTY_VALUE)
+    expect(formatNumber(NaN)).toBe(EMPTY_VALUE)
+    expect(formatNumber(Infinity)).toBe(EMPTY_VALUE)
+    expect(formatNumber('not a number')).toBe(EMPTY_VALUE)
+  })
+})
+
+describe('formatUsd', () => {
+  it('renders fixed cents', () => {
+    expect(formatUsd(1234.5)).toBe('$1,234.50')
+    expect(formatUsd(5)).toBe('$5.00')
+  })
+
+  it('puts the sign before the symbol', () => {
+    expect(formatUsd(-12.3)).toBe('-$12.30')
+  })
+
+  it('collapses a sub-cent residue onto a clean zero', () => {
+    expect(formatUsd(-0.004)).toBe('$0.00')
+    expect(formatUsd(-0)).toBe('$0.00')
+  })
+
+  it('supports a finer precision for unit prices', () => {
+    expect(formatUsd(0.123456, { decimals: 6 })).toBe('$0.123456')
+  })
+
+  it('renders the empty placeholder for values it cannot display', () => {
+    expect(formatUsd(NaN)).toBe(EMPTY_VALUE)
+    expect(formatUsd(null)).toBe(EMPTY_VALUE)
+  })
+})
+
+describe('formatToken', () => {
+  it('suffixes the symbol and keeps variable precision', () => {
+    expect(formatToken(1234.5, 'USDC')).toBe('1,234.5 USDC')
+    expect(formatToken(0, 'SHER')).toBe('0 SHER')
+  })
+
+  it('does not append a symbol to a value it cannot display', () => {
+    expect(formatToken(null, 'USDC')).toBe(EMPTY_VALUE)
+  })
+})
+
+describe('formatCompact', () => {
+  it('shortens large magnitudes', () => {
+    expect(formatCompact(1_500)).toBe('$1.5K')
+    expect(formatCompact(1_234_567)).toBe('$1.23M')
+    expect(formatCompact(-2_000_000_000)).toBe('-$2B')
+  })
+
+  it('honours the requested currency', () => {
+    expect(formatCompact(1_000, { currency: 'EUR' })).toBe('€1K')
+  })
+})
+
+describe('formatPercent', () => {
+  it('takes a ratio, not percentage points', () => {
+    expect(formatPercent(0.125)).toBe('12.50%')
+    expect(formatPercent(1)).toBe('100.00%')
+  })
+
+  it('honours the decimals option', () => {
+    expect(formatPercent(0.125, { decimals: 1 })).toBe('12.5%')
+    expect(formatPercent(0.125, { decimals: 0 })).toBe('13%')
+  })
+
+  it('marks the direction of a delta when asked', () => {
+    expect(formatPercent(0.05, { decimals: 1, signed: true })).toBe('+5.0%')
+    expect(formatPercent(-0.05, { decimals: 1, signed: true })).toBe('-5.0%')
+    expect(formatPercent(0, { decimals: 1, signed: true })).toBe('0.0%')
+  })
+
+  it('renders the empty placeholder for values it cannot display', () => {
+    expect(formatPercent(NaN)).toBe(EMPTY_VALUE)
+  })
+})

--- a/app/src/utils/format/address.ts
+++ b/app/src/utils/format/address.ts
@@ -1,0 +1,43 @@
+/**
+ * Canonical truncation for the long hex strings the UI can't show in full.
+ *
+ * The repo grew five near-identical versions of this, two of which used a `…`
+ * character while the rest used `...` — enough of a difference that the same
+ * address looked like two different values across two tables. One helper, one
+ * ellipsis. See `.github/copilot-instructions/formatting-standards.md`.
+ */
+
+/** The single ellipsis form used for every truncated hex value in the app. */
+const ELLIPSIS = '...'
+
+export interface TruncateOptions {
+  /** Characters kept at the start, `0x` included. Default `6`. */
+  lead?: number
+  /** Characters kept at the end. Default `4`. */
+  tail?: number
+}
+
+/**
+ * `0x1234567890abcdef…` → `0x1234...cdef`.
+ *
+ * Values already short enough to read whole are returned untouched — truncating
+ * them would add an ellipsis without saving a single character.
+ *
+ * Display only: never feed the result back to a contract call or a comparison.
+ */
+export function formatAddress(
+  address: string | null | undefined,
+  { lead = 6, tail = 4 }: TruncateOptions = {}
+): string {
+  if (!address) return ''
+  if (address.length <= lead + tail) return address
+  return address.slice(0, lead) + ELLIPSIS + address.slice(-tail)
+}
+
+/**
+ * Same shape as {@link formatAddress}, named for the intent so a table column of
+ * transaction hashes doesn't read as a column of addresses.
+ */
+export function formatTxHash(hash: string | null | undefined): string {
+  return formatAddress(hash)
+}

--- a/app/src/utils/format/date.ts
+++ b/app/src/utils/format/date.ts
@@ -1,0 +1,133 @@
+/**
+ * Canonical date formatting.
+ *
+ * `dayjs` is the single date library in the monorepo, and this module is the
+ * only place in `app/` allowed to call `.format()` for display — every other
+ * file asks for a *named* style instead of re-inventing a pattern string.
+ * ESLint enforces the ban on `toLocaleString` / `Intl.DateTimeFormat`. See
+ * `.github/copilot-instructions/formatting-standards.md`.
+ */
+
+import dayjs, { type Dayjs } from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+
+import { EMPTY_VALUE } from './shared'
+
+dayjs.extend(utc)
+
+/**
+ * Anything a date formatter accepts.
+ *
+ * A bare `number` is **milliseconds** (the JavaScript convention). On-chain
+ * timestamps are seconds — run them through {@link fromUnix} rather than
+ * sprinkling `* 1000` at call sites, which is where the off-by-1000 bugs that
+ * render `Jan 1, 1970` come from.
+ */
+export type DateInput = Date | string | number | Dayjs
+
+function toDayjs(value: DateInput | null | undefined): Dayjs | null {
+  if (value === null || value === undefined || value === '') return null
+  const parsed = dayjs(value)
+  return parsed.isValid() ? parsed : null
+}
+
+/** Unix **seconds** (block timestamps, contract structs) → a `Dayjs` the formatters accept. */
+export function fromUnix(seconds: number | string | bigint): Dayjs {
+  return dayjs(Number(seconds) * 1000)
+}
+
+/** `Jan 8, 2026` — the default for any date shown on its own. */
+export function formatDate(value: DateInput | null | undefined): string {
+  return toDayjs(value)?.format('MMM D, YYYY') ?? EMPTY_VALUE
+}
+
+/**
+ * `Jan 8, 2026, 14:05:32` — a date **with time of day**.
+ *
+ * Use it wherever rows are ordered chronologically: two ledger entries from the
+ * same day must stay distinguishable, or the table reads as arbitrarily sorted.
+ */
+export function formatDateTime(value: DateInput | null | undefined): string {
+  return toDayjs(value)?.format('MMM D, YYYY, HH:mm:ss') ?? EMPTY_VALUE
+}
+
+/** `Jan 8` — for chart axes and dense tables where the year is already established. */
+export function formatDateShort(value: DateInput | null | undefined): string {
+  return toDayjs(value)?.format('MMM D') ?? EMPTY_VALUE
+}
+
+/** `January 2026` — period headers. */
+export function formatMonthYear(value: DateInput | null | undefined): string {
+  return toDayjs(value)?.format('MMMM YYYY') ?? EMPTY_VALUE
+}
+
+/**
+ * `2026-01-08` — sortable, locale-free.
+ *
+ * For export filenames, CSV columns and API payloads, never for UI copy: a
+ * human reading a screen wants `Jan 8, 2026`.
+ */
+export function formatDateIso(value: DateInput | null | undefined): string {
+  return toDayjs(value)?.format('YYYY-MM-DD') ?? EMPTY_VALUE
+}
+
+/**
+ * `2026-01-08 14:05 UTC` — an unambiguous instant.
+ *
+ * Use it for anything a user may have to line up against a block explorer or a
+ * contract deadline, where "which timezone?" is a costly question.
+ */
+export function formatDateUtc(value: DateInput | null | undefined): string {
+  return toDayjs(value)?.utc().format('YYYY-MM-DD HH:mm [UTC]') ?? EMPTY_VALUE
+}
+
+/**
+ * `just now`, `3 min ago`, `5 h ago`, `2 d ago`, then falls back to
+ * {@link formatDate} past a week — beyond which "37 d ago" stops being easier
+ * to read than the date itself.
+ *
+ * Relative labels are for freshness cues (last sync, latest activity). A value
+ * the user has to act on gets an absolute date.
+ */
+export function formatDateRelative(value: DateInput | null | undefined): string {
+  const date = toDayjs(value)
+  if (!date) return EMPTY_VALUE
+
+  const seconds = Math.floor((Date.now() - date.valueOf()) / 1000)
+  if (seconds < 0) return formatDate(date)
+
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+  const days = Math.floor(hours / 24)
+
+  if (seconds < 60) return 'just now'
+  if (minutes < 60) return `${minutes} min ago`
+  if (hours < 24) return `${hours} h ago`
+  if (days < 7) return `${days} d ago`
+  return formatDate(date)
+}
+
+/**
+ * `2 h 30 min`, `45 min`, `3 d 4 h` — an elapsed **duration**, from minutes.
+ *
+ * Durations are not clock times: `90` minutes is `1 h 30 min`, never `01:30`,
+ * which reads as half past one in the morning.
+ */
+export function formatDuration(totalMinutes: number | null | undefined): string {
+  if (totalMinutes === null || totalMinutes === undefined || !Number.isFinite(totalMinutes)) {
+    return EMPTY_VALUE
+  }
+
+  const sign = totalMinutes < 0 ? '-' : ''
+  const absolute = Math.round(Math.abs(totalMinutes))
+  const days = Math.floor(absolute / (60 * 24))
+  const hours = Math.floor((absolute % (60 * 24)) / 60)
+  const minutes = absolute % 60
+
+  const parts: string[] = []
+  if (days) parts.push(`${days} d`)
+  if (hours) parts.push(`${hours} h`)
+  if (minutes || parts.length === 0) parts.push(`${minutes} min`)
+
+  return sign + parts.join(' ')
+}

--- a/app/src/utils/format/index.ts
+++ b/app/src/utils/format/index.ts
@@ -1,0 +1,45 @@
+/**
+ * The canonical display formatters for `app/`.
+ *
+ * ```ts
+ * import { formatUsd, formatDate, formatAddress } from '@/utils/format'
+ * ```
+ *
+ * Import from this barrel, not from the sub-modules — the split is an
+ * implementation detail. Deliberately **not** re-exported through
+ * `@/utils` (`utils/index.ts`): the explicit path is what makes a stray
+ * hand-rolled formatter obvious in review and greppable in the codebase.
+ *
+ * Rules, rationale and the migration ratchet:
+ * `.github/copilot-instructions/formatting-standards.md`.
+ */
+
+export { EMPTY_VALUE, FORMAT_LOCALE } from './shared'
+
+export {
+  formatCompact,
+  formatNumber,
+  formatPercent,
+  formatToken,
+  formatUsd,
+  type CompactOptions,
+  type DecimalOptions,
+  type NumericInput,
+  type PercentOptions,
+  type UsdOptions
+} from './number'
+
+export {
+  formatDate,
+  formatDateIso,
+  formatDateRelative,
+  formatDateShort,
+  formatDateTime,
+  formatDateUtc,
+  formatDuration,
+  formatMonthYear,
+  fromUnix,
+  type DateInput
+} from './date'
+
+export { formatAddress, formatTxHash, type TruncateOptions } from './address'

--- a/app/src/utils/format/number.ts
+++ b/app/src/utils/format/number.ts
@@ -1,0 +1,137 @@
+/**
+ * Canonical number, money and token-amount formatting.
+ *
+ * This module is the **only** place in `app/` allowed to call
+ * `Intl.NumberFormat` / `toLocaleString` / `toFixed` for display — ESLint
+ * enforces it. See `.github/copilot-instructions/formatting-standards.md`.
+ */
+
+import { collapseSignedZero, EMPTY_VALUE, FORMAT_LOCALE, toFiniteNumber } from './shared'
+
+/** Value accepted by every amount formatter — on-chain amounts arrive as decimal strings. */
+export type NumericInput = number | string | null | undefined
+
+export interface DecimalOptions {
+  /** Trailing zeros are padded up to this many decimals. Default `0`. */
+  minDecimals?: number
+  /** Digits past this are rounded away. Default `4`. */
+  maxDecimals?: number
+}
+
+/**
+ * `1234.5` → `1,234.5`. Thousands separators, trailing zeros trimmed.
+ *
+ * The `maxDecimals` default is **4**, not 0: a default of 0 is what let a
+ * Community Credit position of `0.2 USDC` render as `0` in production
+ * ([#2376](https://github.com/globe-and-citizen/cnc-portal/pull/2376)). Round
+ * down deliberately, never by omission.
+ */
+export function formatNumber(
+  value: NumericInput,
+  { minDecimals = 0, maxDecimals = 4 }: DecimalOptions = {}
+): string {
+  const amount = toFiniteNumber(value)
+  if (amount === null) return EMPTY_VALUE
+
+  return new Intl.NumberFormat(FORMAT_LOCALE, {
+    minimumFractionDigits: minDecimals,
+    maximumFractionDigits: maxDecimals
+  }).format(collapseSignedZero(amount, maxDecimals))
+}
+
+export interface UsdOptions {
+  /** Fixed number of decimals — both the minimum and the maximum. Default `2`. */
+  decimals?: number
+}
+
+/**
+ * `1234.5` → `$1,234.50`, `-12.3` → `-$12.30`.
+ *
+ * Fixed decimals (a price column where `$5` and `$5.20` don't align is a
+ * misread waiting to happen), and a sub-unit residue that rounds to zero
+ * renders `$0.00` rather than the alarming `-$0.00`.
+ *
+ * Pass `decimals: 6` for unit prices, where cents are too coarse to be useful.
+ */
+export function formatUsd(value: NumericInput, { decimals = 2 }: UsdOptions = {}): string {
+  const amount = toFiniteNumber(value)
+  if (amount === null) return EMPTY_VALUE
+
+  return new Intl.NumberFormat(FORMAT_LOCALE, {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals
+  }).format(collapseSignedZero(amount, decimals))
+}
+
+/**
+ * `1234.5, 'USDC'` → `1,234.5 USDC`.
+ *
+ * Token amounts are *not* money: they keep variable precision (trailing zeros
+ * trimmed) because `0.0001 SHER` and `0.00 SHER` are different claims, and the
+ * symbol is a suffix rather than a currency prefix.
+ */
+export function formatToken(
+  value: NumericInput,
+  symbol: string,
+  { maxDecimals = 4 }: Pick<DecimalOptions, 'maxDecimals'> = {}
+): string {
+  const formatted = formatNumber(value, { maxDecimals })
+  return formatted === EMPTY_VALUE ? EMPTY_VALUE : `${formatted} ${symbol}`
+}
+
+export interface CompactOptions {
+  /** ISO 4217 code driving the symbol. Default `'USD'`. */
+  currency?: string
+}
+
+/**
+ * `1_234_567` → `$1.2M`. For dashboard tiles and chart axes, where the exact
+ * figure is noise and the order of magnitude is the message.
+ *
+ * Never use it on a number the user has to reconcile against another system —
+ * `$1.2M` is not a balance, it's a headline.
+ */
+export function formatCompact(value: NumericInput, { currency = 'USD' }: CompactOptions = {}) {
+  const amount = toFiniteNumber(value)
+  if (amount === null) return EMPTY_VALUE
+
+  return new Intl.NumberFormat(FORMAT_LOCALE, {
+    style: 'currency',
+    currency,
+    notation: 'compact',
+    maximumFractionDigits: 2
+  }).format(amount)
+}
+
+export interface PercentOptions {
+  /** Decimals kept on the percentage. Default `2`. */
+  decimals?: number
+  /** Prefix positive values with `+` — for deltas, where direction is the point. */
+  signed?: boolean
+}
+
+/**
+ * Takes a **ratio, not percentage points**: `0.125` → `12.5%`.
+ *
+ * That convention is the whole reason this helper exists — every call site that
+ * hand-rolled `(a / b * 100).toFixed(1) + '%'` had to remember the `* 100`, and
+ * the ones that forgot shipped a `0.12%` that should have read `12%`.
+ */
+export function formatPercent(
+  value: NumericInput,
+  { decimals = 2, signed = false }: PercentOptions = {}
+): string {
+  const ratio = toFiniteNumber(value)
+  if (ratio === null) return EMPTY_VALUE
+
+  const safe = collapseSignedZero(ratio, decimals + 2)
+  const formatted = new Intl.NumberFormat(FORMAT_LOCALE, {
+    style: 'percent',
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals
+  }).format(safe)
+
+  return signed && safe > 0 ? `+${formatted}` : formatted
+}

--- a/app/src/utils/format/shared.ts
+++ b/app/src/utils/format/shared.ts
@@ -1,0 +1,53 @@
+/**
+ * Primitives shared by the canonical formatters.
+ *
+ * Nothing here is meant to be imported outside `@/utils/format` — the public
+ * surface is the barrel (`format/index.ts`). See
+ * `.github/copilot-instructions/formatting-standards.md`.
+ */
+
+/**
+ * The single locale every formatted value in the app renders in.
+ *
+ * Deliberately **not** `undefined` (which would follow the browser): a
+ * `1,234.50` that becomes `1.234,50` for a French visitor makes screenshots,
+ * exports and support threads unreadable, and the UI copy around it is
+ * English-only anyway.
+ */
+export const FORMAT_LOCALE = 'en-US'
+
+/**
+ * What a formatter renders when it has nothing to render — a missing value, or
+ * one that isn't a finite number / valid date.
+ *
+ * An em dash, never `'0'` or `'$0.00'`: a zero is a claim about the data, and
+ * silently claiming "zero" for "unknown" is how a loading balance reads as an
+ * empty wallet.
+ */
+export const EMPTY_VALUE = '—'
+
+/**
+ * Coerce to a finite number, or `null` when the value can't be displayed.
+ *
+ * Strings are accepted because on-chain amounts reach the UI as decimal
+ * strings out of `formatUnits` — parsing them here keeps the `Number(...)`
+ * dance out of every call site.
+ */
+export function toFiniteNumber(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined || value === '') return null
+  const parsed = typeof value === 'string' ? Number(value) : value
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+/**
+ * Collapse a value that rounds to zero at `decimals` precision onto a clean
+ * positive zero.
+ *
+ * Without this, `-0.004` at 2 decimals renders as `-$0.00` and JavaScript's
+ * negative zero renders as `-0` — both read as "we lost a fraction of a cent"
+ * when the honest answer is `$0.00`.
+ */
+export function collapseSignedZero(value: number, decimals: number): number {
+  const factor = 10 ** decimals
+  return Math.round(value * factor) === 0 ? 0 : value
+}

--- a/app/src/utils/formatAddress.ts
+++ b/app/src/utils/formatAddress.ts
@@ -1,8 +1,6 @@
-export function formatAddress(address?: string): string {
-  if (!address) return ''
-  // Keep short addresses intact
-  if (address.length <= 10) return address
-  return address.slice(0, 6) + '...' + address.slice(address.length - 4)
-}
-
-export default formatAddress
+/**
+ * @deprecated Import `formatAddress` from `@/utils/format` instead. This module
+ * is a compatibility shim kept while the existing call sites migrate — it adds
+ * nothing on top of the canonical helper.
+ */
+export { formatAddress, formatAddress as default } from './format/address'

--- a/app/src/utils/generalUtil.ts
+++ b/app/src/utils/generalUtil.ts
@@ -1,3 +1,5 @@
+import { formatAddress } from './format/address'
+
 const isDevelopment = import.meta.env.MODE === 'development'
 // const isVerbose = true
 
@@ -30,7 +32,8 @@ export const log = {
   }
 }
 
-export const shortenAddress = (address: string | undefined) => {
-  if (!address) return ''
-  return address.slice(0, 6) + '...' + address.slice(-4)
-}
+/**
+ * @deprecated Import `formatAddress` from `@/utils/format` instead — this is
+ * the same helper under an older name, kept while call sites migrate.
+ */
+export const shortenAddress = (address: string | undefined) => formatAddress(address)

--- a/dashboard/app/utils/accounting.ts
+++ b/dashboard/app/utils/accounting.ts
@@ -1,3 +1,4 @@
+import { formatUsd as canonicalFormatUsd } from '~/utils/format'
 import type { PolygonTokenTransfer } from '~/api/polygonscan'
 import type { PolymarketActivity, PolymarketPosition } from '~/types/polymarket'
 import type { RealizedTrade } from '~/utils/incomeStatement'
@@ -514,20 +515,23 @@ export const CATEGORY_META: Record<LedgerCategory, { label: string, color: Ledge
   OTHER: { label: 'Other', color: 'neutral' }
 }
 
-/** Formats a USD amount, e.g. 1234.5 → "$1,234.50". */
+/**
+ * Formats a USD amount, e.g. 1234.5 → "$1,234.50".
+ *
+ * @deprecated Import `formatUsd` from `~/utils/format` instead — this wrapper
+ * exists so the auto-imported name keeps working while call sites migrate.
+ */
 export function formatUsd(value: number | undefined): string {
-  if (value == null || Number.isNaN(value)) {
-    return '—'
-  }
-  return `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+  return canonicalFormatUsd(value)
 }
 
-/** Formats a USD amount with full USDC precision (6 decimals). */
+/**
+ * Formats a USD amount with full USDC precision (6 decimals).
+ *
+ * @deprecated Call `formatUsd(value, { decimals: 6 })` from `~/utils/format`.
+ */
 export function formatUsd6(value: number | undefined): string {
-  if (value == null || Number.isNaN(value)) {
-    return '—'
-  }
-  return `$${value.toLocaleString(undefined, { minimumFractionDigits: 6, maximumFractionDigits: 6 })}`
+  return canonicalFormatUsd(value, { decimals: 6 })
 }
 
 /** Formats a signed USD amount, e.g. -12 → "−$12.00". */

--- a/dashboard/app/utils/format/address.ts
+++ b/dashboard/app/utils/format/address.ts
@@ -1,0 +1,43 @@
+/**
+ * Canonical truncation for the long hex strings the UI can't show in full.
+ *
+ * The repo grew five near-identical versions of this, two of which used a `…`
+ * character while the rest used `...` — enough of a difference that the same
+ * address looked like two different values across two tables. One helper, one
+ * ellipsis. See `.github/copilot-instructions/formatting-standards.md`.
+ */
+
+/** The single ellipsis form used for every truncated hex value in the app. */
+const ELLIPSIS = '...'
+
+export interface TruncateOptions {
+  /** Characters kept at the start, `0x` included. Default `6`. */
+  lead?: number
+  /** Characters kept at the end. Default `4`. */
+  tail?: number
+}
+
+/**
+ * `0x1234567890abcdef…` → `0x1234...cdef`.
+ *
+ * Values already short enough to read whole are returned untouched — truncating
+ * them would add an ellipsis without saving a single character.
+ *
+ * Display only: never feed the result back to a contract call or a comparison.
+ */
+export function formatAddress(
+  address: string | null | undefined,
+  { lead = 6, tail = 4 }: TruncateOptions = {}
+): string {
+  if (!address) return ''
+  if (address.length <= lead + tail) return address
+  return address.slice(0, lead) + ELLIPSIS + address.slice(-tail)
+}
+
+/**
+ * Same shape as {@link formatAddress}, named for the intent so a table column of
+ * transaction hashes doesn't read as a column of addresses.
+ */
+export function formatTxHash(hash: string | null | undefined): string {
+  return formatAddress(hash)
+}

--- a/dashboard/app/utils/format/date.ts
+++ b/dashboard/app/utils/format/date.ts
@@ -1,0 +1,133 @@
+/**
+ * Canonical date formatting.
+ *
+ * `dayjs` is the single date library in the monorepo, and this module is the
+ * only place in `dashboard/` allowed to call `.format()` for display — every other
+ * file asks for a *named* style instead of re-inventing a pattern string.
+ * ESLint enforces the ban on `toLocaleString` / `Intl.DateTimeFormat`. See
+ * `.github/copilot-instructions/formatting-standards.md`.
+ */
+
+import dayjs, { type Dayjs } from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+
+import { EMPTY_VALUE } from './shared'
+
+dayjs.extend(utc)
+
+/**
+ * Anything a date formatter accepts.
+ *
+ * A bare `number` is **milliseconds** (the JavaScript convention). On-chain
+ * timestamps are seconds — run them through {@link fromUnix} rather than
+ * sprinkling `* 1000` at call sites, which is where the off-by-1000 bugs that
+ * render `Jan 1, 1970` come from.
+ */
+export type DateInput = Date | string | number | Dayjs
+
+function toDayjs(value: DateInput | null | undefined): Dayjs | null {
+  if (value === null || value === undefined || value === '') return null
+  const parsed = dayjs(value)
+  return parsed.isValid() ? parsed : null
+}
+
+/** Unix **seconds** (block timestamps, contract structs) → a `Dayjs` the formatters accept. */
+export function fromUnix(seconds: number | string | bigint): Dayjs {
+  return dayjs(Number(seconds) * 1000)
+}
+
+/** `Jan 8, 2026` — the default for any date shown on its own. */
+export function formatDate(value: DateInput | null | undefined): string {
+  return toDayjs(value)?.format('MMM D, YYYY') ?? EMPTY_VALUE
+}
+
+/**
+ * `Jan 8, 2026, 14:05:32` — a date **with time of day**.
+ *
+ * Use it wherever rows are ordered chronologically: two ledger entries from the
+ * same day must stay distinguishable, or the table reads as arbitrarily sorted.
+ */
+export function formatDateTime(value: DateInput | null | undefined): string {
+  return toDayjs(value)?.format('MMM D, YYYY, HH:mm:ss') ?? EMPTY_VALUE
+}
+
+/** `Jan 8` — for chart axes and dense tables where the year is already established. */
+export function formatDateShort(value: DateInput | null | undefined): string {
+  return toDayjs(value)?.format('MMM D') ?? EMPTY_VALUE
+}
+
+/** `January 2026` — period headers. */
+export function formatMonthYear(value: DateInput | null | undefined): string {
+  return toDayjs(value)?.format('MMMM YYYY') ?? EMPTY_VALUE
+}
+
+/**
+ * `2026-01-08` — sortable, locale-free.
+ *
+ * For export filenames, CSV columns and API payloads, never for UI copy: a
+ * human reading a screen wants `Jan 8, 2026`.
+ */
+export function formatDateIso(value: DateInput | null | undefined): string {
+  return toDayjs(value)?.format('YYYY-MM-DD') ?? EMPTY_VALUE
+}
+
+/**
+ * `2026-01-08 14:05 UTC` — an unambiguous instant.
+ *
+ * Use it for anything a user may have to line up against a block explorer or a
+ * contract deadline, where "which timezone?" is a costly question.
+ */
+export function formatDateUtc(value: DateInput | null | undefined): string {
+  return toDayjs(value)?.utc().format('YYYY-MM-DD HH:mm [UTC]') ?? EMPTY_VALUE
+}
+
+/**
+ * `just now`, `3 min ago`, `5 h ago`, `2 d ago`, then falls back to
+ * {@link formatDate} past a week — beyond which "37 d ago" stops being easier
+ * to read than the date itself.
+ *
+ * Relative labels are for freshness cues (last sync, latest activity). A value
+ * the user has to act on gets an absolute date.
+ */
+export function formatDateRelative(value: DateInput | null | undefined): string {
+  const date = toDayjs(value)
+  if (!date) return EMPTY_VALUE
+
+  const seconds = Math.floor((Date.now() - date.valueOf()) / 1000)
+  if (seconds < 0) return formatDate(date)
+
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+  const days = Math.floor(hours / 24)
+
+  if (seconds < 60) return 'just now'
+  if (minutes < 60) return `${minutes} min ago`
+  if (hours < 24) return `${hours} h ago`
+  if (days < 7) return `${days} d ago`
+  return formatDate(date)
+}
+
+/**
+ * `2 h 30 min`, `45 min`, `3 d 4 h` — an elapsed **duration**, from minutes.
+ *
+ * Durations are not clock times: `90` minutes is `1 h 30 min`, never `01:30`,
+ * which reads as half past one in the morning.
+ */
+export function formatDuration(totalMinutes: number | null | undefined): string {
+  if (totalMinutes === null || totalMinutes === undefined || !Number.isFinite(totalMinutes)) {
+    return EMPTY_VALUE
+  }
+
+  const sign = totalMinutes < 0 ? '-' : ''
+  const absolute = Math.round(Math.abs(totalMinutes))
+  const days = Math.floor(absolute / (60 * 24))
+  const hours = Math.floor((absolute % (60 * 24)) / 60)
+  const minutes = absolute % 60
+
+  const parts: string[] = []
+  if (days) parts.push(`${days} d`)
+  if (hours) parts.push(`${hours} h`)
+  if (minutes || parts.length === 0) parts.push(`${minutes} min`)
+
+  return sign + parts.join(' ')
+}

--- a/dashboard/app/utils/format/index.ts
+++ b/dashboard/app/utils/format/index.ts
@@ -1,0 +1,49 @@
+/**
+ * The canonical display formatters for `dashboard/`.
+ *
+ * Kept deliberately identical to `app/src/utils/format/` — the two SPAs render
+ * the same figures for the same teams, and a `$1,234.50` here that reads
+ * `1 234,50 $` there is how support tickets start. There is no shared package
+ * to hold it yet, so the duplication is the price; any change lands in both.
+ *
+ * ```ts
+ * import { formatUsd, formatDate } from '~/utils/format'
+ * ```
+ *
+ * Import from this barrel explicitly — Nuxt's auto-import only scans the top
+ * level of `utils/`, and the explicit path is what makes a stray hand-rolled
+ * formatter obvious in review and greppable in the codebase.
+ *
+ * Rules, rationale and the migration ratchet:
+ * `.github/copilot-instructions/formatting-standards.md`.
+ */
+
+export { EMPTY_VALUE, FORMAT_LOCALE } from './shared'
+
+export {
+  formatCompact,
+  formatNumber,
+  formatPercent,
+  formatToken,
+  formatUsd,
+  type CompactOptions,
+  type DecimalOptions,
+  type NumericInput,
+  type PercentOptions,
+  type UsdOptions
+} from './number'
+
+export {
+  formatDate,
+  formatDateIso,
+  formatDateRelative,
+  formatDateShort,
+  formatDateTime,
+  formatDateUtc,
+  formatDuration,
+  formatMonthYear,
+  fromUnix,
+  type DateInput
+} from './date'
+
+export { formatAddress, formatTxHash, type TruncateOptions } from './address'

--- a/dashboard/app/utils/format/number.ts
+++ b/dashboard/app/utils/format/number.ts
@@ -1,0 +1,137 @@
+/**
+ * Canonical number, money and token-amount formatting.
+ *
+ * This module is the **only** place in `dashboard/` allowed to call
+ * `Intl.NumberFormat` / `toLocaleString` / `toFixed` for display — ESLint
+ * enforces it. See `.github/copilot-instructions/formatting-standards.md`.
+ */
+
+import { collapseSignedZero, EMPTY_VALUE, FORMAT_LOCALE, toFiniteNumber } from './shared'
+
+/** Value accepted by every amount formatter — on-chain amounts arrive as decimal strings. */
+export type NumericInput = number | string | null | undefined
+
+export interface DecimalOptions {
+  /** Trailing zeros are padded up to this many decimals. Default `0`. */
+  minDecimals?: number
+  /** Digits past this are rounded away. Default `4`. */
+  maxDecimals?: number
+}
+
+/**
+ * `1234.5` → `1,234.5`. Thousands separators, trailing zeros trimmed.
+ *
+ * The `maxDecimals` default is **4**, not 0: a default of 0 is what let a
+ * Community Credit position of `0.2 USDC` render as `0` in production
+ * ([#2376](https://github.com/globe-and-citizen/cnc-portal/pull/2376)). Round
+ * down deliberately, never by omission.
+ */
+export function formatNumber(
+  value: NumericInput,
+  { minDecimals = 0, maxDecimals = 4 }: DecimalOptions = {}
+): string {
+  const amount = toFiniteNumber(value)
+  if (amount === null) return EMPTY_VALUE
+
+  return new Intl.NumberFormat(FORMAT_LOCALE, {
+    minimumFractionDigits: minDecimals,
+    maximumFractionDigits: maxDecimals
+  }).format(collapseSignedZero(amount, maxDecimals))
+}
+
+export interface UsdOptions {
+  /** Fixed number of decimals — both the minimum and the maximum. Default `2`. */
+  decimals?: number
+}
+
+/**
+ * `1234.5` → `$1,234.50`, `-12.3` → `-$12.30`.
+ *
+ * Fixed decimals (a price column where `$5` and `$5.20` don't align is a
+ * misread waiting to happen), and a sub-unit residue that rounds to zero
+ * renders `$0.00` rather than the alarming `-$0.00`.
+ *
+ * Pass `decimals: 6` for unit prices, where cents are too coarse to be useful.
+ */
+export function formatUsd(value: NumericInput, { decimals = 2 }: UsdOptions = {}): string {
+  const amount = toFiniteNumber(value)
+  if (amount === null) return EMPTY_VALUE
+
+  return new Intl.NumberFormat(FORMAT_LOCALE, {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals
+  }).format(collapseSignedZero(amount, decimals))
+}
+
+/**
+ * `1234.5, 'USDC'` → `1,234.5 USDC`.
+ *
+ * Token amounts are *not* money: they keep variable precision (trailing zeros
+ * trimmed) because `0.0001 SHER` and `0.00 SHER` are different claims, and the
+ * symbol is a suffix rather than a currency prefix.
+ */
+export function formatToken(
+  value: NumericInput,
+  symbol: string,
+  { maxDecimals = 4 }: Pick<DecimalOptions, 'maxDecimals'> = {}
+): string {
+  const formatted = formatNumber(value, { maxDecimals })
+  return formatted === EMPTY_VALUE ? EMPTY_VALUE : `${formatted} ${symbol}`
+}
+
+export interface CompactOptions {
+  /** ISO 4217 code driving the symbol. Default `'USD'`. */
+  currency?: string
+}
+
+/**
+ * `1_234_567` → `$1.2M`. For dashboard tiles and chart axes, where the exact
+ * figure is noise and the order of magnitude is the message.
+ *
+ * Never use it on a number the user has to reconcile against another system —
+ * `$1.2M` is not a balance, it's a headline.
+ */
+export function formatCompact(value: NumericInput, { currency = 'USD' }: CompactOptions = {}) {
+  const amount = toFiniteNumber(value)
+  if (amount === null) return EMPTY_VALUE
+
+  return new Intl.NumberFormat(FORMAT_LOCALE, {
+    style: 'currency',
+    currency,
+    notation: 'compact',
+    maximumFractionDigits: 2
+  }).format(amount)
+}
+
+export interface PercentOptions {
+  /** Decimals kept on the percentage. Default `2`. */
+  decimals?: number
+  /** Prefix positive values with `+` — for deltas, where direction is the point. */
+  signed?: boolean
+}
+
+/**
+ * Takes a **ratio, not percentage points**: `0.125` → `12.5%`.
+ *
+ * That convention is the whole reason this helper exists — every call site that
+ * hand-rolled `(a / b * 100).toFixed(1) + '%'` had to remember the `* 100`, and
+ * the ones that forgot shipped a `0.12%` that should have read `12%`.
+ */
+export function formatPercent(
+  value: NumericInput,
+  { decimals = 2, signed = false }: PercentOptions = {}
+): string {
+  const ratio = toFiniteNumber(value)
+  if (ratio === null) return EMPTY_VALUE
+
+  const safe = collapseSignedZero(ratio, decimals + 2)
+  const formatted = new Intl.NumberFormat(FORMAT_LOCALE, {
+    style: 'percent',
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals
+  }).format(safe)
+
+  return signed && safe > 0 ? `+${formatted}` : formatted
+}

--- a/dashboard/app/utils/format/shared.ts
+++ b/dashboard/app/utils/format/shared.ts
@@ -1,0 +1,53 @@
+/**
+ * Primitives shared by the canonical formatters.
+ *
+ * Nothing here is meant to be imported outside the `format/` barrel — the public
+ * surface is the barrel (`format/index.ts`). See
+ * `.github/copilot-instructions/formatting-standards.md`.
+ */
+
+/**
+ * The single locale every formatted value in the app renders in.
+ *
+ * Deliberately **not** `undefined` (which would follow the browser): a
+ * `1,234.50` that becomes `1.234,50` for a French visitor makes screenshots,
+ * exports and support threads unreadable, and the UI copy around it is
+ * English-only anyway.
+ */
+export const FORMAT_LOCALE = 'en-US'
+
+/**
+ * What a formatter renders when it has nothing to render — a missing value, or
+ * one that isn't a finite number / valid date.
+ *
+ * An em dash, never `'0'` or `'$0.00'`: a zero is a claim about the data, and
+ * silently claiming "zero" for "unknown" is how a loading balance reads as an
+ * empty wallet.
+ */
+export const EMPTY_VALUE = '—'
+
+/**
+ * Coerce to a finite number, or `null` when the value can't be displayed.
+ *
+ * Strings are accepted because on-chain amounts reach the UI as decimal
+ * strings out of `formatUnits` — parsing them here keeps the `Number(...)`
+ * dance out of every call site.
+ */
+export function toFiniteNumber(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined || value === '') return null
+  const parsed = typeof value === 'string' ? Number(value) : value
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+/**
+ * Collapse a value that rounds to zero at `decimals` precision onto a clean
+ * positive zero.
+ *
+ * Without this, `-0.004` at 2 decimals renders as `-$0.00` and JavaScript's
+ * negative zero renders as `-0` — both read as "we lost a fraction of a cent"
+ * when the honest answer is `$0.00`.
+ */
+export function collapseSignedZero(value: number, decimals: number): number {
+  const factor = 10 ** decimals
+  return Math.round(value * factor) === 0 ? 0 : value
+}

--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -1,9 +1,100 @@
 // @ts-check
 import withNuxt from './.nuxt/eslint.config.mjs'
 
-export default withNuxt({
-  rules: {
-    'vue/no-multiple-template-root': 'off',
-    'vue/max-attributes-per-line': ['error', { singleline: 3 }]
+// Formatting standardization (issue #2383).
+//
+// `app/utils/format/` is the single canonical implementation of every display
+// formatter, kept identical to `app/src/utils/format/` in the SPA — the two
+// front-ends render the same figures for the same teams, so they must render
+// them the same way.
+//
+// The primitives below are banned outside that module because each one grew a
+// different convention in every file that reached for it. Rules and rationale:
+// `.github/copilot-instructions/formatting-standards.md`.
+
+const formattingMessage
+  = 'Use the canonical formatters from `app/utils/format` (formatUsd, formatToken, formatNumber, formatPercent, formatDate, formatDateTime, formatAddress, …) instead of formatting by hand. See .github/copilot-instructions/formatting-standards.md and issue #2383.'
+
+const formattingSelectors = [
+  {
+    selector: 'NewExpression[callee.object.name="Intl"]',
+    message: formattingMessage
+  },
+  {
+    selector: 'CallExpression[callee.property.name=/^toLocale(String|DateString|TimeString)$/]',
+    message: formattingMessage
+  },
+  {
+    selector: 'CallExpression[callee.property.name="toFixed"]',
+    message: `${formattingMessage} For on-chain amounts, pass the unrounded value straight to \`parseUnits\` — never \`parseUnits(x.toFixed(d), d)\`.`
+  },
+  // `.format('MMM D, YYYY')` — a literal pattern string is the dayjs shape.
+  // `formatter.format(value)` passes a value, not a literal, and stays allowed.
+  {
+    selector: 'CallExpression[callee.property.name="format"][arguments.0.type="Literal"]',
+    message: formattingMessage
   }
-})
+]
+
+// Migration debt — every file that still formats by hand. This list only ever
+// shrinks. If you're about to add an entry, extend `app/utils/format/` instead:
+// the ceiling below fails lint at config load if the list grows.
+const formattingLegacyFiles = [
+  'app/components/accounting/AccountingIdentitiesCard.vue',
+  'app/components/accounting/AccountingIncomeStatement.vue',
+  'app/components/accounting/AccountingLedger.vue',
+  'app/components/accounting/AccountingPositions.vue',
+  'app/components/contracts/ContractHistoryCard.vue',
+  'app/components/features/TeamOverridesSection.vue',
+  'app/components/sections/FeeCollectorView/FeeConfigList.vue',
+  'app/components/stats/StatsActivitySection.vue',
+  'app/components/stats/StatsOverviewSection.vue',
+  'app/components/teams/ContractBalance.vue',
+  'app/components/teams/ProjectTvlCard.vue',
+  'app/components/teams/TeamOfficersCell.vue',
+  'app/components/teams/TeamsList.vue',
+  'app/composables/useTeamsBalanceRecaps.ts',
+  'app/pages/contracts/history.vue',
+  'app/pages/features/index.vue',
+  // Escaped: an unescaped `[id]` would read as a glob character class.
+  'app/pages/teams/\\[id\\].vue',
+  'app/queries/contractTokenBalances.query.ts',
+  'app/utils/currency.ts',
+  'app/utils/datePicker.ts',
+  'app/utils/generalUtil.ts',
+  'app/utils/mergedLedger.ts'
+]
+
+const FORMATTING_LEGACY_MAX = 22
+if (formattingLegacyFiles.length > FORMATTING_LEGACY_MAX) {
+  throw new Error(
+    `formattingLegacyFiles has ${formattingLegacyFiles.length} entries (ceiling ${FORMATTING_LEGACY_MAX}). `
+    + 'Format through `app/utils/format` instead of whitelisting a new file — see '
+    + '.github/copilot-instructions/formatting-standards.md.'
+  )
+}
+
+export default withNuxt(
+  {
+    rules: {
+      'vue/no-multiple-template-root': 'off',
+      'vue/max-attributes-per-line': ['error', { singleline: 3 }]
+    }
+  },
+  {
+    name: 'dashboard/formatting-standards',
+    files: ['app/**/*.{ts,vue}', 'server/**/*.ts'],
+    ignores: [
+      // The canonical implementation — the one place the primitives belong.
+      'app/utils/format/**',
+      ...formattingLegacyFiles
+    ],
+    rules: {
+      // Two rules, one selector list: the core rule only walks `<script>`,
+      // `vue/no-restricted-syntax` covers `<template>` expressions — and a
+      // `{{ x.toFixed(2) }}` in a template is exactly the drift we're stopping.
+      'no-restricted-syntax': ['error', ...formattingSelectors],
+      'vue/no-restricted-syntax': ['error', ...formattingSelectors]
+    }
+  }
+)


### PR DESCRIPTION
Closes #2385. First of three steps in #2383.

## Why

`app/src` alone carried four ways to render a date (dayjs with 14 distinct pattern strings, `toLocaleString('en-US')`, `Intl.DateTimeFormat`, and a hand-rolled `String.replace` on `dd/MM/yyyy`), five strictly identical per-domain transaction-date helpers, three money conventions with different decimal policies, and five address truncations — two of which used `…` where the rest used `...`, so the same address looked like two different values across two tables.

#2376 is what that costs in production: a `maximumFractionDigits: 0` default plus raw `toLocaleString` at the call sites rounded every fractional Community Credit amount to a whole number, so a `0.2 USDC` position displayed as `0`.

A formatter is a product decision — how much precision a user is trusted with, whether zero means zero or unknown, whether a figure is reconcilable against a block explorer. Those belong in one reviewed place.

## What this PR does

**One canonical module**, identical in both front-ends (`app/src/utils/format/`, `dashboard/app/utils/format/`): named styles for money, token amounts, numbers, percentages, dates, durations, addresses and transaction hashes. It is the only place allowed to touch the raw primitives. 35 unit tests.

Conventions it encodes:
- locale pinned to `en-US`, not the browser's — a `1,234.50` that renders `1.234,50` for one teammate makes screenshots and support threads unreadable;
- nothing renderable → `—`, never `0`: a zero is a claim about the data, and a still-loading balance shown as `$0.00` reads as an empty wallet;
- a value that rounds to zero renders `$0.00`, never `-$0.00`;
- money is fixed-precision (columns align), tokens are not (`0.0001 SHER` and `0.00 SHER` are different claims);
- `formatPercent` takes a ratio, not percentage points — the `* 100` that call sites kept forgetting.

**One document** — `.github/copilot-instructions/formatting-standards.md`, linked from `AGENTS.md`, the copilot-instructions README and the review checklist, so it is reachable from every entry point a dev or a coding agent reads.

**One ESLint guard** — `Intl.*`, `toLocaleString`, `toFixed` and literal dayjs pattern strings are errors outside the module, in `<script>` and `<template>` alike. This is the part that makes the standard hold: a document alone drifts within two sprints, because whoever doesn't read it re-introduces a local `Intl.NumberFormat` and review misses it. Current offenders are allowlisted behind a ceiling constant that fails lint at config load if the list grows — the same ratchet already used for `vmCastLegacyFiles`. 46 files in `app/`, 22 in `dashboard/`; the lists only shrink.

## Migration posture

No call site moves. The two strict duplicates (`utils/formatAddress.ts`, `shortenAddress`) and the dashboard's `formatUsd` / `formatUsd6` delegate to the canonical module instead.

Two dashboard rendering details do change with that delegation, both deliberate: the locale no longer follows the browser, and a negative amount reads `-$12.00` rather than `$-12.00`. `formatSignedUsd` is unaffected — it already passed `Math.abs(value)`.

Follow-ups tracked in #2383:
- PR 2 — mechanical migration: the 5 duplicated transaction-date helpers, the 5 address truncations, the local formatters inside `.vue` files.
- PR 3 — the `toFixed()` calls feeding `parseUnits()`. Rounding a display value before an on-chain conversion means the user signs a different number than they entered, so those are fixes reviewed one by one, not a refactor.

## Checks

- `app/`: `eslint .` clean, `prettier --check` clean, `vue-tsc` clean after `build-only`, 2580 unit tests pass (304 files).
- `dashboard/`: `eslint .` clean. `nuxt typecheck` reports 18 pre-existing errors in `stats/`, `constant/` and `queries/`, none in the files this PR touches.
- Both guards verified against a probe component: all four selectors fire on new code, in template and script.
