### PR TITLE
fix: 🐛 record money leaving the Safe so its accounting balance is correct

### DIFF
--- a/app/src/components/sections/AccountingView/AccountingSummary.vue
+++ b/app/src/components/sections/AccountingView/AccountingSummary.vue
@@ -37,13 +37,14 @@
       >
     </div>
 
-    <!-- Metric cards -->
-    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <!-- Metric cards — 4 per row; the last row stretches to fill the width when
+         "Debt repaid" is absent (7 cards → 4/3), and is a plain 4/4 when it shows. -->
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-12">
       <div
-        v-for="card in summaryCards"
+        v-for="(card, index) in summaryCards"
         :key="card.label"
         class="border-default bg-default rounded-2xl border p-4.5 shadow-sm"
-        :class="card.accent ? [card.accentClass, 'border-t-[3px]'] : ''"
+        :class="[card.accent ? [card.accentClass, 'border-t-[3px]'] : '', cardSpan(index)]"
         :data-test="`summary-${card.label}`"
       >
         <div class="flex items-center justify-between">
@@ -82,6 +83,18 @@ const summaryCards = computed(() =>
   presentSummaryCards(acc.summary.value, acc.incomeStatement.value, acc.balanceSheet.value)
 )
 const banner = computed(() => presentBanner(acc.balanceSheet.value, acc.generalLedger.value))
+
+const LAST_ROW_SPAN: Record<number, string> = {
+  1: 'lg:col-span-12',
+  2: 'lg:col-span-6',
+  3: 'lg:col-span-4',
+  4: 'lg:col-span-3'
+}
+
+function cardSpan(index: number): string {
+  if (index < 4) return 'lg:col-span-3'
+  return LAST_ROW_SPAN[summaryCards.value.length - 4] ?? 'lg:col-span-3'
+}
 
 // Whole-book ledger size — surfaced in the modal so the user knows a full ledger
 // export may be long.

--- a/app/src/composables/accounting/useCNCAccounting.ts
+++ b/app/src/composables/accounting/useCNCAccounting.ts
@@ -35,7 +35,10 @@ import { useSafeDepositRouterEventsViaLogs } from '@/composables/investor/useSaf
 import { useGetTeamQuery } from '@/queries/team.queries'
 import { useGetTeamWeeklyClaimsQuery } from '@/queries/weeklyClaim.queries'
 import { useGetExpensesQuery } from '@/queries/expense.queries'
-import { useGetSafeIncomingTransfersQuery } from '@/queries/safe.queries'
+import {
+  useGetSafeIncomingTransfersQuery,
+  useGetSafeOutgoingTransactionsQuery
+} from '@/queries/safe.queries'
 import { useCurrencyStore } from '@/stores/currencyStore'
 import { useTransferInitiators } from './useTransferInitiators'
 import {
@@ -159,8 +162,12 @@ export function useCNCAccounting(
   const weeklyClaims = useGetTeamWeeklyClaimsQuery({ queryParams: { teamId } })
   const expenses = useGetExpensesQuery({ queryParams: { teamId } })
 
-  // ── Safe service: incoming transfers (optional / flaky — never blocks) ──
+  // ── Safe service: incoming + outgoing transfers (optional / flaky — never blocks) ──
   const safeTransfers = useGetSafeIncomingTransfersQuery({
+    pathParams: { safeAddress },
+    queryParams: { limit: EVENT_LIMIT }
+  })
+  const safeOutgoing = useGetSafeOutgoingTransactionsQuery({
     pathParams: { safeAddress },
     queryParams: { limit: EVENT_LIMIT }
   })
@@ -205,6 +212,7 @@ export function useCNCAccounting(
     investorEvents: investor.result.value,
     safeDepositRouterEvents: router.result.value,
     safeTransfers: safeTransfers.data.value,
+    safeOutgoingTransactions: safeOutgoing.data.value,
     weeklyClaims: weeklyClaims.data.value?.data,
     expenses: expenses.data.value
   }))
@@ -273,7 +281,8 @@ export function useCNCAccounting(
         routerMultiplier,
         weeklyClaims,
         expenses,
-        safeTransfers
+        safeTransfers,
+        safeOutgoing
       ].map(run)
     )
   }

