### PR TITLE
refactor: ♻️ type contract write args against the ABI

### DIFF
--- a/app/src/components/sections/AdministrationView/CurrentBoDElectionSection.vue
+++ b/app/src/components/sections/AdministrationView/CurrentBoDElectionSection.vue
@@ -115,15 +115,15 @@ const createElection = async (electionData: OldProposal) => {
       electionData.title,
       electionData.description,
       dateToUnixTimestamp(electionData.startDate as Date) < dateNow
-        ? dateNow + 60 // Start in 1 minute if start date is in the past
-        : dateToUnixTimestamp(electionData.startDate as Date),
+        ? BigInt(dateNow + 60) // Start in 1 minute if start date is in the past
+        : BigInt(dateToUnixTimestamp(electionData.startDate as Date)),
       dateToUnixTimestamp(electionData.startDate as Date) < dateNow
-        ? dateNow + 60 + 60 // End 1 minute after adjusted start time if start date is in the past
-        : dateToUnixTimestamp(electionData.endDate as Date),
-      electionData.winnerCount,
+        ? BigInt(dateNow + 60 + 60) // End 1 minute after adjusted start time if start date is in the past
+        : BigInt(dateToUnixTimestamp(electionData.endDate as Date)),
+      BigInt(electionData.winnerCount),
       electionData.candidates?.map((c) => c.candidateAddress) || [],
       teamStore.currentTeam?.members.map((m) => m.address) || []
-    ] as readonly unknown[]
+    ] as const
 
     await writeCreateElection({ args })
 

--- a/app/src/components/sections/ContractManagementView/MainContractActions.vue
+++ b/app/src/components/sections/ContractManagementView/MainContractActions.vue
@@ -91,7 +91,8 @@
 </template>
 <script setup lang="ts">
 import { Icon as IconifyIcon } from '@iconify/vue'
-import { encodeFunctionData, type Abi, type Address } from 'viem'
+import { encodeFunctionData, type Address } from 'viem'
+import { ownablePausableAbi } from '@/artifacts/abi/ownable-pausable'
 import type { TableRow } from '@/types/table'
 import { ref, computed, watch } from 'vue'
 import { useTeamStore, useUserDataStore } from '@/stores'
@@ -167,7 +168,6 @@ const formatedActions = computed(() => {
 })
 
 const rowAddress = computed(() => props.row.address as Address)
