### PR TITLE
fix: 🐛 pre-fill the Community Credit deadline relative to today

### DIFF
--- a/app/src/components/sections/CommunityCreditView/__tests__/CreditCallTermsStep.spec.ts
+++ b/app/src/components/sections/CommunityCreditView/__tests__/CreditCallTermsStep.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { reactive } from 'vue'
 import { Time } from '@internationalized/date'
@@ -30,6 +30,18 @@ function makeForm(overrides: Partial<CreditCallForm> = {}): CreditCallForm {
 function mountStep(form: CreditCallForm) {
   return mount(CreditCallTermsStep, { props: { form } })
 }
+
+// The fixture deadline is fixed (several tests assert calendar arithmetic off it)
+// while the schema compares it against the real clock, so the suite silently
+// expired the day the wall clock passed it. Pin "now" ahead of the deadline
+// instead of bumping the date, which would only re-arm the same trap.
+beforeAll(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-07-01T09:00:00Z'))
+})
+afterAll(() => {
+  vi.useRealTimers()
+})
 
 describe('CreditCallTermsStep', () => {
   it('selects a preset term and stays in preset mode', async () => {

--- a/app/src/utils/__tests__/communityCreditWizardUtil.spec.ts
+++ b/app/src/utils/__tests__/communityCreditWizardUtil.spec.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  createCreditCallTermsSchema,
+  type CreditCallTermsSchemaContext
+} from '@/types/communityCredit.schemas'
+import {
+  createDefaultCreditCallForm,
+  creditCallDeadlineContext,
+  DEFAULT_CREDIT_DEADLINE_DAYS
+} from '@/utils/communityCreditWizardUtil'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function at(iso: string) {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(iso))
+}
+
+describe('createDefaultCreditCallForm', () => {
+  // Regression guard: the default deadline used to be the hard-coded `2026-07-31`,
+  // so from 2026-08-01 every issuer opening the wizard got a deadline already in the
+  // past and could not publish. A date-independent assertion is the point here — any
+  // fixed expectation would re-arm the same trap.
+  it.each([
+    ['2026-08-01T00:00:00Z', 'the day the old hard-coded default expired'],
+    ['2030-01-15T12:00:00Z', 'far in the future'],
+    ['2026-12-31T23:59:00Z', 'across a year boundary']
+  ])('pre-fills a deadline that passes validation at %s (%s)', (iso) => {
+    at(iso)
+
+    const form = createDefaultCreditCallForm()
+    const context: CreditCallTermsSchemaContext = creditCallDeadlineContext()
+    const result = createCreditCallTermsSchema(context).safeParse({
+      rate: form.rate,
+      deadline: form.deadline,
+      deadlineTime: form.deadlineTime,
+      period: form.period
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it(`sets the deadline ${DEFAULT_CREDIT_DEADLINE_DAYS} days out`, () => {
+    at('2026-08-01T00:00:00Z')
+
+    const expected = new Date(
+      Date.UTC(2026, 7, 1) + DEFAULT_CREDIT_DEADLINE_DAYS * 24 * 60 * 60 * 1000
+    )
+      .toISOString()
+      .slice(0, 10)
+
+    expect(createDefaultCreditCallForm().deadline).toBe(expected)
+  })
+})

--- a/app/src/utils/communityCreditWizardUtil.ts
+++ b/app/src/utils/communityCreditWizardUtil.ts
@@ -51,9 +51,19 @@ export function creditCallDeadlineContext(): { today: string; now: Date } {
   return { today: now.toISOString().slice(0, 10), now }
 }
 
+/** How far ahead of today a brand-new wizard form pre-fills the subscription
+ *  deadline. Long enough for the issuer to circulate the round before it closes. */
+export const DEFAULT_CREDIT_DEADLINE_DAYS = 30
+
 /** Default field values for a brand-new Community Credit wizard form — pulled out of
- *  NewView.vue so the component doesn't have to inline the whole literal. */
+ *  NewView.vue so the component doesn't have to inline the whole literal.
+ *
+ *  The deadline is relative to today. It used to be the hard-coded date
+ *  `2026-07-31`, which meant that from 2026-08-01 every issuer opening the wizard
+ *  got a default deadline already in the past and could not publish without
+ *  noticing and editing the field. Any fixed date re-arms that trap. */
 export function createDefaultCreditCallForm(): CreditCallForm {
+  const deadline = new Date(Date.now() + DEFAULT_CREDIT_DEADLINE_DAYS * 24 * 60 * 60 * 1000)
   return {
     name: '',
     desc: '',
@@ -64,7 +74,7 @@ export function createDefaultCreditCallForm(): CreditCallForm {
     periodMode: 'preset',
     periodVal: '90',
     periodUnit: 'days',
-    deadline: '2026-07-31',
+    deadline: deadline.toISOString().slice(0, 10),
     deadlineTime: '23:59',
     access: 'everyone',
     whitelist: [],


### PR DESCRIPTION
# Description

## Intial Issue Description

Fixes #2401

`createDefaultCreditCallForm` hard-coded `deadline: '2026-07-31'`. Since **2026-08-01**, every issuer
opening the new-credit-call wizard gets a default subscription deadline already in the past: the
Terms step refuses to advance ("Subscription deadline cannot be in the past") and publishing is
blocked until the issuer notices the pre-filled field and edits it by hand. The wizard looks broken
on first use.

## Issues introduced and fixed

Found while investigating why `app-unit-test` was red on #2400. Five tests have been failing on
`develop` since the same date and were correctly reporting this — I first assumed expired test
fixtures, but the fixture mirrors the product default and both expired together. The product default
is the actual bug.

## PR Summary Or Solution description

**`3d6e501b3`** — the default deadline becomes today + 30 days
(`DEFAULT_CREDIT_DEADLINE_DAYS`). The new spec validates the default form against the *real*
`createCreditCallTermsSchema` at several simulated dates, including 2026-08-01. It deliberately
asserts "the default passes validation" rather than "the default equals date X" — a fixed expected
value would re-arm exactly the trap being fixed.

**`0715e2b5b`** — `CreditCallTermsStep.spec.ts` keeps its fixed fixture deadline on purpose (several
tests assert calendar arithmetic off that exact date) while the schema compares it to the real clock,
so its clock is pinned ahead of the fixture rather than the date bumped.

## Notes for the reviewer

- **Why 30 days:** long enough to circulate a round before it closes, and it matches the 90-day
  default term already in the same form. Happy to change it — it is one constant.
- **The unit suite is not a required check on `develop`** (only `codecov/patch` and
  `codecov/project` are), which is why a live wizard bug sat behind a red suite unnoticed. Worth
  deciding separately whether to require it; I have not changed any branch protection here.
- This branches from `develop` and is independent of #2400, which is red for exactly these five
  tests and will go green once this lands.

## Verification

- `npm run test:unit` — 2617 pass, **0 fail** (was 5 failing on `develop` before this branch).
- `npm run type-check`, `npm run lint`, `npm run format-check` — clean.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features) — n/a, behaviour of a default value