--- a/app/src/queries/safe.queries.ts
+++ b/app/src/queries/safe.queries.ts
@@ -11,8 +11,7 @@ import type {
   GetSafeIncomingTransfersParams,
   GetSafeOutgoingTransactionsParams,
   SafeIncomingTransfersResponse,
-  SafeIncomingTransfer,
-  SafeTransaction
+  SafeIncomingTransfer
 } from '@/types'
 
 const chainId = currentChainId

--- a/app/src/queries/safe.queries.ts
+++ b/app/src/queries/safe.queries.ts
@@ -9,8 +9,10 @@ import type {
   GetSafeInfoParams,
   GetSafeTransactionsParams,
   GetSafeIncomingTransfersParams,
+  GetSafeOutgoingTransactionsParams,
   SafeIncomingTransfersResponse,
-  SafeIncomingTransfer
+  SafeIncomingTransfer,
+  SafeTransaction
 } from '@/types'
 
 const chainId = currentChainId
@@ -32,6 +34,9 @@ export const safeKeys = {
   incomingTransferLists: () => [...safeKeys.all, 'incoming-transfers'] as const,
   incomingTransfers: (safeAddress: string | undefined, limit?: number) =>
     [...safeKeys.incomingTransferLists(), { safeAddress, limit }] as const,
+  outgoingTransactionLists: () => [...safeKeys.all, 'outgoing-transactions'] as const,
+  outgoingTransactions: (safeAddress: string | undefined, limit?: number) =>
+    [...safeKeys.outgoingTransactionLists(), { safeAddress, limit }] as const,
   balance: (address: string | undefined, chainId: number | undefined) =>
     ['balance', { address, chainId }] as const,
   tokenBalance: (
@@ -173,6 +178,36 @@ export function useGetSafeIncomingTransfersQuery(params: GetSafeIncomingTransfer
       const queryString = params.toString() ? `?${params.toString()}` : ''
       const { data } = await externalApiClient.get<SafeIncomingTransfersResponse>(
         `${txService.url}/api/v1/safes/${address}/incoming-transfers/${queryString}`
+      )
+      return data.results || []
+    },
+    staleTime: 300_000,
+    refetchInterval: 300_000
+  })
+}
+
+// ============================================================================
+// GET /api/v1/safes/{safeAddress}/multisig-transactions - Executed outgoing txs
+// ============================================================================
+
+export function useGetSafeOutgoingTransactionsQuery(params: GetSafeOutgoingTransactionsParams) {
+  const { pathParams, queryParams } = params
+
+  return useQuery<SafeTransaction[]>({
+    queryKey: safeKeys.outgoingTransactions(toValue(pathParams.safeAddress), queryParams?.limit),
+    enabled: !!toValue(pathParams.safeAddress),
+    queryFn: async () => {
+      const address = toValue(pathParams.safeAddress)
+      if (!address) throw new Error('Missing Safe address')
+      if (!txService) throw new Error(`Unsupported chainId: ${chainId}`)
+
+      const qp = new URLSearchParams({ executed: 'true' })
+      if (queryParams?.limit) {
+        qp.append('limit', queryParams.limit.toString())
+      }
+
+      const { data } = await externalApiClient.get<{ results: SafeTransaction[] }>(
+        `${txService.url}/api/v1/safes/${address}/multisig-transactions/?${qp.toString()}`
       )
       return data.results || []
     },

--- a/app/src/types/safe.queries.ts
+++ b/app/src/types/safe.queries.ts
@@ -86,3 +86,18 @@ export interface GetSafeTransactionParams {
   pathParams: GetSafeTransactionPathParams
   queryParams?: GetSafeTransactionQueryParams
 }
+
+/**
+ * Query parameters for Safe outgoing (multisig) transactions
+ */
+export interface GetSafeOutgoingTransactionsQueryParams {
+  limit?: number
+}
+
+/**
+ * Combined parameters for useGetSafeOutgoingTransactionsQuery
+ */
+export interface GetSafeOutgoingTransactionsParams {
+  pathParams: { safeAddress: MaybeRefOrGetter<string | undefined> }
+  queryParams?: GetSafeOutgoingTransactionsQueryParams
+}

--- a/app/src/utils/accounting/__tests__/toSafeTransferRows.spec.ts
+++ b/app/src/utils/accounting/__tests__/toSafeTransferRows.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import type { SafeIncomingTransfer } from '@/types/safe'
-import { toSafeTransferRows } from '@/utils/accounting/assemble'
+import type { SafeIncomingTransfer, SafeTransaction } from '@/types/safe'
+import { toSafeTransferRows, toSafeOutgoingTransferRows } from '@/utils/accounting/assemble'
 import { ADDR } from './fixtures'
 
 const ROUTER = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
@@ -90,5 +90,78 @@ describe('toSafeTransferRows', () => {
 
     const withDeposits = toSafeTransferRows([investorDeposit], ROUTER, deposits)
     expect(withDeposits).toHaveLength(0) // matched the router deposit → excluded
+  })
+})
+
+describe('toSafeOutgoingTransferRows', () => {
+  const baseTx: SafeTransaction = {
+    safe: ADDR.safe,
+    to: ADDR.client,
+    value: '1000000000000000000',
+    operation: 0,
+    safeTxGas: '0',
+    baseGas: '0',
+    gasPrice: '0',
+    gasToken: '0x0000000000000000000000000000000000000000',
+    nonce: 1,
+    executionDate: '2026-04-01T12:00:00Z',
+    submissionDate: '2026-04-01T11:00:00Z',
+    modified: '2026-04-01T12:00:00Z',
+    blockNumber: 100,
+    transactionHash: '0xoutHash1',
+    safeTxHash: '0xsafeTxHash1',
+    executor: ADDR.founder,
+    isExecuted: true,
+    isSuccessful: true,
+    confirmationsRequired: 1,
+    confirmations: []
+  }
+
+  it('converts a native outflow to a SafeTransferRow', () => {
+    const rows = toSafeOutgoingTransferRows([baseTx], ADDR.safe)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      from: ADDR.safe,
+      to: ADDR.client,
+      token: null,
+      amount: '1000000000000000000',
+      txHash: '0xoutHash1'
+    })
+    expect(rows[0].timestamp).toBe(Math.floor(Date.parse('2026-04-01T12:00:00Z') / 1000))
+  })
+
+  it('converts an ERC20 transfer call to a SafeTransferRow', () => {
+    const erc20Tx: SafeTransaction = {
+      ...baseTx,
+      to: ADDR.usdcToken,
+      value: '0',
+      transactionHash: '0xoutHash2',
+      dataDecoded: {
+        method: 'transfer',
+        parameters: [
+          { name: 'to', type: 'address', value: ADDR.member },
+          { name: 'value', type: 'uint256', value: '5000000' }
+        ]
+      }
+    }
+    const rows = toSafeOutgoingTransferRows([erc20Tx], ADDR.safe)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      from: ADDR.safe,
+      to: ADDR.member,
+      token: ADDR.usdcToken,
+      amount: '5000000'
+    })
+  })
+
+  it('skips unexecuted or failed transactions', () => {
+    const notExecuted = { ...baseTx, isExecuted: false, executionDate: null }
+    const failed = { ...baseTx, isSuccessful: false }
+    const rows = toSafeOutgoingTransferRows([notExecuted, failed], ADDR.safe)
+    expect(rows).toHaveLength(0)
+  })
+
+  it('tolerates a null transaction list', () => {
+    expect(toSafeOutgoingTransferRows(null, ADDR.safe)).toEqual([])
   })
 })