-const rowAbi = computed(() => props.row.abi as Abi)
 
 const {
   mutate: executeTransferOwnership,
@@ -175,7 +175,7 @@ const {
   error: errorTransferOwnership
 } = useContractWritesV3({
   contractAddress: rowAddress,
-  abi: rowAbi,
+  abi: ownablePausableAbi,
   functionName: 'transferOwnership'
 })
 
@@ -185,7 +185,7 @@ const {
   error: errorPauseContract
 } = useContractWritesV3({
   contractAddress: rowAddress,
-  abi: rowAbi,
+  abi: ownablePausableAbi,
   functionName: 'pause'
 })
 
@@ -195,7 +195,7 @@ const {
   error: errorUnpauseContract
 } = useContractWritesV3({
   contractAddress: rowAddress,
-  abi: rowAbi,
+  abi: ownablePausableAbi,
   functionName: 'unpause'
 })
 

--- a/app/src/components/sections/ExpenseAccountView/TransferAction.vue
+++ b/app/src/components/sections/ExpenseAccountView/TransferAction.vue
@@ -89,6 +89,7 @@ import { useChainId } from '@wagmi/vue'
 import { config } from '@/wagmi.config'
 import { useERC20Approve } from '@/composables/erc20/writes'
 import { useExpenseAccountTransfer } from '@/composables/expenseAccount/writes'
+import type { WriteFunctionArgs } from '@/composables/contracts/useContractWritesV3'
 import { expenseKeys } from '@/queries'
 import { useQueryClient } from '@tanstack/vue-query'
 import type { TableRow } from '@/types/table'
@@ -227,7 +228,9 @@ const verifyApprovalSignature = async (budgetLimit: BudgetLimit) => {
   return true
 }
 
-const submitExpenseAccountTransfer = (args: readonly unknown[]) => {
+type ExpenseTransferArgs = WriteFunctionArgs<typeof expenseAccountEip712Abi, 'transfer'>
+
+const submitExpenseAccountTransfer = (args: ExpenseTransferArgs) => {
   transferMutation.mutate(
     { args },
     {

--- a/app/src/composables/bank/writes.ts
+++ b/app/src/composables/bank/writes.ts
@@ -1,12 +1,14 @@
 import { computed } from 'vue'
 import { bankAbi } from '@/artifacts/abi/generated'
-import { useContractWritesV3 } from '@/composables/contracts/useContractWritesV3'
+import {
+  useContractWritesV3,
+  type WriteFunctionName
+} from '@/composables/contracts/useContractWritesV3'
 import { useTeamStore } from '@/stores/teamStore'
-import type { ExtractAbiFunctionNames } from 'abitype'
 
-type BankFunctionNames = ExtractAbiFunctionNames<typeof bankAbi>
+type BankFunctionNames = WriteFunctionName<typeof bankAbi>
 
-function useBankContractWrite(functionName: BankFunctionNames) {
+function useBankContractWrite<F extends BankFunctionNames>(functionName: F) {
   const teamStore = useTeamStore()
   const bankAddress = computed(() => teamStore.getContractAddressByType('Bank'))
   return useContractWritesV3({

--- a/app/src/composables/bod/writes.ts
+++ b/app/src/composables/bod/writes.ts
@@ -10,6 +10,9 @@ import { log } from '@/utils'
 import { useCreateActionMutation, useUpdateActionMutation } from '@/queries/action.queries'
 import { useCreateBulkNotificationsMutation } from '@/queries/notification.queries'
 import type { Action } from '@/types'
+
+/** The fields `BoardOfDirectors.addAction` encodes, plus any extra Action metadata. */
+type AddActionInput = Pick<Action, 'targetAddress' | 'description' | 'data'> & Partial<Action>
 import { BOD_FUNCTION_NAMES } from './reads'
 
 /**
@@ -75,7 +78,15 @@ export function useBodAddAction() {
     }
   })
 
-  const executeAddAction = async (data: Partial<Action>) => {
+  /**
+   * `targetAddress` / `description` / `data` are what `addAction` encodes, so
+   * they are required. They used to be optional (`Partial<Action>`) and the
+   * args tuple was cast to `readonly unknown[]`, so passing an incomplete
+   * action compiled — and viem encodes `undefined` without complaining, which
+   * would have submitted a governance action with an empty target and payload
+   * rather than failing. Every call site already passes all three.
+   */
+  const executeAddAction = async (data: AddActionInput) => {
     try {
       if (!bodAddress.value) {
         toast.add({ title: 'BOD address not found', color: 'error' })
@@ -99,7 +110,7 @@ export function useBodAddAction() {
       }
 
       return await mutation.mutateAsync({
-        args: [data.targetAddress, data.description, data.data] as readonly unknown[]
+        args: [data.targetAddress, data.description, data.data]
       })
     } catch (err) {
       console.error(err)
@@ -169,7 +180,7 @@ export function useBodApproveAction() {
   const executeApproveAction = async (actionId: number, dbId?: number) => {
     currentActionId.value = BigInt(actionId)
     currentDbId.value = dbId
-    return mutation.mutateAsync({ args: [BigInt(actionId)] as readonly unknown[] })
+    return mutation.mutateAsync({ args: [BigInt(actionId)] })
   }
 
   return {

--- a/app/src/composables/cashRemuneration/writes.ts
+++ b/app/src/composables/cashRemuneration/writes.ts
@@ -1,12 +1,16 @@
 import { computed } from 'vue'
 import { cashRemunerationEip712Abi } from '@/artifacts/abi/generated'
-import { useContractWritesV3 } from '@/composables/contracts/useContractWritesV3'
+import {
+  useContractWritesV3,
+  type WriteFunctionName
+} from '@/composables/contracts/useContractWritesV3'
 import { useTeamStore } from '@/stores/teamStore'
-import type { ExtractAbiFunctionNames } from 'abitype'
 
-type CashRemunerationFunctionNames = ExtractAbiFunctionNames<typeof cashRemunerationEip712Abi>
+type CashRemunerationFunctionNames = WriteFunctionName<typeof cashRemunerationEip712Abi>
 
-function useCashRemunerationContractWrite(functionName: CashRemunerationFunctionNames) {
+function useCashRemunerationContractWrite<F extends CashRemunerationFunctionNames>(
+  functionName: F
+) {
   const teamStore = useTeamStore()
   const contractAddress = computed(() =>
     teamStore.getContractAddressByType('CashRemunerationEIP712')

--- a/app/src/composables/contracts/README.md
+++ b/app/src/composables/contracts/README.md
@@ -42,19 +42,19 @@ adding a new contract:
 
 ```ts
 import { computed } from 'vue'
-import { BANK_ABI } from '@/artifacts/abi/bank'
+import { bankAbi } from '@/artifacts/abi/generated'
 import { useContractWritesV3 } from '@/composables/contracts/useContractWritesV3'
 import { useTeamStore } from '@/stores/teamStore'
-import type { ExtractAbiFunctionNames } from 'abitype'
+import { type WriteFunctionName } from '@/composables/contracts/useContractWritesV3'
 
-type BankFunctionNames = ExtractAbiFunctionNames<typeof BANK_ABI>
+type BankFunctionNames = WriteFunctionName<typeof bankAbi>
 
-function useBankContractWrite(functionName: BankFunctionNames) {
+function useBankContractWrite<F extends BankFunctionNames>(functionName: F) {
   const teamStore = useTeamStore()
   const bankAddress = computed(() => teamStore.getContractAddressByType('Bank'))
   return useContractWritesV3({
     contractAddress: bankAddress,
-    abi: BANK_ABI,
+    abi: bankAbi,
     functionName
   })
 }
@@ -75,8 +75,9 @@ Rules of thumb:
   one composable — callers need independent `isPending` / `error` states per
   call site.
 - **Pass refs, not values, for addresses.** `useContractWritesV3` accepts
-  `MaybeRef` for `contractAddress`, `abi`, `functionName`, and `chainId`. Keep
-  the address reactive so the mutation tracks store updates.
+  `MaybeRef` for `contractAddress` and `chainId`. Keep the address reactive so
+  the mutation tracks store updates. `abi` and `functionName` are plain values —
+  see below.
 - **Pin `chainId` only when you mean it.** Omitting `chainId` lets wagmi
   resolve the chain from the connected wallet at call time and invalidates
   reads across every chain in the cache. Pin it when the contract is single-
@@ -88,10 +89,24 @@ Rules of thumb:
   await transfer.mutateAsync({ args: [to, amount] })
   ```
 
-`abi` is widened to `Abi` inside `useContractWritesV3`, so `variables.args` is
-**not** structurally validated against the function signature. The
-`ExtractAbiFunctionNames` factory above gives you function-name safety; argument
-typing remains the caller's responsibility.
+`variables.args` **is** structurally validated against the function signature:
+`useContractWritesV3` is generic over `abi` and `functionName`, so viem resolves
+`args` to the exact tuple the ABI declares. Wrong order, a `string` where the ABI
+says `uint256`, and a missing argument are all compile errors.
+
+This is why `abi` and `functionName` are plain values, not `MaybeRef`: `args` is
+derived from them, and a reactive `functionName` would make that derivation the
+union of every function's tuple, which constrains nothing. No call site needs a
+reactive ABI — pass a different `abi`/`functionName` pair from a different
+composable instead.
+
+The tuple types are exported if you need to type a helper that forwards args:
+
+```ts
+import type { WriteFunctionArgs } from '@/composables/contracts/useContractWritesV3'
+
+type TransferArgs = WriteFunctionArgs<typeof bankAbi, 'transferToken'>
+```
 
 ## 2. Error handling
 

--- a/app/src/composables/contracts/useContractWritesV3.ts
+++ b/app/src/composables/contracts/useContractWritesV3.ts
@@ -7,7 +7,13 @@ import {
   type SimulateContractParameters,
   type WaitForTransactionReceiptParameters
 } from '@wagmi/core'
-import { BaseError, type Abi, type Address } from 'viem'
+import {
+  BaseError,
+  type Abi,
+  type Address,
+  type ContractFunctionArgs,
+  type ContractFunctionName
+} from 'viem'
 import { config as wagmiConfig, type config as wagmiConfigType } from '@/wagmi.config'
 import { log, parseErrorV2 } from '@/utils'
 
@@ -19,10 +25,28 @@ type WaitParams = WaitForTransactionReceiptParameters<WagmiConfig>
 // be validated structurally with `satisfies` rather than cast wholesale.
 type AppChainId = SimulateParams['chainId']
 
-export interface ContractWriteV3Config {
+/** State-changing function names of `abi`. */
+export type WriteFunctionName<abi extends Abi> = ContractFunctionName<abi, 'nonpayable' | 'payable'>
+
+/** The argument tuple `abi`'s `fn` declares. */
+export type WriteFunctionArgs<
+  abi extends Abi,
+  fn extends WriteFunctionName<abi>
+> = ContractFunctionArgs<abi, 'nonpayable' | 'payable', fn>
+
+export interface ContractWriteV3Config<
+  abi extends Abi = Abi,
+  fn extends WriteFunctionName<abi> = WriteFunctionName<abi>
+> {
   contractAddress: MaybeRef<Address | undefined>
-  abi: MaybeRef<Abi>
-  functionName: MaybeRef<string>
+  /**
+   * Plain value, not a `MaybeRef`: `args` is derived from it, and a reactive
+   * ABI would make that derivation the union of every function's tuple — which
+   * constrains nothing. No call site needs a reactive ABI; pass a different
+   * `abi`/`functionName` pair from a different composable instead.
+   */
+  abi: abi
+  functionName: fn
   chainId?: MaybeRef<number | undefined>
   config?: {
     log?: boolean
@@ -34,16 +58,19 @@ export interface ContractWriteV3Config {
    */
   onSuccess?: (
     result: ExecuteContractWriteResult,
-    variables: ExecuteWriteVariables
+    variables: ExecuteWriteVariables<abi, fn>
   ) => void | Promise<void>
   /**
    * Runs after the built-in error log. Must not throw.
    */
-  onError?: (error: Error, variables: ExecuteWriteVariables) => void
+  onError?: (error: Error, variables: ExecuteWriteVariables<abi, fn>) => void
 }
 
-export interface ExecuteWriteVariables {
-  args?: readonly unknown[]
+export interface ExecuteWriteVariables<
+  abi extends Abi = Abi,
+  fn extends WriteFunctionName<abi> = WriteFunctionName<abi>
+> {
+  args?: WriteFunctionArgs<abi, fn>
   value?: bigint
 }
 
@@ -195,25 +222,29 @@ export async function executeContractWrite(
  *   handler invalidates `useReadContract` queries for this address across
  *   *every* chain in the cache. Pin `chainId` to scope the invalidation.
  */
-export function useContractWritesV3(cfg: ContractWriteV3Config) {
+export function useContractWritesV3<const abi extends Abi, fn extends WriteFunctionName<abi>>(
+  cfg: ContractWriteV3Config<abi, fn>
+) {
   const queryClient = useQueryClient()
 
   const shouldLog = cfg.config?.log ?? true
 
   return useMutation({
-    mutationFn: async (variables: ExecuteWriteVariables = {}) => {
+    mutationFn: async (variables: ExecuteWriteVariables<abi, fn> = {}) => {
       const address = unref(cfg.contractAddress)
-      const functionName = unref(cfg.functionName)
+      const functionName = cfg.functionName
 
       if (!address) throw new Error('Contract address is undefined')
       if (!functionName) throw new Error('Function name is empty')
 
       return executeContractWrite({
         address,
-        abi: unref(cfg.abi),
+        abi: cfg.abi,
         functionName,
         chainId: unref(cfg.chainId),
-        args: variables.args,
+        // `executeContractWrite` is the framework-agnostic escape hatch and stays
+        // loosely typed; the tuple was already validated against the ABI above.
+        args: variables.args as readonly unknown[] | undefined,
         value: variables.value,
         onReplayError: shouldLog
           ? (err) =>
@@ -223,7 +254,7 @@ export function useContractWritesV3(cfg: ContractWriteV3Config) {
     },
     onError: (error, variables) => {
       if (shouldLog) {
-        log.error(`useContractWritesV3(${unref(cfg.functionName)}) failed:\n`, parseErrorV2(error))
+        log.error(`useContractWritesV3(${cfg.functionName}) failed:\n`, parseErrorV2(error))
       }
       cfg.onError?.(error, variables)
     },

--- a/app/src/composables/elections/writes.ts
+++ b/app/src/composables/elections/writes.ts
@@ -1,10 +1,18 @@
 import { computed } from 'vue'
 import { electionsAbi } from '@/artifacts/abi/generated'
-import { useContractWritesV3 } from '@/composables/contracts/useContractWritesV3'
+import {
+  useContractWritesV3,
+  type WriteFunctionName
+} from '@/composables/contracts/useContractWritesV3'
 import { useTeamStore } from '@/stores/teamStore'
-import { type ElectionsFunctionName } from './reads'
 
-function useElectionsContractWrite(functionName: ElectionsFunctionName) {
+/**
+ * State-changing names only. `ElectionsFunctionName` in ./reads covers every
+ * function on the contract, reads included, so it is the wrong constraint here.
+ */
+type ElectionsWriteNames = WriteFunctionName<typeof electionsAbi>
+
+function useElectionsContractWrite<F extends ElectionsWriteNames>(functionName: F) {
   const teamStore = useTeamStore()
   const contractAddress = computed(() => teamStore.getContractAddressByType('Elections'))
   return useContractWritesV3({

--- a/app/src/composables/expenseAccount/writes.ts
+++ b/app/src/composables/expenseAccount/writes.ts
@@ -1,12 +1,14 @@
 import { computed } from 'vue'
 import { expenseAccountEip712Abi } from '@/artifacts/abi/generated'
-import { useContractWritesV3 } from '@/composables/contracts/useContractWritesV3'
+import {
+  useContractWritesV3,
+  type WriteFunctionName
+} from '@/composables/contracts/useContractWritesV3'
 import { useTeamStore } from '@/stores/teamStore'
-import type { ExtractAbiFunctionNames } from 'abitype'
 
-type ExpenseAccountFunctionNames = ExtractAbiFunctionNames<typeof expenseAccountEip712Abi>
+type ExpenseAccountFunctionNames = WriteFunctionName<typeof expenseAccountEip712Abi>
 
-function useExpenseAccountContractWrite(functionName: ExpenseAccountFunctionNames) {
+function useExpenseAccountContractWrite<F extends ExpenseAccountFunctionNames>(functionName: F) {
   const teamStore = useTeamStore()
   const contractAddress = computed(() => teamStore.getContractAddressByType('ExpenseAccountEIP712'))
   return useContractWritesV3({

--- a/app/src/composables/fixedReturn/writes.ts
+++ b/app/src/composables/fixedReturn/writes.ts
@@ -7,7 +7,7 @@ import { useFixedReturnAddress } from './reads'
 /** State-changing names only. */
 type FixedReturnWriteNames = ContractFunctionName<typeof fixedReturnAbi, 'nonpayable' | 'payable'>
 
-function useFixedReturnContractWrite(functionName: FixedReturnWriteNames) {
+function useFixedReturnContractWrite<F extends FixedReturnWriteNames>(functionName: F) {
   const fixedReturnAddress = useFixedReturnAddress()
   return useContractWritesV3({
     contractAddress: computed(() => fixedReturnAddress.value ?? undefined),

--- a/app/src/composables/investor/writes.ts
+++ b/app/src/composables/investor/writes.ts
@@ -1,12 +1,14 @@
 import { computed } from 'vue'
 import { investorAbi } from '@/artifacts/abi/generated'
-import { useContractWritesV3 } from '@/composables/contracts/useContractWritesV3'
+import {
+  useContractWritesV3,
+  type WriteFunctionName
+} from '@/composables/contracts/useContractWritesV3'
 import { useTeamStore } from '@/stores/teamStore'
-import type { ExtractAbiFunctionNames } from 'abitype'
 
-type InvestorFunctionNames = ExtractAbiFunctionNames<typeof investorAbi>
+type InvestorFunctionNames = WriteFunctionName<typeof investorAbi>
 
-function useInvestorContractWrite(functionName: InvestorFunctionNames) {
+function useInvestorContractWrite<F extends InvestorFunctionNames>(functionName: F) {
   const teamStore = useTeamStore()
   const contractAddress = computed(() => teamStore.getInvestorAddress())
   return useContractWritesV3({

--- a/app/src/composables/proposals/writes.ts
+++ b/app/src/composables/proposals/writes.ts
@@ -1,12 +1,14 @@
 import { computed } from 'vue'
-import type { ExtractAbiFunctionNames } from 'abitype'
 import { proposalsAbi } from '@/artifacts/abi/generated'
-import { useContractWritesV3 } from '@/composables/contracts/useContractWritesV3'
+import {
+  useContractWritesV3,
+  type WriteFunctionName
+} from '@/composables/contracts/useContractWritesV3'
 import { useTeamStore } from '@/stores/teamStore'
 
-type ProposalsFunctionNames = ExtractAbiFunctionNames<typeof proposalsAbi>
+type ProposalsFunctionNames = WriteFunctionName<typeof proposalsAbi>
 
-function useProposalsContractWrite(functionName: ProposalsFunctionNames) {
+function useProposalsContractWrite<F extends ProposalsFunctionNames>(functionName: F) {
   const teamStore = useTeamStore()
   const contractAddress = computed(() => teamStore.getContractAddressByType('Proposals'))
   return useContractWritesV3({

--- a/app/src/composables/safeDepositRouter/writes.ts
+++ b/app/src/composables/safeDepositRouter/writes.ts
@@ -1,13 +1,17 @@
 import { computed } from 'vue'
 import { useQueryClient } from '@tanstack/vue-query'
 import { safeDepositRouterAbi } from '@/artifacts/abi/generated'
-import { useContractWritesV3 } from '@/composables/contracts/useContractWritesV3'
+import {
+  useContractWritesV3,
+  type WriteFunctionName
+} from '@/composables/contracts/useContractWritesV3'
 import { useTeamStore } from '@/stores/teamStore'
-import type { ExtractAbiFunctionNames } from 'abitype'
 
-type SafeDepositRouterFunctionNames = ExtractAbiFunctionNames<typeof safeDepositRouterAbi>
+type SafeDepositRouterFunctionNames = WriteFunctionName<typeof safeDepositRouterAbi>
 
-function useSafeDepositRouterContractWrite(functionName: SafeDepositRouterFunctionNames) {
+function useSafeDepositRouterContractWrite<F extends SafeDepositRouterFunctionNames>(
+  functionName: F
+) {
   const teamStore = useTeamStore()
   const contractAddress = computed(() => teamStore.getContractAddressByType('SafeDepositRouter'))
   return useContractWritesV3({

--- a/app/src/composables/vesting/writes.ts
+++ b/app/src/composables/vesting/writes.ts
@@ -1,12 +1,14 @@
 import { computed } from 'vue'
-import type { ExtractAbiFunctionNames } from 'abitype'
 import { vestingAbi } from '@/artifacts/abi/generated'
-import { useContractWritesV3 } from '@/composables/contracts/useContractWritesV3'
+import {
+  useContractWritesV3,
+  type WriteFunctionName
+} from '@/composables/contracts/useContractWritesV3'
 import { useVestingAddress } from './reads'
 
-type VestingFunctionNames = ExtractAbiFunctionNames<typeof vestingAbi>
+type VestingFunctionNames = WriteFunctionName<typeof vestingAbi>
 
-function useVestingContractWrite(functionName: VestingFunctionNames) {
+function useVestingContractWrite<F extends VestingFunctionNames>(functionName: F) {
   const vestingAddress = useVestingAddress()
   return useContractWritesV3({
     contractAddress: computed(() => vestingAddress.value ?? undefined),


### PR DESCRIPTION
# Description

## Intial Issue Description

Fixes #2399 — follow-up to #2392, which generated the ABIs `as const` but left the write path
untyped.

`useContractWritesV3` widened `abi` to `Abi` and declared `args?: readonly unknown[]`, so a wrong
argument order, a `string` where the ABI says `uint256`, or a missing argument all compiled and
failed at simulation time — when the user clicks. Reads were already fully typed; they only needed
the `as const` ABIs.

## Issues introduced and fixed

The new typing surfaced two real defects, both committed **before** the refactor so every commit is
independently green:

**`b17e423a7` — `BoardOfDirectors.addAction` could be called with undefined arguments.**
`executeAddAction` took `Partial<Action>`, so `targetAddress` / `description` / `data` were
optional, and the args tuple was cast to `readonly unknown[]`. I checked what viem actually does
here: `encodeFunctionData` **encodes `undefined` rather than throwing**, so an incomplete call would
have submitted a governance action with an empty target and payload, silently, instead of failing.
All four call sites already pass the three fields.

**`79261092a` — `Elections.createElection` received `number` for `uint256` params.** Also checked:
viem accepts numbers for uint types, so this was not broken in production — but it silently loses
precision above 2^53, and it is what forced the `as readonly unknown[]` cast on the args array.

## PR Summary Or Solution description

**`2699d1445`** makes `useContractWritesV3` generic over `abi` and `functionName`, so viem resolves
`args: ContractFunctionArgs<abi, 'nonpayable' | 'payable', fn>`.

`abi` and `functionName` become plain values rather than `MaybeRef`. That is the trade that buys the
typing: a reactive `functionName` makes the arg derivation the union of every function's tuple,
which constrains nothing. `contractAddress` and `chainId` stay reactive — neither feeds the arg
types — and no call site passed a ref for either narrowed field.

**The one apparently dynamic ABI was not dynamic.** `MainContractActions.vue` did
`computed(() => props.row.abi as Abi)`, but `getTeamContracts` sets `abi: ownablePausableAbi` on
every row — so it was that single ABI laundered through an untyped `TableRow` (`Record<string, any>`)
and re-widened. It now imports the ABI directly, and the escape hatch I expected to need doesn't
exist.

Per-domain factories become generic pass-throughs using the exported `WriteFunctionName<abi>`, which
also makes their function-name check real for the first time: `ExtractAbiFunctionNames<Abi>` resolves
to `string`, so before #2392 `useBankContractWrite('anythingAtAll')` type-checked.
`elections/writes.ts` was additionally constraining on `ElectionsFunctionName`, which covers reads.

`WriteFunctionName` and `WriteFunctionArgs` are exported for helpers that forward args;
`TransferAction.vue`'s `submitExpenseAccountTransfer` is the first user.

## Notes for the reviewer

- **One deliberate cast remains**, in `useContractWritesV3`'s `mutationFn`: `executeContractWrite` is
  the framework-agnostic escape hatch and stays loosely typed, so the tuple is widened at that
  boundary after being validated against the ABI above it.
- **`develop` is currently red** — 5 unit tests fail in
  `CommunityCreditView/__tests__/CreditCallTermsStep.spec.ts` and
  `CommunityCredit/__tests__/NewView.spec.ts`. I verified this on a clean `develop` by stashing;
  they are not from this PR and I have not touched them. They go unnoticed because `app-unit-test`
  is not a required check on develop — only `codecov/patch` and `codecov/project` are.
- **Still open after this PR:** the three read helpers in `composables/fixedReturn/reads.ts` take a
  non-generic `functionName`, so their return type degrades to the union of every view function's
  return. One line each; tracked in #2399.

## Verification

- `npm run type-check` — 0 errors.
- `npm run test:unit` — 2608 pass, 5 fail (the pre-existing `develop` failures above; no new ones).
- `npm run lint` and `npm run format-check` — clean.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features) — the guarantees here are
      compile-time; the existing suite covers the touched call sites
- [x] Docs have been added / updated (for bug fixes / features) — `composables/contracts/README.md`
      said `args` was "**not** structurally validated"; that paragraph is now the opposite
