### PR TITLE
test: ✅ stop the unit suite from writing PDF exports into app/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ scripts/
 
 # Local working todolist shared between dev and AI agents (never committed)
 /todolist.md
+
+# Accounting export artifacts dropped at the root of app/ when an export runs
+# outside a browser (jsPDF / the Excel writer fall back to the process cwd)
+/app/*.pdf
+/app/*.xlsx

--- a/app/src/components/sections/AccountingView/__tests__/AccountingView.spec.ts
+++ b/app/src/components/sections/AccountingView/__tests__/AccountingView.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { flushPromises } from '@vue/test-utils'
 import { renderWithProviders } from '@/tests/mocks'
 import AccountingSummary from '../AccountingSummary.vue'
@@ -12,6 +12,23 @@ import TablePagination from '@/components/TablePagination.vue'
 import { entriesForAccount, accountBalance } from '@/utils/accounting/accountLedger'
 import { catalogueLedger } from '@/utils/accounting/__tests__/catalogueLedger'
 import type { StatementLineView } from '@/utils/accounting/presenter'
+
+// Clicking an export button used to run the real writers: `exportTablesPdf`
+// ends on `doc.save(filename)`, and jsPDF — which only knows how to trigger a
+// browser download — falls back to writing the file to the process cwd once the
+// export settles after this file's jsdom window is gone, dropping real PDFs into
+// `app/` on every run. Stub the composable so the click stops at the boundary;
+// the builders behind it are covered by `accountingPdf.spec.ts` and the
+// filenames by `exportNaming.spec.ts`.
+const { exportPdf, exportExcel } = vi.hoisted(() => ({ exportPdf: vi.fn(), exportExcel: vi.fn() }))
+vi.mock('@/composables/accounting/useAccountingExport', () => ({
+  useAccountingExport: () => ({ exportPdf, exportExcel })
+}))
+
+beforeEach(() => {
+  exportPdf.mockClear()
+  exportExcel.mockClear()
+})
 
 // The cards now read live books via `useAccountingContext`. Rendered standalone
 // (no parent provider) they self-fetch through the globally-mocked queries, which
@@ -53,7 +70,10 @@ describe('TrialBalanceCard', () => {
     await wrapper.find('[data-test="export-excel"]').trigger('click')
     await wrapper.find('[data-test="export-pdf"]').trigger('click')
     await flushPromises()
-    expect(wrapper.find('[data-test="export-excel"]').exists()).toBe(true)
+    expect(exportExcel).toHaveBeenCalledTimes(1)
+    expect(exportExcel.mock.calls[0][1]).toMatch(/^Trial Balance .*\.xlsx$/)
+    expect(exportPdf).toHaveBeenCalledTimes(1)
+    expect(exportPdf.mock.calls[0][1].filename).toMatch(/^Trial Balance .*\.pdf$/)
     wrapper.unmount()
   })
 })
@@ -83,7 +103,8 @@ describe('IncomeStatementCard', () => {
     await wrapper.find('[data-test="export-excel"]').trigger('click')
     await wrapper.find('[data-test="export-pdf"]').trigger('click')
     await flushPromises()
-    expect(wrapper.find('[data-test="export-pdf"]').exists()).toBe(true)
+    expect(exportExcel.mock.calls[0][1]).toMatch(/^Income Statement .*\.xlsx$/)
+    expect(exportPdf.mock.calls[0][1].filename).toMatch(/^Income Statement .*\.pdf$/)
     wrapper.unmount()
   })
 })
@@ -115,7 +136,8 @@ describe('BalanceSheetCard', () => {
     await wrapper.find('[data-test="export-excel"]').trigger('click')
     await wrapper.find('[data-test="export-pdf"]').trigger('click')
     await flushPromises()
-    expect(wrapper.find('[data-test="export-excel"]').exists()).toBe(true)
+    expect(exportExcel.mock.calls[0][1]).toMatch(/^Balance Sheet .*\.xlsx$/)
+    expect(exportPdf.mock.calls[0][1].filename).toMatch(/^Balance Sheet .*\.pdf$/)
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
# Description

## Intial Issue Description

Closes #2388

Running the `app/` unit suite dropped three real PDF files at the root of `app/`, untracked, on every local run:

```
app/Balance Sheet - As of <today>.pdf
app/Income Statement - All time.pdf
app/Trial Balance - As of <today>.pdf
```

## PR Summary Or Solution description

**1. The write, at the source.** `AccountingView.spec.ts` was the only spec exercising the real export path: its three "exports and prints … from the export bar" tests click the real buttons, which run `useAccountingExport` → `exportTablesPdf` → `doc.save(filename)`. jsPDF only knows how to trigger a browser download, and the export settles *after* the spec file's jsdom window is torn down, so it took its Node fallback and wrote each PDF to the process cwd.

The spec now stubs `useAccountingExport`, so the click stops at the composable boundary. Worth noting for anyone hitting this again: stubbing `jspdf` itself is **not** enough — because the export resolves after the module registry is gone, one of the three writes reloads the real module and slips past the mock. The composable is the reliable seam.

Since the exports are stubbed, the three tests can assert something real instead of the tautological `expect(button.exists()).toBe(true)` they carried: each card must hand the export the filename its section is named after (`Trial Balance …xlsx` / `.pdf`, and so on). The builders behind the composable stay covered by `accountingPdf.spec.ts`, the filename rules by `exportNaming.spec.ts`.

**2. The safety net.** `/app/*.pdf` and `/app/*.xlsx` are now git-ignored — `app/src/utils/excelExport.ts` writes spreadsheets through the same download mechanism, so it can leak the same way. The rule is scoped to the root of `app/`, not a blanket `*.pdf`, so documents committed deliberately elsewhere in the repo still show up in `git status`.

Side benefit: the suite no longer renders three real PDFs, and local wall-clock dropped from ~110s to ~58s.

## Verification

Full `app/` quality gate, all green:

- `npx eslint .` — clean (one pre-existing warning in `registry.spec.ts`, untouched here)
- `npx prettier . --check` — clean
- `CI=1 npm run build-only` then `npm run type-check` — clean
- `CI=1 npm run test:unit -- --run` — 301 files, 2545 passed / 1 skipped, and `app/` is left with no `.pdf` / `.xlsx`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