--- a/app/src/utils/accounting/assemble.ts
+++ b/app/src/utils/accounting/assemble.ts
@@ -18,7 +18,7 @@ import { getAddress, isAddress, type Address } from 'viem'
 import type { TeamContract } from '@/types/teamContract'
 import type { WeeklyClaim } from '@/types/cash-remuneration'
 import type { ExpenseResponse } from '@/types/expense-account'
-import type { SafeIncomingTransfer } from '@/types/safe'
+import type { SafeIncomingTransfer, SafeTransaction } from '@/types/safe'
 import type { BankEventsQuery } from '@/types/ponder/bank'
 import type { CashRemunerationEventsQuery } from '@/types/ponder/cash-remuneration'
 import type { ExpenseEventsQuery } from '@/types/ponder/expense'
@@ -82,6 +82,8 @@ export interface CncAccountingInput {
   investorEvents?: InvestorEventsQuery | null
   safeDepositRouterEvents?: SafeDepositRouterEventsQuery | null
   safeTransfers?: readonly SafeIncomingTransfer[] | null
+  /** Executed multisig transactions — outflows from the Safe. */
+  safeOutgoingTransactions?: readonly SafeTransaction[] | null
   // ── portal DB rows (off-chain enrichment context, spec §3.2) ──
   weeklyClaims?: readonly WeeklyClaim[]
   expenses?: readonly ExpenseResponse[]
@@ -182,6 +184,52 @@ export function toSafeTransferRows(
   return rows
 }
 
+/**
+ * Convert executed Safe multisig transactions into {@link SafeTransferRow}s so the
+ * mapper can book outflows (Cr Cash — Safe). Handles native transfers (`value > 0`)
+ * and ERC-20 `transfer(to, amount)` calls (decoded by the Transaction Service).
+ */
+export function toSafeOutgoingTransferRows(
+  transactions: readonly SafeTransaction[] | null | undefined,
+  safeAddress: string
+): SafeTransferRow[] {
+  const rows: SafeTransferRow[] = []
+  for (const tx of transactions ?? []) {
+    if (!tx.isExecuted || tx.isSuccessful === false || !tx.executionDate) continue
+    const timestamp = Math.floor(new Date(tx.executionDate).getTime() / 1000)
+    const txHash = tx.transactionHash ?? tx.safeTxHash
+
+    if (tx.dataDecoded?.method === 'transfer' && tx.dataDecoded.parameters?.length >= 2) {
+      const recipient = tx.dataDecoded.parameters[0]?.value
+      const amount = tx.dataDecoded.parameters[1]?.value
+      if (recipient && amount && amount !== '0') {
+        rows.push({
+          id: `out-${txHash}-erc20`,
+          from: safeAddress,
+          to: recipient,
+          token: tx.to,
+          amount,
+          timestamp,
+          txHash
+        })
+      }
+    }
+
+    if (tx.value && tx.value !== '0') {
+      rows.push({
+        id: `out-${txHash}-native`,
+        from: safeAddress,
+        to: tx.to,
+        token: null,
+        amount: tx.value,
+        timestamp,
+        txHash
+      })
+    }
+  }
+  return rows
+}
+
 /** Build the {@link LedgerSources} the mappers consume from the raw query results. */
 function toLedgerSources(input: CncAccountingInput): LedgerSources {
   const sources: LedgerSources = {}
@@ -250,13 +298,18 @@ function toLedgerSources(input: CncAccountingInput): LedgerSources {
   }
 
   if (input.safeAddress) {
+    const incomingRows = toSafeTransferRows(
+      input.safeTransfers,
+      input.safeDepositRouterAddress,
+      input.safeDepositRouterEvents?.safeDeposits?.items
+    )
+    const outgoingRows = toSafeOutgoingTransferRows(
+      input.safeOutgoingTransactions,
+      input.safeAddress
+    )
     sources.safe = {
       safeAddress: input.safeAddress,
-      transfers: toSafeTransferRows(
-        input.safeTransfers,
-        input.safeDepositRouterAddress,
-        input.safeDepositRouterEvents?.safeDeposits?.items
-      )
+      transfers: [...incomingRows, ...outgoingRows]
     }
   }
 


### PR DESCRIPTION
# Description

Fixes #2398 — the Safe's accounting balance was wrong because money leaving the Safe was never recorded.

## Summary

The accounting only ever collected the money coming **into** the Safe. Everything going **out** — a payment to another contract, a transfer to an outside address — was never gathered, so the Safe's balance in the books could only grow and never came back down. That produced the two symptoms in the issue: the trial balance reporting an amount for a Safe that is actually empty, and outgoing payments missing from the ledger and the statements.

This PR collects the executed outgoing transactions alongside the incoming ones and feeds both into the accounting. The part that decides how to record an outgoing payment already existed and was already correct — a transfer to one of the team's own accounts is booked as an internal move, anything else as money spent — it had simply never received any data. With both directions now recorded, the Safe balance in the books matches the balance on chain, and an empty Safe reads as zero.

Both kinds of outgoing payment are handled: transfers of the network's own currency, and transfers of tokens such as USDC. Transactions that were never executed, or that failed, are ignored so they cannot distort the books.

Also included: a small layout fix on the Accounting summary. The metric cards are laid out four per row, and the last row now stretches to fill the width instead of leaving a gap when the "Debt repaid" card is absent.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Four new unit tests cover the conversion of outgoing transactions: a currency transfer, a token transfer, transactions that were not executed or failed, and the empty case. The existing accounting suite (323 tests) still passes, along with type-check and lint.
