### PR TITLE
refactor: ♻️ drive useContractBalance from TanStack Query and wagmi core

### DIFF
--- a/app/src/components/GenericTokenHoldingsSection.vue
+++ b/app/src/components/GenericTokenHoldingsSection.vue
@@ -3,20 +3,7 @@
   <UCard>
     <template #header>Token Holding</template>
     <UTable
-      :data="
-        balances.map((balance, index) => ({
-          ...balance,
-          rank: index + 1,
-          icon:
-            balance.token.symbol === 'USDC' || balance.token.symbol === 'USDCe'
-              ? USDCIcon
-              : balance.token.symbol === 'POL'
-                ? MaticIcon
-                : balance.token.symbol === 'ETH'
-                  ? EthereumIcon
-                  : null
-        }))
-      "
+      :data="rows"
       :loading="isLoading"
       :columns="[
         { accessorKey: 'rank', header: 'RANK' },
@@ -30,11 +17,11 @@
         {{ row.amount }} {{ row.token.symbol }}
       </template>
       <template #price-cell="{ row: { original: row } }">
-        {{ row.values[currency.code ?? 'USD']?.formatedPrice }} / {{ row.token.symbol }}
+        {{ row.priceLabel }} / {{ row.token.symbol }}
       </template>
 
       <template #balance-cell="{ row: { original: row } }">
-        {{ row.values[currency.code ?? 'USD']?.formated }}
+        {{ row.balanceLabel }}
       </template>
 
       <template #token-cell="{ row: { original: row } }">
@@ -57,22 +44,38 @@
 import EthereumIcon from '@/assets/Ethereum.png'
 import USDCIcon from '@/assets/usdc.png'
 import MaticIcon from '@/assets/matic-logo.png'
+import { computed } from 'vue'
 import { useContractBalance } from '@/composables'
-import { useStorage } from '@vueuse/core'
 import type { Address } from 'viem'
 
 const props = defineProps<{
   address: Address
 }>()
 
-// const teamStore = useTeamStore()
-// const currencyStore = useCurrencyStore()
-
-const currency = useStorage('currency', {
-  code: 'USD',
-  name: 'US Dollar',
-  symbol: '$'
-})
 // Reactive state for balances: composable that fetches address balances
-const { balances, isLoading } = useContractBalance(props.address as Address)
+const { data: balance, isLoading } = useContractBalance(props.address as Address)
+
+const iconFor = (symbol: string) => {
+  if (symbol === 'USDC' || symbol === 'USDCe') return USDCIcon
+  if (symbol === 'POL') return MaticIcon
+  if (symbol === 'ETH') return EthereumIcon
+  return null
+}
+
+/**
+ * `price` and `balance` are flattened to plain numbers because the table sorts
+ * on the accessor value, and a `CurrencyPair` object would not compare. The
+ * display strings ride alongside as `*Label`.
+ */
+const rows = computed(() =>
+  (balance.value?.balances ?? []).map((entry, index) => ({
+    ...entry,
+    rank: index + 1,
+    icon: iconFor(entry.token.symbol),
+    price: entry.price.local.value,
+    priceLabel: entry.price.local.formatted,
+    balance: entry.value.local.value,
+    balanceLabel: entry.value.local.formatted
+  }))
+)
 </script>

--- a/app/src/components/forms/DepositBankForm.vue
+++ b/app/src/components/forms/DepositBankForm.vue
@@ -71,7 +71,7 @@ import { ref, computed } from 'vue'
 import TeamArchivedTooltip from '@/components/TeamArchivedTooltip.vue'
 import { z } from 'zod'
 import { parseEther, zeroAddress, type Address } from 'viem'
-import { useContractBalance } from '@/composables/useContractBalance'
+import { useContractBalance, contractBalanceKeys } from '@/composables/useContractBalance'
 import { useSafeSendTransaction } from '@/composables/transactions/useSafeSendTransaction'
 import { useERC20Approve } from '@/composables/erc20/writes'
 import { useErc20Allowance } from '@/composables/erc20/reads'
@@ -130,7 +130,8 @@ const userDataStore = useUserDataStore()
 const toast = useToast()
 
 // Reactive state for balances
-const { balances, isLoading } = useContractBalance(userDataStore.address as Address)
+const { data: balance, isLoading } = useContractBalance(userDataStore.address as Address)
+const balances = computed(() => balance.value?.balances ?? [])
 
 // Native token deposit using safe transaction handler
 const nativeDeposit = useSafeSendTransaction({
@@ -235,20 +236,12 @@ const submitForm = async () => {
         args: [selectedTokenAddress.value, bigIntAmount.value]
       })
 
-      const invalidateErc20Balance = (tokenAddress: Address, target: Address) =>
-        queryClient.invalidateQueries({
-          queryKey: [
-            'readContract',
-            {
-              address: tokenAddress,
-              chainId,
-              functionName: 'balanceOf',
-              args: [target]
-            }
-          ]
-        })
-
-      invalidateErc20Balance(selectedTokenAddress.value, props.bankAddress)
+      // The Bank's native and ERC-20 amounts share one query per contract, so
+      // one key refreshes what the deposit changed. `chainId` is a ref — it has
+      // to be unwrapped, or the key never matches anything.
+      await queryClient.invalidateQueries({
+        queryKey: contractBalanceKeys.detail(props.bankAddress, chainId.value)
+      })
 
       submitting.value = false
       amount.value = ''

--- a/app/src/components/forms/DepositSafeForm.vue
+++ b/app/src/components/forms/DepositSafeForm.vue
@@ -65,7 +65,7 @@ import { ref, computed } from 'vue'
 import TeamArchivedTooltip from '@/components/TeamArchivedTooltip.vue'
 import { z } from 'zod'
 import { parseEther, zeroAddress, type Address } from 'viem'
-import { useContractBalance } from '@/composables/useContractBalance'
+import { useContractBalance, contractBalanceKeys } from '@/composables/useContractBalance'
 import { useSafeSendTransaction } from '@/composables/transactions/useSafeSendTransaction'
 import { useERC20Approve, useERC20Transfer } from '@/composables/erc20/writes'
 import { useErc20Allowance } from '@/composables/erc20/reads'
@@ -142,7 +142,8 @@ const errorMessage = computed(() => {
 })
 
 // Reactive state for balances
-const { balances, isLoading } = useContractBalance(userDataStore.address as Address)
+const { data: balance, isLoading } = useContractBalance(userDataStore.address as Address)
+const balances = computed(() => balance.value?.balances ?? [])
 
 // Native token deposit using safe transaction handler
 const nativeDeposit = useSafeSendTransaction({
@@ -230,10 +231,11 @@ const submitForm = async () => {
         args: [props.safeAddress, bigIntAmount.value]
       })
 
-      // V3 invalidates `readContract` queries on the token address; the
-      // Safe's native balance lives on a separate key, so invalidate it here.
+      // V3 invalidates `readContract` queries on the token address; the Safe's
+      // own token balances live on their own key, so invalidate it here.
+      // `chainId` is a ref — it has to be unwrapped, or the key never matches.
       await queryClient.invalidateQueries({
-        queryKey: ['balance', { address: props.safeAddress, chainId }]
+        queryKey: contractBalanceKeys.detail(props.safeAddress, chainId.value)
       })
 
       submitting.value = false

--- a/app/src/components/forms/SafeDepositRouterForm.vue
+++ b/app/src/components/forms/SafeDepositRouterForm.vue
@@ -136,9 +136,10 @@ const formattedMultiplier = computed(() =>
 
 const multiplierNumber = computed(() => parseFloat(formattedMultiplier.value) || 0)
 
-const { balances, isLoading: isBalanceLoading } = useContractBalance(
+const { data: balance, isLoading: isBalanceLoading } = useContractBalance(
   userDataStore.address as Address
 )
+const balances = computed(() => balance.value?.balances ?? [])
 
 const ROUTER_SUPPORTED_TOKENS: TokenId[] = ['usdc']
 

--- a/app/src/components/forms/TransferModal.vue
+++ b/app/src/components/forms/TransferModal.vue
@@ -61,7 +61,7 @@ import { useOfficerFeeBps } from '@/composables/officer/reads'
 import { useTransfer, useTransferToken } from '@/composables/bank/writes'
 import { classifyError, log } from '@/utils'
 import type { TokenOption } from '@/types'
-import { useContractBalance } from '@/composables'
+import { useContractBalance, contractBalanceKeys } from '@/composables'
 
 interface Props {
   bankAddress: Address
@@ -73,7 +73,8 @@ const chainId = useChainId()
 const queryClient = useQueryClient()
 const toast = useToast()
 
-const { balances } = useContractBalance(props.bankAddress)
+const { data: balance } = useContractBalance(props.bankAddress)
+const balances = computed(() => balance.value?.balances ?? [])
 
 const userStore = useUserDataStore()
 
@@ -120,7 +121,7 @@ const getTokens = (): TokenOption[] =>
       symbol: b.token.symbol,
       balance: b.amount,
       tokenId: b.token.id,
-      price: b.values['USD']?.price ?? 0,
+      price: b.price.usd.value,
       name: b.token.name,
       code: b.token.code
     }))
@@ -218,17 +219,11 @@ const handleTransfer = async (data: {
   const onSuccess = async () => {
     toast.add({ title: 'Transferred successfully', color: 'success' })
 
-    const queryKey = isNativeToken
-      ? ['balance', { address: props.bankAddress, chainId: chainId.value }]
-      : [
-          'readContract',
-          {
-            address: tokenAddress,
-            args: [props.bankAddress],
-            chainId: chainId.value
-          }
-        ]
-    await queryClient.invalidateQueries({ queryKey })
+    // Native and ERC-20 amounts share one query per contract, so both transfer
+    // paths refresh through the same key.
+    await queryClient.invalidateQueries({
+      queryKey: contractBalanceKeys.detail(props.bankAddress, chainId.value)
+    })
 
     resetTransferValues()
   }

--- a/app/src/components/forms/__tests__/SafeDepositRouterForm.spec.ts
+++ b/app/src/components/forms/__tests__/SafeDepositRouterForm.spec.ts
@@ -9,7 +9,8 @@ import {
   mockSafeDepositRouterAddress,
   mockSafeDepositRouterReads,
   mockSafeDepositRouterWrites,
-  mockInvestorReads
+  mockInvestorReads,
+  makeTokenBalance
 } from '@/tests/mocks'
 
 type MutateOptions = {
@@ -66,8 +67,9 @@ describe('SafeDepositRouterForm.vue', () => {
     vi.clearAllMocks()
     mockInvestorReads.symbol.data.value = 'SHER'
     mockUseContractBalance.balances.value = [
-      {
+      makeTokenBalance({
         amount: 50,
+        usdPrice: 1,
         token: {
           id: 'usdc',
           name: 'USD Coin',
@@ -76,19 +78,8 @@ describe('SafeDepositRouterForm.vue', () => {
           coingeckoId: 'usd-coin',
           decimals: 6,
           address: '0xA3492D046095AFFE351cFac15de9b86425E235dB'
-        },
-        values: {
-          USD: {
-            value: 50,
-            formated: '$50',
-            id: 'usd',
-            code: 'USD',
-            symbol: '$',
-            price: 1,
-            formatedPrice: '$1'
-          }
         }
-      }
+      })
     ]
     mockERC20Reads.allowance.data.value = 0n
   })

--- a/app/src/components/forms/__tests__/TransferModal.spec.ts
+++ b/app/src/components/forms/__tests__/TransferModal.spec.ts
@@ -10,8 +10,11 @@ import {
   mockUserStore,
   mockUseContractBalance,
   mockBankWrites,
-  useQueryClientFn
+  useQueryClientFn,
+  makeTokenBalance,
+  mockUseChainId
 } from '@/tests/mocks'
+import { contractBalanceKeys } from '@/composables/useContractBalance'
 
 vi.mock('@/artifacts/abi/bank', () => ({
   BANK_ABI: [
@@ -47,20 +50,18 @@ describe('TransferModal', () => {
   const mockRecipientAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as const
 
   const setBalances = (balances?: Array<Record<string, unknown>>) => {
-    mockUseContractBalance.balances.value =
-      (balances as never) ??
-      ([
-        {
-          token: { id: 'native', symbol: NETWORK.currencySymbol, name: 'Native', code: 'ETH' },
-          amount: 10,
-          values: { USD: { price: 2000 } }
-        },
-        {
-          token: { id: 'usdc', symbol: 'USDC', name: 'USD Coin', code: 'USDC' },
-          amount: 5000,
-          values: { USD: { price: 1 } }
-        }
-      ] as never)
+    mockUseContractBalance.balances.value = (balances as never) ?? [
+      makeTokenBalance({
+        token: { id: 'native', symbol: NETWORK.currencySymbol, name: 'Native', code: 'ETH' },
+        amount: 10,
+        usdPrice: 2000
+      }),
+      makeTokenBalance({
+        token: { id: 'usdc', symbol: 'USDC', name: 'USD Coin', code: 'USDC', decimals: 6 },
+        amount: 5000,
+        usdPrice: 1
+      })
+    ]
   }
 
   const createQueryClient = () => {
@@ -222,7 +223,7 @@ describe('TransferModal', () => {
     expect(mockBankWrites.transferToken.mutate).not.toHaveBeenCalled()
   })
 
-  it('handles direct token transfers and invalidates the token balance query', async () => {
+  it('handles direct token transfers and invalidates the contract balance query', async () => {
     const { invalidateQueries } = createQueryClient()
     wrapper = mountComponent()
     await openModal(wrapper)
@@ -234,9 +235,11 @@ describe('TransferModal', () => {
     })
 
     expect(mockBankWrites.transferToken.mutate).toHaveBeenCalledOnce()
-    expect(invalidateQueries).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: expect.arrayContaining(['readContract']) })
-    )
+    // Native and ERC-20 amounts live on one key per contract, so the ERC-20
+    // path refreshes the Bank's balance query rather than a per-token read.
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: contractBalanceKeys.detail(mockBankAddress, mockUseChainId.value)
+    })
   })
 
   it('handles direct native transfers and surfaces errors from the mutation', async () => {

--- a/app/src/components/sections/BankView/BankBalanceSection.vue
+++ b/app/src/components/sections/BankView/BankBalanceSection.vue
@@ -11,13 +11,13 @@
           <span class="text-4xl font-bold">
             <span class="inline-block h-10 min-w-16">
               <USkeleton v-if="isLoading" class="h-10 w-16" data-test="loading-spinner" />
-              <span v-else>{{ total['USD']?.formated ?? 0 }}</span>
+              <span v-else>{{ balance?.total.usd.formatted ?? 0 }}</span>
             </span>
           </span>
           <span class="text-gray-600">USD</span>
         </div>
         <div class="mt-1 text-sm text-gray-500">
-          ≈ {{ total[currency.code]?.formated ?? 0 }} {{ currency.code }}
+          ≈ {{ balance?.total.local.formatted ?? 0 }} {{ currency.code }}
         </div>
       </div>
       <div class="flex flex-col items-end gap-4">
@@ -53,5 +53,5 @@ const currency = useStorage('currency', {
 })
 
 // Use the contract balance composable
-const { total, isLoading } = useContractBalance(props.bankAddress)
+const { data: balance, isLoading } = useContractBalance(props.bankAddress)
 </script>

--- a/app/src/components/sections/BankView/__tests__/BankBalanceSection.spec.ts
+++ b/app/src/components/sections/BankView/__tests__/BankBalanceSection.spec.ts
@@ -19,15 +19,8 @@ vi.mock('@iconify/vue', () => ({
 }))
 
 const baseTotal = {
-  USD: {
-    value: 50500,
-    formated: '$50.5K',
-    id: 'usd',
-    code: 'USD',
-    symbol: '$',
-    price: 1000,
-    formatedPrice: '$1K'
-  }
+  usd: { value: 50500, formatted: '$50.5K' },
+  local: { value: 50500, formatted: '$50.5K' }
 }
 
 describe('BankBalanceSection', () => {
@@ -50,15 +43,17 @@ describe('BankBalanceSection', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUseContractBalance.total.value = {
-      USD: { ...baseTotal.USD }
+      usd: { ...baseTotal.usd },
+      local: { ...baseTotal.local }
     }
+    mockUseContractBalance.hasData.value = true
     mockUseContractBalance.isLoading.value = false
   })
 
   it('renders total balance', () => {
     const wrapper = createWrapper()
 
-    expect(wrapper.text()).toContain(mockUseContractBalance.total.value.USD.formated)
+    expect(wrapper.text()).toContain(mockUseContractBalance.total.value.usd.formatted)
     expect(wrapper.text()).toContain('USD')
   })
 

--- a/app/src/components/sections/CashRemunerationView/CashRemunerationTotalBalance.vue
+++ b/app/src/components/sections/CashRemunerationView/CashRemunerationTotalBalance.vue
@@ -1,6 +1,6 @@
 <template>
   <OverviewCard
-    :title="total[currency.code]?.formated ?? 0"
+    :title="balance?.total.local.formatted ?? 0"
     variant="success"
     subtitle="Total Balance"
     :card-icon="bagIcon"
@@ -21,16 +21,12 @@ import uptrendIcon from '@/assets/uptrend.svg'
 import OverviewCard from '@/components/OverviewCard.vue'
 import { useContractBalance } from '@/composables/useContractBalance'
 import { useTeamStore } from '@/stores'
-import { useStorage } from '@vueuse/core'
 import type { Address } from 'viem'
 
-const currency = useStorage('currency', {
-  code: 'USD',
-  name: 'US Dollar',
-  symbol: '$'
-})
 const teamStore = useTeamStore()
 
 const contractAddress = teamStore.getContractAddressByType('CashRemunerationEIP712')
-const { isLoading: isLoadingBalance, total } = useContractBalance(contractAddress as Address)
+const { isLoading: isLoadingBalance, data: balance } = useContractBalance(
+  contractAddress as Address
+)
 </script>

--- a/app/src/components/sections/CashRemunerationView/__tests__/CashRemunerationTotalBalance.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/__tests__/CashRemunerationTotalBalance.spec.ts
@@ -7,16 +7,10 @@ import { mockUseContractBalance } from '@/tests/mocks/composables.mock'
 describe('CashRemunerationTotalBalance', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseContractBalance.hasData.value = true
     mockUseContractBalance.total.value = {
-      USD: {
-        value: 50500,
-        formated: '$50.5K',
-        id: 'usd',
-        code: 'USD',
-        symbol: '$',
-        price: 1000,
-        formatedPrice: '$1K'
-      }
+      usd: { value: 50500, formatted: '$50.5K' },
+      local: { value: 50500, formatted: '$50.5K' }
     }
   })
 
@@ -39,18 +33,8 @@ describe('CashRemunerationTotalBalance', () => {
     expect(card.props('title')).toBe('$50.5K')
   })
 
-  it('should fall back to 0 when current currency total does not exist', () => {
-    mockUseContractBalance.total.value = {
-      EUR: {
-        value: 100,
-        formated: 'EUR 100',
-        id: 'eur',
-        code: 'EUR',
-        symbol: '€',
-        price: 1,
-        formatedPrice: '€1'
-      }
-    }
+  it('should fall back to 0 before the first balance read lands', () => {
+    mockUseContractBalance.hasData.value = false
 
     const wrapper = createComponent()
     const card = wrapper.findComponent({ name: 'OverviewCard' })

--- a/app/src/components/sections/CommunityCreditView/CreditBalanceSection.vue
+++ b/app/src/components/sections/CommunityCreditView/CreditBalanceSection.vue
@@ -10,13 +10,13 @@
           <span class="text-4xl font-bold">
             <span class="inline-block h-10 min-w-16">
               <USkeleton v-if="isLoading" class="h-10 w-16" data-test="loading-spinner" />
-              <span v-else>{{ total['USD']?.formated ?? 0 }}</span>
+              <span v-else>{{ balance?.total.usd.formatted ?? 0 }}</span>
             </span>
           </span>
           <span class="text-gray-600">USD</span>
         </div>
         <div class="mt-1 text-sm text-gray-500">
-          ≈ {{ total[currency.code]?.formated ?? 0 }} {{ currency.code }}
+          ≈ {{ balance?.total.local.formatted ?? 0 }} {{ currency.code }}
         </div>
       </div>
       <div v-if="fixedReturnAddress" class="flex items-center gap-2">
@@ -41,5 +41,5 @@ const currency = useStorage('currency', {
   symbol: '$'
 })
 
-const { total, isLoading } = useContractBalance(fixedReturnAddress)
+const { data: balance, isLoading } = useContractBalance(fixedReturnAddress)
 </script>

--- a/app/src/components/sections/ContractManagementView/MainContractBalanceCell.vue
+++ b/app/src/components/sections/ContractManagementView/MainContractBalanceCell.vue
@@ -7,13 +7,10 @@
 import { computed, toRef } from 'vue'
 import type { Address } from 'viem'
 import { useContractBalance } from '@/composables/useContractBalance'
-import { useCurrencyStore } from '@/stores'
 
 const props = defineProps<{ address: Address }>()
 
-const currencyStore = useCurrencyStore()
-const { total, isLoading } = useContractBalance(toRef(props, 'address'))
+const { data: balance, isLoading } = useContractBalance(toRef(props, 'address'))
 
-const currencyCode = computed(() => currencyStore.localCurrency.code)
-const formatted = computed(() => total.value[currencyCode.value]?.formated ?? '$0.00')
+const formatted = computed(() => balance.value?.total.local.formatted ?? '$0.00')
 </script>

--- a/app/src/components/sections/DashboardView/CashOutAllAction.vue
+++ b/app/src/components/sections/DashboardView/CashOutAllAction.vue
@@ -168,9 +168,9 @@ const { data: bankOwner } = useBankOwner()
 
 const currencyCode = computed(() => currencyStore.localCurrency.code)
 const fiat = (balance: ReturnType<typeof useContractBalance>) =>
-  balance.total.value[currencyCode.value]?.value ?? 0
+  balance.data.value?.total.local.value ?? 0
 const fiatFormatted = (balance: ReturnType<typeof useContractBalance>) =>
-  balance.total.value[currencyCode.value]?.formated ?? '—'
+  balance.data.value?.total.local.formatted ?? '—'
 
 const isOwner = computed(() => {
   if (!bankOwner.value || !userStore.address) return false

--- a/app/src/components/sections/DashboardView/CompanyOverview.vue
+++ b/app/src/components/sections/DashboardView/CompanyOverview.vue
@@ -145,8 +145,6 @@ const safeBalance = useContractBalance(safeAddress as unknown as Address)
 const expenseBalance = useContractBalance(expenseAddress as unknown as Address)
 const cashRemBalance = useContractBalance(cashRemAddress as unknown as Address)
 
-const currencyCode = computed(() => currencyStore.localCurrency.code)
-
 const isLoadingBalances = computed(
   () =>
     bankBalance.isLoading.value ||
@@ -156,11 +154,11 @@ const isLoadingBalances = computed(
 )
 
 function getFormattedTotal(balance: ReturnType<typeof useContractBalance>) {
-  return balance.total.value[currencyCode.value]?.formated ?? '$0.00'
+  return balance.data.value?.total.local.formatted ?? '$0.00'
 }
 
 function getRawTotal(balance: ReturnType<typeof useContractBalance>) {
-  return balance.total.value[currencyCode.value]?.value ?? 0
+  return balance.data.value?.total.local.value ?? 0
 }
 
 const totalBalance = computed(() => {

--- a/app/src/components/sections/DashboardView/__tests__/CashOutAllAction.spec.ts
+++ b/app/src/components/sections/DashboardView/__tests__/CashOutAllAction.spec.ts
@@ -72,7 +72,10 @@ describe('CashOutAllAction', () => {
   })
 
   it('disables the button when every account is empty', () => {
-    mockUseContractBalance.total.value = {}
+    mockUseContractBalance.total.value = {
+      usd: { value: 0, formatted: '$0' },
+      local: { value: 0, formatted: '$0' }
+    }
     expect(createWrapper().get(BUTTON).attributes('disabled')).toBeDefined()
   })
 

--- a/app/src/components/sections/ExpenseAccountView/ExpenseAccountBalance.vue
+++ b/app/src/components/sections/ExpenseAccountView/ExpenseAccountBalance.vue
@@ -1,7 +1,7 @@
 <template>
   <OverviewCard
     data-test="expense-account-balance"
-    :title="total[currencyStore.localCurrency.code]?.formated ?? 0"
+    :title="balance?.total.local.formatted ?? 0"
     subtitle="Total Balance"
     variant="success"
     :card-icon="bagIcon"
@@ -13,11 +13,9 @@ import bagIcon from '@/assets/bag.svg'
 import OverviewCard from '@/components/OverviewCard.vue'
 import { useContractBalance } from '@/composables/useContractBalance'
 import { useTeamStore } from '@/stores'
-import { useCurrencyStore } from '@/stores/currencyStore'
 import { computed } from 'vue'
 
 const teamStore = useTeamStore()
-const currencyStore = useCurrencyStore()
 const expenseAddress = computed(() => teamStore.getContractAddressByType('ExpenseAccountEIP712'))
-const { total, isLoading } = useContractBalance(expenseAddress)
+const { data: balance, isLoading } = useContractBalance(expenseAddress)
 </script>

--- a/app/src/components/sections/ExpenseAccountView/TransferAction.vue
+++ b/app/src/components/sections/ExpenseAccountView/TransferAction.vue
@@ -100,9 +100,10 @@ const teamStore = useTeamStore()
 const userDataStore = useUserDataStore()
 const toast = useToast()
 const chainId = useChainId()
-const { balances } = useContractBalance(
+const { data: balance } = useContractBalance(
   ref(teamStore.getContractAddressByType('ExpenseAccountEIP712'))
 )
+const balances = computed(() => balance.value?.balances ?? [])
 const queryClient = useQueryClient()
 
 const showModal = ref({ mount: false, show: false })

--- a/app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts
@@ -16,7 +16,7 @@ vi.mock('@/utils', async (importOriginal) => ({
 }))
 
 vi.mock('@/composables', () => ({
-  useContractBalance: () => ({ balances: ref({}) })
+  useContractBalance: () => ({ data: ref({ balances: [], total: undefined }) })
 }))
 
 vi.mock('@wagmi/core', () => ({

--- a/app/src/components/sections/OwnerTreasuryWithdrawAction.vue
+++ b/app/src/components/sections/OwnerTreasuryWithdrawAction.vue
@@ -64,7 +64,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { encodeFunctionData, type Address } from 'viem'
-import { useContractBalance } from '@/composables'
+import { useContractBalance, contractBalanceKeys } from '@/composables'
 import { useCashRemunerationOwner } from '@/composables/cashRemuneration/reads'
 import { useOwnerWithdrawAllToBank as useCashOwnerWithdrawAll } from '@/composables/cashRemuneration/writes'
 import { useExpenseAccountOwner } from '@/composables/expenseAccount/reads'
@@ -125,8 +125,10 @@ const isOwner = computed(() => {
 
 const hasTheRight = computed(() => isOwner.value || isBodAction.value)
 
-const { balances } = useContractBalance(contractAddress)
-const hasWithdrawableBalance = computed(() => balances.value.some((b) => b.amount > 0))
+const { data: balance } = useContractBalance(contractAddress)
+const hasWithdrawableBalance = computed(() =>
+  (balance.value?.balances ?? []).some((b) => b.raw > 0n)
+)
 
 const cashWithdraw = useCashOwnerWithdrawAll()
 const expenseWithdraw = useExpenseOwnerWithdrawAll()
@@ -145,14 +147,11 @@ const resetWithdrawState = () => {
 const refreshContractBalances = async () => {
   if (!contractAddress.value) return
 
-  await Promise.all([
-    queryClient.invalidateQueries({
-      queryKey: ['balance', { address: contractAddress.value, chainId: chainId.value }]
-    }),
-    queryClient.invalidateQueries({
-      queryKey: ['readContract', { args: [contractAddress.value], chainId: chainId.value }]
-    })
-  ])
+  // Native and ERC-20 amounts share one query per contract now, so a single key
+  // covers what used to take a `balance` plus a `readContract` invalidation.
+  await queryClient.invalidateQueries({
+    queryKey: contractBalanceKeys.detail(contractAddress.value, chainId.value)
+  })
 }
 
 const openWithdrawModal = () => {

--- a/app/src/components/sections/SafeView/SafeBalanceSection.vue
+++ b/app/src/components/sections/SafeView/SafeBalanceSection.vue
@@ -21,13 +21,13 @@
                 class="text-primary h-10 w-10 animate-spin"
                 data-test="safe-balance-loading"
               />
-              <span v-else>{{ total['USD']?.formated ?? 0 }}</span>
+              <span v-else>{{ balance?.total.usd.formatted ?? 0 }}</span>
             </span>
           </span>
           <span class="text-gray-600">USD</span>
         </div>
         <div class="mt-1 text-sm text-gray-500">
-          ≈ {{ total[currency.code]?.formated ?? total['USD']?.formated ?? 0 }} {{ currency.code }}
+          ≈ {{ balance?.total.local.formatted ?? 0 }} {{ currency.code }}
         </div>
         <div class="mt-2 flex flex-col gap-1 text-sm text-gray-600">
           <div>
@@ -147,15 +147,15 @@ interface Props {
 const props = defineProps<Props>()
 const { isWriteDisabled } = useTeamWriteGuard()
 
-const { total, balances, isLoading } = useContractBalance(props.address)
+const { data: balance, isLoading } = useContractBalance(props.address)
 
 const getTokens = (): TokenOption[] =>
-  balances.value
+  (balance.value?.balances ?? [])
     .map((b) => ({
       symbol: b.token.symbol,
       balance: b.amount,
       tokenId: b.token.id,
-      price: b.values['USD']?.price ?? 0,
+      price: b.price.usd.value,
       name: b.token.name,
       code: b.token.code
     }))

--- a/app/src/components/sections/SafeView/__tests__/SafeBalanceSection.rendering.spec.ts
+++ b/app/src/components/sections/SafeView/__tests__/SafeBalanceSection.rendering.spec.ts
@@ -4,7 +4,7 @@ import { nextTick, ref, defineComponent } from 'vue'
 import { useStorage } from '@vueuse/core'
 import type { Address } from 'viem'
 import SafeBalanceSection from '../SafeBalanceSection.vue'
-import { mockUseContractBalance, mockUseAccount } from '@/tests/mocks'
+import { mockUseContractBalance, mockUseAccount, makeTokenBalance } from '@/tests/mocks'
 import { mockUserStore } from '@/tests/mocks/store.mock'
 
 // Mock @iconify/vue
@@ -87,10 +87,10 @@ const MOCK_DATA = {
     threshold: 2
   },
   balances: [
-    {
+    makeTokenBalance({
       token: {
         symbol: 'ETH',
-        id: 'ethereum',
+        id: 'native',
         name: 'Ethereum',
         code: 'ETH',
         coingeckoId: 'ethereum',
@@ -98,19 +98,9 @@ const MOCK_DATA = {
         address: '0x0000000000000000000000000000000000000000'
       },
       amount: 1.5,
-      values: {
-        USD: {
-          value: 3000,
-          formated: '$3,000',
-          id: 'usd',
-          code: 'USD',
-          symbol: '$',
-          price: 2000,
-          formatedPrice: '$2K'
-        }
-      }
-    },
-    {
+      usdPrice: 2000
+    }),
+    makeTokenBalance({
       token: {
         symbol: 'SHER',
         id: 'sher',
@@ -121,29 +111,12 @@ const MOCK_DATA = {
         address: '0x1234567890123456789012345678901234567890'
       },
       amount: 100,
-      values: {
-        USD: {
-          value: 500,
-          formated: '$500',
-          id: 'usd',
-          code: 'USD',
-          symbol: '$',
-          price: 5,
-          formatedPrice: '$5'
-        }
-      }
-    }
+      usdPrice: 5
+    })
   ],
   total: {
-    USD: {
-      value: 4500,
-      formated: '$4,500',
-      id: 'usd',
-      code: 'USD',
-      symbol: '$',
-      price: 1,
-      formatedPrice: '$1'
-    }
+    usd: { value: 4500, formatted: '$4,500' },
+    local: { value: 4500, formatted: '$4,500' }
   },
   defaultCurrency: {
     code: 'USD',
@@ -254,14 +227,12 @@ describe('SafeBalanceSection', () => {
 
   describe('Tokens Computation', () => {
     it('should handle missing USD price gracefully', async () => {
+      // An unpriced token still lists, at a value of 0 — it must not vanish
+      // from the picker just because the price feed has nothing for it.
       const sourceBalance = mockUseContractBalance.balances.value[0]!
-      const balanceWithoutUsd = {
-        ...sourceBalance,
-        token: { ...sourceBalance.token },
-        values: { ...sourceBalance.values }
-      }
-      delete (balanceWithoutUsd.values as Record<string, unknown>).USD
-      mockUseContractBalance.balances.value = [balanceWithoutUsd]
+      mockUseContractBalance.balances.value = [
+        makeTokenBalance({ token: sourceBalance.token, amount: sourceBalance.amount })
+      ]
       wrapper = createWrapper()
 
       // Open transfer modal so TransferForm receives `tokens` as a prop

--- a/app/src/components/sections/SafeView/__tests__/SafeBalanceSection.transfer.spec.ts
+++ b/app/src/components/sections/SafeView/__tests__/SafeBalanceSection.transfer.spec.ts
@@ -4,7 +4,7 @@ import { nextTick, ref, defineComponent } from 'vue'
 import { useStorage } from '@vueuse/core'
 import type { Address } from 'viem'
 import SafeBalanceSection from '../SafeBalanceSection.vue'
-import { mockUseContractBalance } from '@/tests/mocks'
+import { mockUseContractBalance, makeTokenBalance } from '@/tests/mocks'
 import { mockUserStore } from '@/tests/mocks/store.mock'
 
 const {
@@ -88,10 +88,10 @@ const MOCK_DATA = {
   safeAddress: '0x1234567890123456789012345678901234567890' as Address,
   safeInfo: { owners: ['0x1111111111111111111111111111111111111111' as Address], threshold: 2 },
   balances: [
-    {
+    makeTokenBalance({
       token: {
         symbol: 'ETH',
-        id: 'ethereum',
+        id: 'native',
         name: 'Ethereum',
         code: 'ETH',
         coingeckoId: 'ethereum',
@@ -99,19 +99,9 @@ const MOCK_DATA = {
         address: '0x0000000000000000000000000000000000000000'
       },
       amount: 1.5,
-      values: {
-        USD: {
-          value: 3000,
-          formated: '$3,000',
-          id: 'usd',
-          code: 'USD',
-          symbol: '$',
-          price: 2000,
-          formatedPrice: '$2K'
-        }
-      }
-    },
-    {
+      usdPrice: 2000
+    }),
+    makeTokenBalance({
       token: {
         symbol: 'SHER',
         id: 'sher',
@@ -122,29 +112,12 @@ const MOCK_DATA = {
         address: '0x1234567890123456789012345678901234567890'
       },
       amount: 100,
-      values: {
-        USD: {
-          value: 500,
-          formated: '$500',
-          id: 'usd',
-          code: 'USD',
-          symbol: '$',
-          price: 5,
-          formatedPrice: '$5'
-        }
-      }
-    }
+      usdPrice: 5
+    })
   ],
   total: {
-    USD: {
-      value: 4500,
-      formated: '$4,500',
-      id: 'usd',
-      code: 'USD',
-      symbol: '$',
-      price: 1,
-      formatedPrice: '$1'
-    }
+    usd: { value: 4500, formatted: '$4,500' },
+    local: { value: 4500, formatted: '$4,500' }
   },
   defaultCurrency: { code: 'USD', name: 'US Dollar', symbol: '$' },
   team: {
@@ -241,7 +214,7 @@ describe('SafeBalanceSection', () => {
             options: {
               to: '0x3333333333333333333333333333333333333333',
               amount: '1',
-              tokenId: 'ethereum'
+              tokenId: 'native'
             }
           }
         },

--- a/app/src/components/sections/SherTokenView/forms/PayDividendsForm.vue
+++ b/app/src/components/sections/SherTokenView/forms/PayDividendsForm.vue
@@ -78,7 +78,9 @@ defineProps<{
 }>()
 
 const bankAddress = teamStore.getContractAddressByType('Bank')
-const { balances } = useContractBalance(bankAddress as Address)
+const { data: balance } = useContractBalance(bankAddress as Address)
+
+const balances = computed(() => balance.value?.balances ?? [])
 
 const getTokens = (): TokenOption[] =>
   balances.value
@@ -86,7 +88,7 @@ const getTokens = (): TokenOption[] =>
       symbol: b.token.symbol,
       balance: b.amount,
       tokenId: b.token.id,
-      price: b.values['USD']?.price ?? 0,
+      price: b.price.usd.value,
       name: b.token.name,
       code: b.token.code
     }))

--- a/app/src/components/sections/SherTokenView/forms/__tests__/PayDividendsForm.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/PayDividendsForm.spec.ts
@@ -3,73 +3,9 @@ import { mount } from '@vue/test-utils'
 import PayDividendsForm from '../PayDividendsForm.vue'
 import { createTestingPinia } from '@pinia/testing'
 import type { Team } from '@/types'
-import { mockUseContractBalance } from '@/tests/mocks'
+import { mockUseContractBalance, makeTokenBalance } from '@/tests/mocks'
 
-type BalanceEntry = {
-  amount: number
-  token: {
-    id: string
-    name: string
-    symbol: string
-    code: string
-    coingeckoId: string
-    decimals: number
-    address: string
-  }
-  values: {
-    USD: {
-      value: number
-      formated: string
-      id: string
-      code: string
-      symbol: string
-      price: number
-      formatedPrice: string
-    }
-  }
-}
-
-type BalanceEntryOverrides = Partial<Omit<BalanceEntry, 'token' | 'values'>> & {
-  token?: Partial<BalanceEntry['token']>
-  values?: {
-    USD?: Partial<BalanceEntry['values']['USD']>
-  }
-}
-
-const makeBalance = (overrides: BalanceEntryOverrides = {}): BalanceEntry => {
-  const base: BalanceEntry = {
-    amount: 0,
-    token: {
-      id: 'native',
-      name: 'Token',
-      symbol: 'TKN',
-      code: 'TKN',
-      coingeckoId: 'token',
-      decimals: 18,
-      address: '0x0000000000000000000000000000000000000000'
-    },
-    values: {
-      USD: {
-        value: 0,
-        formated: '$0',
-        id: 'usd',
-        code: 'USD',
-        symbol: '$',
-        price: 1,
-        formatedPrice: '$1'
-      }
-    }
-  }
-
-  return {
-    ...base,
-    ...overrides,
-    token: { ...base.token, ...(overrides.token ?? {}) },
-    values: {
-      USD: { ...base.values.USD, ...(overrides.values?.USD ?? {}) }
-    }
-  }
-}
+const makeBalance = makeTokenBalance
 
 const TokenAmountStub = {
   props: ['modelValue', 'tokens', 'loading'],
@@ -113,17 +49,7 @@ const defaultBalances = () => [
       decimals: 18,
       address: '0x0000000000000000000000000000000000000001'
     },
-    values: {
-      USD: {
-        value: 20000,
-        formated: '$20K',
-        id: 'usd',
-        code: 'USD',
-        symbol: '$',
-        price: 2000,
-        formatedPrice: '$2K'
-      }
-    }
+    usdPrice: 2000
   }),
   makeBalance({
     amount: 25,
@@ -135,17 +61,7 @@ const defaultBalances = () => [
       decimals: 6,
       address: '0x0000000000000000000000000000000000000002'
     },
-    values: {
-      USD: {
-        value: 25,
-        formated: '$25',
-        id: 'usd',
-        code: 'USD',
-        symbol: '$',
-        price: 1,
-        formatedPrice: '$1'
-      }
-    }
+    usdPrice: 1
   }),
   makeBalance({
     amount: 5,

--- a/app/src/components/sections/__tests__/OwnerTreasuryWithdrawAction.spec.ts
+++ b/app/src/components/sections/__tests__/OwnerTreasuryWithdrawAction.spec.ts
@@ -14,7 +14,8 @@ import {
   mockUseChainId,
   mockUseContractBalance,
   mockUserStore,
-  useQueryClientFn
+  useQueryClientFn,
+  makeTokenBalance
 } from '@/tests/mocks'
 
 const OWNER_ADDRESS = '0x00000000000000000000000000000000000000aa'
@@ -25,29 +26,7 @@ const BUTTON = '[data-test="owner-withdraw-button"]'
 const CONFIRM = '[data-test="owner-withdraw-modal-confirm-button"]'
 const WARNING = '[data-test="owner-withdraw-modal-warning"]'
 
-const makeBalance = (amount: number) => ({
-  amount,
-  token: {
-    id: 'native',
-    name: 'ETH',
-    symbol: 'ETH',
-    code: 'ETH',
-    coingeckoId: 'ethereum',
-    decimals: 18,
-    address: '0x0000000000000000000000000000000000000000'
-  },
-  values: {
-    USD: {
-      value: amount,
-      formated: `$${amount}`,
-      id: 'usd',
-      code: 'USD',
-      symbol: '$',
-      price: 1,
-      formatedPrice: '$1'
-    }
-  }
-})
+const makeBalance = (amount: number) => makeTokenBalance({ amount, usdPrice: 1 })
 
 const createWrapper = (
   contractType: 'CashRemunerationEIP712' | 'ExpenseAccountEIP712' = 'CashRemunerationEIP712'

--- a/app/src/composables/__tests__/useContractBalance.spec.ts
+++ b/app/src/composables/__tests__/useContractBalance.spec.ts
@@ -80,55 +80,59 @@ describe('useContractBalance', () => {
 
   describe('data', () => {
     it('is undefined until the first read lands, so loading is not read as a zero balance', () => {
-      const { data: balances, total } = useContractBalance(ADDRESS)
+      const { data: derived } = useContractBalance(ADDRESS)
 
-      expect(balances.value).toBeUndefined()
-      expect(total.value).toEqual({})
+      expect(derived.value).toBeUndefined()
     })
 
     it('prices the cached amounts once the read lands', () => {
-      const { data: balances, total } = useContractBalance(ADDRESS)
+      const { data: derived } = useContractBalance(ADDRESS)
 
       data.value = { [nativeToken.id]: 10n ** 18n }
 
-      const native = balances.value?.find((balance) => balance.token.id === 'native')
+      const native = derived.value?.balances.find((balance) => balance.token.id === 'native')
       expect(native?.amount).toBe(1)
+      expect(native?.raw).toBe(10n ** 18n)
       // The store mock prices native at 2000 USD.
-      expect(native?.values.USD?.value).toBe(2000)
-      expect(total.value.USD?.value).toBe(2000)
+      expect(native?.value.usd.value).toBe(2000)
+      expect(derived.value?.total.usd.value).toBe(2000)
     })
 
     it('exposes one entry per supported token, in configuration order', () => {
-      const { data: balances } = useContractBalance(ADDRESS)
+      const { data: derived } = useContractBalance(ADDRESS)
 
       data.value = {}
 
-      expect(balances.value?.map((balance) => balance.token.id)).toEqual(
+      expect(derived.value?.balances.map((balance) => balance.token.id)).toEqual(
         SUPPORTED_TOKENS.map((token) => token.id)
       )
-      expect(balances.value?.every((balance) => balance.amount === 0)).toBe(true)
+      expect(derived.value?.balances.every((balance) => balance.amount === 0)).toBe(true)
     })
 
     it('re-prices when the currency changes, without refetching', () => {
-      const price = ref(2)
-      const code = ref('USD')
+      const localPrice = ref(2)
+      const localCode = ref('USD')
       vi.mocked(useCurrencyStore).mockReturnValue({
         getTokenInfo: () => ({
-          prices: [{ id: 'local', price: price.value, code: code.value, symbol: '$' }]
+          prices: [
+            { id: 'local', price: localPrice.value, code: localCode.value, symbol: '$' },
+            { id: 'usd', price: 2, code: 'USD', symbol: '$' }
+          ]
         })
       } as never)
 
-      const { data: balances, total } = useContractBalance(ADDRESS)
+      const { data: derived } = useContractBalance(ADDRESS)
       data.value = { [nativeToken.id]: 10n ** 18n }
 
-      expect(total.value.USD?.value).toBe(2)
+      expect(derived.value?.total.local).toEqual({ value: 2, formatted: '$2' })
 
-      price.value = 5
-      code.value = 'EUR'
+      localPrice.value = 5
+      localCode.value = 'EUR'
 
-      expect(total.value.USD).toBeUndefined()
-      expect(total.value.EUR?.value).toBe(5)
-      expect(balances.value?.find((balance) => balance.token.id === 'native')?.amount).toBe(1)
+      expect(derived.value?.total.local).toEqual({ value: 5, formatted: '€5' })
+      // The USD side and the on-chain amount are untouched by the switch.
+      expect(derived.value?.total.usd.value).toBe(2)
+      expect(derived.value?.balances.find((b) => b.token.id === 'native')?.amount).toBe(1)
       // Re-pricing is pure derivation: no new read was issued.
       expect(mockWagmiCore.getBalance).not.toHaveBeenCalled()
     })

--- a/app/src/composables/__tests__/useContractBalance.spec.ts
+++ b/app/src/composables/__tests__/useContractBalance.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { ref, type Ref } from 'vue'
+import type { Address } from 'viem'
+import { useQueryFn } from '@/tests/mocks/composables.mock'
+import { mockWagmiCore, mockUseChainId } from '@/tests/mocks/wagmi.vue.mock'
+import { useCurrencyStore } from '@/stores'
+import { SUPPORTED_TOKENS } from '@/constant'
+import type { RawTokenBalances } from '@/lib/balances/tokenBalances'
+
+// Globally mocked in composables.setup.ts — this spec exercises the real one.
+vi.unmock('@/composables/useContractBalance')
+
+import { useContractBalance, contractBalanceKeys } from '@/composables/useContractBalance'
+
+const ADDRESS = '0x1234567890123456789012345678901234567890' as Address
+
+type CapturedConfig = {
+  queryKey: Ref<readonly unknown[]>
+  enabled: Ref<boolean>
+  refetchInterval: number
+  queryFn: () => Promise<RawTokenBalances>
+}
+
+const nativeToken = SUPPORTED_TOKENS.find((token) => token.id === 'native')!
+const erc20Tokens = SUPPORTED_TOKENS.filter((token) => token.id !== 'native')
+
+describe('useContractBalance', () => {
+  let captured: CapturedConfig
+  let data: Ref<RawTokenBalances | undefined>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    data = ref<RawTokenBalances | undefined>(undefined)
+    useQueryFn.mockImplementation((cfg: unknown) => {
+      captured = cfg as CapturedConfig
+      return { data, isLoading: ref(false), error: ref(null), refetch: vi.fn() }
+    })
+  })
+
+  describe('query wiring', () => {
+    it('keys the query the way the invalidation call sites target it', () => {
+      useContractBalance(ADDRESS)
+
+      expect(captured.queryKey.value).toEqual(['balance', { address: ADDRESS, chainId: 1 }])
+      expect(captured.queryKey.value).toEqual(contractBalanceKeys.detail(ADDRESS, 1))
+    })
+
+    it('re-keys when the address ref changes', () => {
+      const address = ref<Address | undefined>(ADDRESS)
+      useContractBalance(address)
+
+      const other = '0x9999999999999999999999999999999999999999' as Address
+      address.value = other
+
+      expect(captured.queryKey.value).toEqual(['balance', { address: other, chainId: 1 }])
+    })
+
+    it('stays disabled until an address is available', () => {
+      const address = ref<Address | undefined>(undefined)
+      useContractBalance(address)
+
+      expect(captured.enabled.value).toBe(false)
+
+      address.value = ADDRESS
+      expect(captured.enabled.value).toBe(true)
+    })
+
+    it('reads every supported token in one pass', async () => {
+      mockWagmiCore.getBalance.mockResolvedValue({ value: 10n ** 18n })
+      mockWagmiCore.readContract.mockResolvedValue(1_000_000n)
+
+      useContractBalance(ADDRESS)
+      const raw = await captured.queryFn()
+
+      expect(mockWagmiCore.getBalance).toHaveBeenCalledTimes(1)
+      expect(mockWagmiCore.readContract).toHaveBeenCalledTimes(erc20Tokens.length)
+      expect(Object.keys(raw)).toEqual(SUPPORTED_TOKENS.map((token) => token.id))
+    })
+  })
+
+  describe('data', () => {
+    it('is undefined until the first read lands, so loading is not read as a zero balance', () => {
+      const { data: balances, total } = useContractBalance(ADDRESS)
+
+      expect(balances.value).toBeUndefined()
+      expect(total.value).toEqual({})
+    })
+
+    it('prices the cached amounts once the read lands', () => {
+      const { data: balances, total } = useContractBalance(ADDRESS)
+
+      data.value = { [nativeToken.id]: 10n ** 18n }
+
+      const native = balances.value?.find((balance) => balance.token.id === 'native')
+      expect(native?.amount).toBe(1)
+      // The store mock prices native at 2000 USD.
+      expect(native?.values.USD?.value).toBe(2000)
+      expect(total.value.USD?.value).toBe(2000)
+    })
+
+    it('exposes one entry per supported token, in configuration order', () => {
+      const { data: balances } = useContractBalance(ADDRESS)
+
+      data.value = {}
+
+      expect(balances.value?.map((balance) => balance.token.id)).toEqual(
+        SUPPORTED_TOKENS.map((token) => token.id)
+      )
+      expect(balances.value?.every((balance) => balance.amount === 0)).toBe(true)
+    })
+
+    it('re-prices when the currency changes, without refetching', () => {
+      const price = ref(2)
+      const code = ref('USD')
+      vi.mocked(useCurrencyStore).mockReturnValue({
+        getTokenInfo: () => ({
+          prices: [{ id: 'local', price: price.value, code: code.value, symbol: '$' }]
+        })
+      } as never)
+
+      const { data: balances, total } = useContractBalance(ADDRESS)
+      data.value = { [nativeToken.id]: 10n ** 18n }
+
+      expect(total.value.USD?.value).toBe(2)
+
+      price.value = 5
+      code.value = 'EUR'
+
+      expect(total.value.USD).toBeUndefined()
+      expect(total.value.EUR?.value).toBe(5)
+      expect(balances.value?.find((balance) => balance.token.id === 'native')?.amount).toBe(1)
+      // Re-pricing is pure derivation: no new read was issued.
+      expect(mockWagmiCore.getBalance).not.toHaveBeenCalled()
+    })
+  })
+
+  it('passes the connected chain through to the reads', async () => {
+    mockUseChainId.value = 31337
+    mockWagmiCore.getBalance.mockResolvedValue({ value: 0n })
+    mockWagmiCore.readContract.mockResolvedValue(0n)
+
+    useContractBalance(ADDRESS)
+
+    expect(captured.queryKey.value).toEqual(['balance', { address: ADDRESS, chainId: 31337 }])
+
+    await captured.queryFn()
+    expect(mockWagmiCore.getBalance).toHaveBeenCalledWith(expect.anything(), {
+      address: ADDRESS,
+      chainId: 31337
+    })
+
+    mockUseChainId.value = 1
+  })
+})

--- a/app/src/composables/cashOut/useCashOutAll.ts
+++ b/app/src/composables/cashOut/useCashOutAll.ts
@@ -7,6 +7,7 @@ import { erc20Abi } from 'viem'
 import { SUPPORTED_TOKENS } from '@/constant'
 import { useTeamStore, useUserDataStore } from '@/stores'
 import { classifyError } from '@/utils'
+import { contractBalanceKeys } from '@/composables/useContractBalance'
 import type { ContractKey } from '@/composables/contracts/errorCatalogs.types'
 import { useOwnerWithdrawAllToBank as useCashOwnerWithdrawAll } from '@/composables/cashRemuneration/writes'
 import { useOwnerWithdrawAllToBank as useExpenseOwnerWithdrawAll } from '@/composables/expenseAccount/writes'
@@ -123,17 +124,19 @@ export function useCashOutAll() {
   }
 
   /**
-   * One-shot refresh of every contract balance touched by the flow. The
-   * per-write invalidation in `useContractWritesV3` only covers reads keyed by
-   * the called contract's address, which misses the Bank's ERC-20 `balanceOf`
-   * reads (keyed by the token address) — so we sweep both query families once
-   * the sequence completes.
+   * One-shot refresh of every contract balance touched by the flow.
+   *
+   * The sequence moves funds between several contracts, so rather than name
+   * each one we sweep the whole `balance` family plus the contract reads that
+   * `useContractWritesV3` scopes to a single written address.
    */
   async function refreshBalances() {
     await queryClient.invalidateQueries({
       predicate: (query) => {
         const key = query.queryKey
-        return Array.isArray(key) && (key[0] === 'balance' || key[0] === 'readContract')
+        return (
+          Array.isArray(key) && (key[0] === contractBalanceKeys.all[0] || key[0] === 'readContract')
+        )
       }
     })
   }

--- a/app/src/composables/transactions/useSafeSendTransaction.ts
+++ b/app/src/composables/transactions/useSafeSendTransaction.ts
@@ -8,6 +8,7 @@ import {
 } from '@wagmi/core'
 import { getAddress, type Address } from 'viem'
 import { config as wagmiConfig, type config as wagmiConfigType } from '@/wagmi.config'
+import { contractBalanceKeys } from '@/composables/useContractBalance'
 import { log, parseErrorV2 } from '@/utils'
 
 type WagmiConfig = typeof wagmiConfigType
@@ -122,7 +123,7 @@ export function useSafeSendTransaction(cfg: SendTransactionConfig) {
       await Promise.all(
         addresses.map((address) =>
           queryClient.invalidateQueries({
-            queryKey: ['balance', { address, chainId: chainId ?? receipt.chainId }]
+            queryKey: contractBalanceKeys.detail(address, chainId ?? receipt.chainId)
           })
         )
       )

--- a/app/src/composables/useContractBalance.ts
+++ b/app/src/composables/useContractBalance.ts
@@ -5,10 +5,10 @@ import type { Address } from 'viem'
 import { config as wagmiConfig } from '@/wagmi.config'
 import { useCurrencyStore } from '@/stores'
 import { SUPPORTED_TOKENS, type TokenId } from '@/constant'
-import { fetchTokenBalances, sumTokenBalances, toTokenBalances } from '@/lib/balances/tokenBalances'
-import type { TokenBalance } from '@/types'
+import { fetchTokenBalances, toContractBalances } from '@/lib/balances/tokenBalances'
+import type { ContractBalances } from '@/types'
 
-export type { TokenBalance, TokenBalanceValue } from '@/types'
+export type { ContractBalances, TokenBalance, CurrencyPair, Money } from '@/types'
 
 /** Refresh cadence for a balance that nothing on screen just changed. */
 const REFETCH_INTERVAL = 300_000
@@ -36,14 +36,12 @@ export const contractBalanceKeys = {
  * exposed by the currency store.
  *
  * Returns the TanStack query itself — `status`, `isLoading`, `error`,
- * `refetch`, `dataUpdatedAt`… are all the standard ones — with two additions:
- *
- * - `data` is the **priced** balances, not the raw payload. The query caches
- *   raw bigints; `data` is a `computed` over them, so it re-derives when the
- *   user switches currency or prices refresh, with no refetch. It is
- *   `undefined` until the first successful read, per TanStack semantics — a
- *   balance still loading is now distinguishable from a balance of 0.
- * - `total` sums those balances per currency code.
+ * `refetch`, `dataUpdatedAt`… are all the standard ones — with one twist:
+ * `data` holds the **priced** balances (`{ balances, total }`), not the raw
+ * payload. The query caches raw bigints; `data` is a `computed` over them, so
+ * it re-derives when the user switches currency or prices refresh, with no
+ * refetch. It is `undefined` until the first successful read, per TanStack
+ * semantics — a balance still loading is distinguishable from a balance of 0.
  *
  * One query covers every token: the reads are issued through `@wagmi/core` in
  * a single tick, so they cost one JSON-RPC round-trip and share a single
@@ -70,19 +68,13 @@ export function useContractBalance(address: MaybeRefOrGetter<Address | undefined
       })
   })
 
-  const balances = computed<TokenBalance[] | undefined>(() => {
+  const data = computed<ContractBalances | undefined>(() => {
     const raw = query.data.value
     if (!raw) return undefined
-    return toTokenBalances(SUPPORTED_TOKENS, raw, (tokenId: TokenId) =>
+    return toContractBalances(SUPPORTED_TOKENS, raw, (tokenId: TokenId) =>
       currencyStore.getTokenInfo(tokenId)
     )
   })
 
-  const total = computed(() => sumTokenBalances(balances.value ?? []))
-
-  return {
-    ...query,
-    data: balances,
-    total
-  }
+  return { ...query, data }
 }

--- a/app/src/composables/useContractBalance.ts
+++ b/app/src/composables/useContractBalance.ts
@@ -1,182 +1,88 @@
-import { computed, unref, type Ref } from 'vue'
-import { useBalance, useReadContract, useChainId } from '@wagmi/vue'
-import { erc20Abi, formatEther, formatUnits, type Address } from 'viem'
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+import { useChainId } from '@wagmi/vue'
+import { useQuery } from '@tanstack/vue-query'
+import type { Address } from 'viem'
+import { config as wagmiConfig } from '@/wagmi.config'
 import { useCurrencyStore } from '@/stores'
-import { SUPPORTED_TOKENS } from '@/constant'
-import type { TokenId } from '@/constant'
-import { formatCurrencyShort } from '@/utils/currencyUtil'
+import { SUPPORTED_TOKENS, type TokenId } from '@/constant'
+import { fetchTokenBalances, sumTokenBalances, toTokenBalances } from '@/lib/balances/tokenBalances'
+import type { TokenBalance } from '@/types'
+
+export type { TokenBalance, TokenBalanceValue } from '@/types'
+
+/** Refresh cadence for a balance that nothing on screen just changed. */
+const REFETCH_INTERVAL = 300_000
 
 /**
- * @description Represents the value of a token balance in a specific currency
- * @param value - The numeric value of the token balance in the given currency
- * @param formated - The formatted value for display, e.g. "$1,234.56"
- * @param id - Unique identifier for the currency
- * @param code - The currency code, e.g. "USD", "EUR"
- * @param symbol - The currency symbol, e.g. "$", "€"
- * @param price - The price of the token in the given currency
- * @param formatedPrice - The formatted price for display, e.g. "$1,234.56"
- * @description This type is used to represent the value of a token balance in different currencies
- * and is returned by the useContractBalance composable.
- * It includes the raw value, formatted value, currency ID, code, symbol, and price information.
- */
-export type TokenBalanceValue = {
-  value: number
-  formated: string
-  id: string
-  code: string
-  symbol: string
-  price: number
-  formatedPrice: string
-}
-
-/**
- * @description Represents a token balance for a specific address
- * @param amount - The numeric amount of the token balance
- * @param token - The token configuration object, including ID, name, symbol, etc.
- * @param values - An object mapping currency codes to TokenBalanceValue objects,
- */
-export interface TokenBalance {
-  amount: number
-  token: (typeof SUPPORTED_TOKENS)[number]
-  values: Record<string, TokenBalanceValue>
-}
-
-type NativeTokenBalanceEntry = {
-  token: (typeof SUPPORTED_TOKENS)[number]
-  data: { value?: { value: bigint } }
-  isLoading: { value: boolean }
-  error: { value: unknown }
-  isNative: true
-}
-type ERC20TokenBalanceEntry = {
-  token: (typeof SUPPORTED_TOKENS)[number]
-  data: { value?: bigint }
-  isLoading: { value: boolean }
-  error: { value: unknown }
-  isNative: false
-}
-type TokenBalanceEntry = NativeTokenBalanceEntry | ERC20TokenBalanceEntry
-
-// TODO: support reactive address changes
-/**
- * @description Composable to fetch and compute balances for an address
+ * Query keys for contract balances.
  *
- * Supports both native and ERC20 tokens
+ * The shape is deliberately the one wagmi's `useBalance` used to store —
+ * `['balance', { address, chainId }]` — because a dozen call sites invalidate
+ * that key by hand after a transfer, deposit or withdrawal. Keeping it means
+ * those keep working; TanStack's partial matching also makes the bare
+ * `['balance']` prefix a valid "refresh every balance" sweep (see
+ * `useCashOutAll`).
+ *
+ * Prefer this factory over hand-written literals at new call sites.
  */
-export function useContractBalance(address: Address | Ref<Address | undefined>) {
+export const contractBalanceKeys = {
+  all: ['balance'] as const,
+  detail: (address: Address | undefined, chainId: number | undefined) =>
+    ['balance', { address, chainId }] as const
+}
+
+/**
+ * Balances of every supported token held by `address`, priced in the currencies
+ * exposed by the currency store.
+ *
+ * Returns the TanStack query itself — `status`, `isLoading`, `error`,
+ * `refetch`, `dataUpdatedAt`… are all the standard ones — with two additions:
+ *
+ * - `data` is the **priced** balances, not the raw payload. The query caches
+ *   raw bigints; `data` is a `computed` over them, so it re-derives when the
+ *   user switches currency or prices refresh, with no refetch. It is
+ *   `undefined` until the first successful read, per TanStack semantics — a
+ *   balance still loading is now distinguishable from a balance of 0.
+ * - `total` sums those balances per currency code.
+ *
+ * One query covers every token: the reads are issued through `@wagmi/core` in
+ * a single tick, so they cost one JSON-RPC round-trip and share a single
+ * loading/error state. A failing read fails the whole query rather than
+ * reporting a silent 0.
+ *
+ * `address` may be a ref/getter — the query re-keys and refetches when it
+ * changes, and stays disabled while it is undefined.
+ */
+export function useContractBalance(address: MaybeRefOrGetter<Address | undefined>) {
   const chainId = useChainId()
   const currencyStore = useCurrencyStore()
-  const supportedToken = computed(() => {
-    const tokens = [...SUPPORTED_TOKENS]
-    return tokens
-  })
+  const contractAddress = computed(() => toValue(address))
 
-  // Store for all token balances
-  const tokenBalances: TokenBalanceEntry[] = supportedToken.value.map((token) => {
-    if (token.id === 'native') {
-      const native = useBalance({
-        address: unref(address),
-        chainId,
-        query: { refetchInterval: 300_000 }
+  const query = useQuery({
+    queryKey: computed(() => contractBalanceKeys.detail(contractAddress.value, chainId.value)),
+    enabled: computed(() => !!contractAddress.value),
+    refetchInterval: REFETCH_INTERVAL,
+    queryFn: () =>
+      fetchTokenBalances(wagmiConfig, {
+        address: contractAddress.value as Address,
+        chainId: chainId.value,
+        tokens: SUPPORTED_TOKENS
       })
-      return {
-        token,
-        data: native.data,
-        isLoading: native.isLoading,
-        error: native.error,
-        isNative: true
-      } as NativeTokenBalanceEntry
-    } else {
-      const erc20 = useReadContract({
-        address: token.address as Address,
-        abi: erc20Abi,
-        functionName: 'balanceOf' as const,
-        args: [unref(address) as Address] as const,
-        query: { refetchInterval: 300_000 }
-      })
-      return {
-        token,
-        data: erc20.data,
-        isLoading: erc20.isLoading,
-        error: erc20.error,
-        isNative: false
-      } as ERC20TokenBalanceEntry
-    }
   })
 
-  const balances = computed<TokenBalance[]>(() => {
-    return tokenBalances.map(({ token, data, isNative }) => {
-      let amount = 0
-      if (data.value) {
-        if (isNative) {
-          const nativeRecord = data.value as { value: bigint } | undefined
-          const raw = Number(formatEther(nativeRecord?.value ?? 0n))
-
-          amount = raw
-        } else {
-          const tokenDecimals = token.decimals ?? 18
-          const erc20Val = (data.value as bigint) ?? 0n
-          const raw = Number(formatUnits(erc20Val, tokenDecimals))
-
-          amount = raw
-        }
-      }
-
-      const info = currencyStore.getTokenInfo(token.id as TokenId)
-      const values: Record<string, TokenBalanceValue> = {}
-      if (info?.prices) {
-        for (const price of info.prices) {
-          const val = amount * (price.price ?? 0)
-          values[price.code] = {
-            value: val,
-            formated: formatCurrencyShort(val, price.code),
-            id: price.id,
-            code: price.code,
-            symbol: price.symbol,
-            price: price.price ?? 0,
-            formatedPrice: formatCurrencyShort(price.price ?? 0, price.code)
-          }
-        }
-      }
-      return {
-        amount,
-        token,
-        values
-      }
-    })
+  const balances = computed<TokenBalance[] | undefined>(() => {
+    const raw = query.data.value
+    if (!raw) return undefined
+    return toTokenBalances(SUPPORTED_TOKENS, raw, (tokenId: TokenId) =>
+      currencyStore.getTokenInfo(tokenId)
+    )
   })
 
-  // Computed total balance for each currency
-  const total = computed<Record<string, TokenBalanceValue>>(() => {
-    const totals: Record<string, TokenBalanceValue> = {}
-    if (balances.value.length > 0 && balances.value[0]) {
-      const allCodes = Object.keys(balances.value[0].values)
-      for (const code of allCodes) {
-        const first = balances.value[0].values[code]
-        if (!first) continue
-        const sum = balances.value.reduce((acc, bal) => acc + (bal.values[code]?.value ?? 0), 0)
-        totals[code] = {
-          value: sum,
-          formated: formatCurrencyShort(sum, code),
-          id: first.id,
-          code: first.code,
-          symbol: first.symbol,
-          price: first.price,
-          formatedPrice: formatCurrencyShort(first.price, code)
-        }
-      }
-    }
-    return totals
-  })
-
-  // Combined loading and error states
-  const isLoading = computed(() => tokenBalances.some((tb) => tb.isLoading.value))
-  const error = computed(() => tokenBalances.find((tb) => tb.error.value)?.error.value || null)
+  const total = computed(() => sumTokenBalances(balances.value ?? []))
 
   return {
-    balances,
-    total,
-    isLoading,
-    error
+    ...query,
+    data: balances,
+    total
   }
 }

--- a/app/src/lib/balances/__tests__/tokenBalances.spec.ts
+++ b/app/src/lib/balances/__tests__/tokenBalances.spec.ts
@@ -3,9 +3,9 @@ import { erc20Abi, type Address } from 'viem'
 import { mockWagmiCore } from '@/tests/mocks/wagmi.vue.mock'
 import { config as wagmiConfig } from '@/wagmi.config'
 import type { TokenConfig } from '@/constant'
-import type { TokenBalance } from '@/types'
 import {
   fetchTokenBalances,
+  toContractBalances,
   toTokenBalances,
   sumTokenBalances,
   type GetTokenInfo
@@ -36,13 +36,15 @@ const usdcToken: TokenConfig = {
 
 const TOKENS = [usdcToken, nativeToken]
 
-/** Two currencies so the per-code fan-out is actually exercised. */
+/** Local currency is EUR, so the two rows are genuinely distinct. */
 const getTokenInfo: GetTokenInfo = (tokenId) => ({
   prices: [
-    { id: 'usd', price: tokenId === 'native' ? 2000 : 1, code: 'USD', symbol: '$' },
-    { id: 'local', price: tokenId === 'native' ? 1800 : 0.9, code: 'EUR', symbol: '€' }
+    { id: 'local', price: tokenId === 'native' ? 1800 : 0.9, code: 'EUR', symbol: '€' },
+    { id: 'usd', price: tokenId === 'native' ? 2000 : 1, code: 'USD', symbol: '$' }
   ]
 })
+
+const USD_CODES = { usd: 'USD', local: 'USD' }
 
 describe('fetchTokenBalances', () => {
   beforeEach(() => {
@@ -83,76 +85,104 @@ describe('fetchTokenBalances', () => {
 })
 
 describe('toTokenBalances', () => {
-  it('applies each token decimals and prices every currency the store exposes', () => {
+  const codes = { usd: 'USD', local: 'EUR' }
+
+  it('keeps the exact on-chain amount alongside the lossy decimal one', () => {
+    const balances = toTokenBalances(TOKENS, { usdc: 12_500_000n }, getTokenInfo, codes)
+
+    expect(balances[0]?.raw).toBe(12_500_000n)
+    expect(balances[0]?.amount).toBe(12.5)
+  })
+
+  it('prices the holding in both currencies from the matching store rows', () => {
     const balances = toTokenBalances(
       TOKENS,
       { usdc: 12_500_000n, native: 10n ** 18n },
-      getTokenInfo
+      getTokenInfo,
+      codes
     )
 
-    expect(balances.map((b) => b.amount)).toEqual([12.5, 1])
-    expect(balances[0]?.values.USD).toMatchObject({ value: 12.5, price: 1, code: 'USD' })
-    expect(balances[0]?.values.EUR).toMatchObject({ value: 11.25, price: 0.9, code: 'EUR' })
-    expect(balances[1]?.values.USD).toMatchObject({ value: 2000, price: 2000 })
+    expect(balances[0]?.value.usd.value).toBe(12.5)
+    expect(balances[0]?.value.local.value).toBe(11.25)
+    expect(balances[0]?.price).toEqual({
+      usd: { value: 1, formatted: '$1' },
+      local: { value: 0.9, formatted: '€0.9' }
+    })
+    expect(balances[1]?.value.usd.value).toBe(2000)
   })
 
   it('returns one entry per token in order, defaulting a missing balance to zero', () => {
-    const balances = toTokenBalances(TOKENS, { native: 10n ** 18n }, getTokenInfo)
+    const balances = toTokenBalances(TOKENS, { native: 10n ** 18n }, getTokenInfo, codes)
 
     expect(balances).toHaveLength(2)
-    expect(balances[0]).toMatchObject({ amount: 0, token: usdcToken })
-    expect(balances[0]?.values.USD?.value).toBe(0)
+    expect(balances[0]).toMatchObject({ raw: 0n, amount: 0, token: usdcToken })
+    expect(balances[0]?.value.usd.value).toBe(0)
   })
 
   it('treats an unpriced token as zero-valued without dropping it', () => {
-    const balances = toTokenBalances(TOKENS, { usdc: 12_500_000n }, (tokenId) =>
-      tokenId === 'usdc' ? { prices: [{ id: 'usd', price: null, code: 'USD', symbol: '$' }] } : null
-    )
+    const balances = toTokenBalances(TOKENS, { usdc: 12_500_000n }, () => null, codes)
 
-    expect(balances[0]?.values.USD).toMatchObject({ value: 0, price: 0 })
-    expect(balances[1]?.values).toEqual({})
+    expect(balances).toHaveLength(2)
+    expect(balances[0]?.amount).toBe(12.5)
+    expect(balances[0]?.value.usd.value).toBe(0)
+    expect(balances[0]?.price.usd.value).toBe(0)
   })
 })
 
 describe('sumTokenBalances', () => {
-  it('sums every token per currency code', () => {
+  it('sums the held value of every token, in both currencies', () => {
+    const codes = { usd: 'USD', local: 'EUR' }
     const balances = toTokenBalances(
       TOKENS,
       { usdc: 12_500_000n, native: 10n ** 18n },
-      getTokenInfo
+      getTokenInfo,
+      codes
     )
 
-    const total = sumTokenBalances(balances)
-
-    expect(total.USD?.value).toBe(2012.5)
-    expect(total.EUR?.value).toBe(1811.25)
-    expect(total.USD?.symbol).toBe('$')
+    expect(sumTokenBalances(balances, codes)).toEqual({
+      usd: { value: 2012.5, formatted: '$2.01K' },
+      local: { value: 1811.25, formatted: '€1.81K' }
+    })
   })
 
-  it('returns an empty record when there is nothing to sum', () => {
-    expect(sumTokenBalances([])).toEqual({})
+  it('returns a zeroed pair when there is nothing to sum', () => {
+    expect(sumTokenBalances([], USD_CODES)).toEqual({
+      usd: { value: 0, formatted: '$0' },
+      local: { value: 0, formatted: '$0' }
+    })
+  })
+})
+
+describe('toContractBalances', () => {
+  it('formats the local side with the store currency, not USD', () => {
+    const { total } = toContractBalances(TOKENS, { native: 10n ** 18n }, getTokenInfo)
+
+    expect(total.usd.formatted).toBe('$2K')
+    expect(total.local.formatted).toBe('€1.8K')
   })
 
-  it('ignores a currency a later token does not carry', () => {
-    const balances: TokenBalance[] = [
-      {
-        amount: 1,
-        token: usdcToken,
-        values: {
-          USD: {
-            value: 1,
-            formated: '$1',
-            id: 'usd',
-            code: 'USD',
-            symbol: '$',
-            price: 1,
-            formatedPrice: '$1'
-          }
-        }
-      },
-      { amount: 2, token: nativeToken, values: {} }
-    ]
+  it('keeps both sides distinct when the local currency IS usd', () => {
+    const usdOnly: GetTokenInfo = () => ({
+      prices: [
+        { id: 'local', price: 2, code: 'USD', symbol: '$' },
+        { id: 'usd', price: 2, code: 'USD', symbol: '$' }
+      ]
+    })
 
-    expect(sumTokenBalances(balances).USD?.value).toBe(1)
+    const { total } = toContractBalances(TOKENS, { native: 10n ** 18n }, usdOnly)
+
+    // A code-keyed map collapsed these two rows into one entry.
+    expect(total.usd.value).toBe(2)
+    expect(total.local.value).toBe(2)
+  })
+
+  it('falls back to USD formatting before prices have loaded', () => {
+    const { balances, total } = toContractBalances(TOKENS, {}, () => null)
+
+    expect(balances).toHaveLength(2)
+    expect(total).toEqual({
+      usd: { value: 0, formatted: '$0' },
+      local: { value: 0, formatted: '$0' }
+    })
   })
 })

--- a/app/src/lib/balances/__tests__/tokenBalances.spec.ts
+++ b/app/src/lib/balances/__tests__/tokenBalances.spec.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { erc20Abi, type Address } from 'viem'
+import { mockWagmiCore } from '@/tests/mocks/wagmi.vue.mock'
+import { config as wagmiConfig } from '@/wagmi.config'
+import type { TokenConfig } from '@/constant'
+import type { TokenBalance } from '@/types'
+import {
+  fetchTokenBalances,
+  toTokenBalances,
+  sumTokenBalances,
+  type GetTokenInfo
+} from '../tokenBalances'
+
+const HOLDER = '0x1111111111111111111111111111111111111111' as Address
+const USDC = '0x2222222222222222222222222222222222222222' as Address
+
+const nativeToken: TokenConfig = {
+  id: 'native',
+  name: 'Ether',
+  symbol: 'ETH',
+  code: 'ETH',
+  coingeckoId: 'ethereum',
+  decimals: 18,
+  address: '0x0000000000000000000000000000000000000000'
+}
+
+const usdcToken: TokenConfig = {
+  id: 'usdc',
+  name: 'USD Coin',
+  symbol: 'USDC',
+  code: 'USDC',
+  coingeckoId: 'usd-coin',
+  decimals: 6,
+  address: USDC
+}
+
+const TOKENS = [usdcToken, nativeToken]
+
+/** Two currencies so the per-code fan-out is actually exercised. */
+const getTokenInfo: GetTokenInfo = (tokenId) => ({
+  prices: [
+    { id: 'usd', price: tokenId === 'native' ? 2000 : 1, code: 'USD', symbol: '$' },
+    { id: 'local', price: tokenId === 'native' ? 1800 : 0.9, code: 'EUR', symbol: '€' }
+  ]
+})
+
+describe('fetchTokenBalances', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWagmiCore.getBalance.mockResolvedValue({ value: 10n ** 18n })
+    mockWagmiCore.readContract.mockResolvedValue(12_500_000n)
+  })
+
+  it('reads native through getBalance and ERC-20s through balanceOf, keyed by token id', async () => {
+    const balances = await fetchTokenBalances(wagmiConfig, {
+      address: HOLDER,
+      chainId: 31337,
+      tokens: TOKENS
+    })
+
+    expect(balances).toEqual({ usdc: 12_500_000n, native: 10n ** 18n })
+
+    expect(mockWagmiCore.getBalance).toHaveBeenCalledWith(wagmiConfig, {
+      address: HOLDER,
+      chainId: 31337
+    })
+    expect(mockWagmiCore.readContract).toHaveBeenCalledWith(wagmiConfig, {
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [HOLDER],
+      chainId: 31337
+    })
+  })
+
+  it('rejects when a single read fails rather than reporting a silent zero', async () => {
+    mockWagmiCore.readContract.mockRejectedValue(new Error('RPC down'))
+
+    await expect(
+      fetchTokenBalances(wagmiConfig, { address: HOLDER, chainId: 31337, tokens: TOKENS })
+    ).rejects.toThrow('RPC down')
+  })
+})
+
+describe('toTokenBalances', () => {
+  it('applies each token decimals and prices every currency the store exposes', () => {
+    const balances = toTokenBalances(
+      TOKENS,
+      { usdc: 12_500_000n, native: 10n ** 18n },
+      getTokenInfo
+    )
+
+    expect(balances.map((b) => b.amount)).toEqual([12.5, 1])
+    expect(balances[0]?.values.USD).toMatchObject({ value: 12.5, price: 1, code: 'USD' })
+    expect(balances[0]?.values.EUR).toMatchObject({ value: 11.25, price: 0.9, code: 'EUR' })
+    expect(balances[1]?.values.USD).toMatchObject({ value: 2000, price: 2000 })
+  })
+
+  it('returns one entry per token in order, defaulting a missing balance to zero', () => {
+    const balances = toTokenBalances(TOKENS, { native: 10n ** 18n }, getTokenInfo)
+
+    expect(balances).toHaveLength(2)
+    expect(balances[0]).toMatchObject({ amount: 0, token: usdcToken })
+    expect(balances[0]?.values.USD?.value).toBe(0)
+  })
+
+  it('treats an unpriced token as zero-valued without dropping it', () => {
+    const balances = toTokenBalances(TOKENS, { usdc: 12_500_000n }, (tokenId) =>
+      tokenId === 'usdc' ? { prices: [{ id: 'usd', price: null, code: 'USD', symbol: '$' }] } : null
+    )
+
+    expect(balances[0]?.values.USD).toMatchObject({ value: 0, price: 0 })
+    expect(balances[1]?.values).toEqual({})
+  })
+})
+
+describe('sumTokenBalances', () => {
+  it('sums every token per currency code', () => {
+    const balances = toTokenBalances(
+      TOKENS,
+      { usdc: 12_500_000n, native: 10n ** 18n },
+      getTokenInfo
+    )
+
+    const total = sumTokenBalances(balances)
+
+    expect(total.USD?.value).toBe(2012.5)
+    expect(total.EUR?.value).toBe(1811.25)
+    expect(total.USD?.symbol).toBe('$')
+  })
+
+  it('returns an empty record when there is nothing to sum', () => {
+    expect(sumTokenBalances([])).toEqual({})
+  })
+
+  it('ignores a currency a later token does not carry', () => {
+    const balances: TokenBalance[] = [
+      {
+        amount: 1,
+        token: usdcToken,
+        values: {
+          USD: {
+            value: 1,
+            formated: '$1',
+            id: 'usd',
+            code: 'USD',
+            symbol: '$',
+            price: 1,
+            formatedPrice: '$1'
+          }
+        }
+      },
+      { amount: 2, token: nativeToken, values: {} }
+    ]
+
+    expect(sumTokenBalances(balances).USD?.value).toBe(1)
+  })
+})

--- a/app/src/lib/balances/tokenBalances.ts
+++ b/app/src/lib/balances/tokenBalances.ts
@@ -2,7 +2,7 @@ import { erc20Abi, formatUnits, type Address } from 'viem'
 import { getBalance, readContract, type Config } from '@wagmi/core'
 import { SUPPORTED_TOKENS, type TokenConfig, type TokenId } from '@/constant'
 import { formatCurrencyShort } from '@/utils/currencyUtil'
-import type { TokenBalance, TokenBalanceValue } from '@/types'
+import type { ContractBalances, CurrencyPair, Money, TokenBalance } from '@/types'
 
 /**
  * On-chain balances for one address, in each token's smallest unit, keyed by
@@ -67,9 +67,38 @@ export async function fetchTokenBalances(
   return Object.fromEntries(entries)
 }
 
+/** Currency codes to format each side of a `CurrencyPair` with. */
+interface PairCodes {
+  usd: string
+  local: string
+}
+
+const money = (value: number, code: string): Money => ({
+  value,
+  formatted: formatCurrencyShort(value, code)
+})
+
+const pair = (usd: number, local: number, codes: PairCodes): CurrencyPair => ({
+  usd: money(usd, codes.usd),
+  local: money(local, codes.local)
+})
+
 /**
- * Turn raw on-chain amounts into display balances, one entry per supported
- * token in `tokens` order.
+ * The store prices every token in the same two currencies, so the local code is
+ * the same whichever token we ask about. Falls back to USD when prices have not
+ * loaded yet — the amounts are 0 then anyway.
+ */
+function resolveCodes(tokens: readonly TokenConfig[], getTokenInfo: GetTokenInfo): PairCodes {
+  for (const token of tokens) {
+    const local = getTokenInfo(token.id)?.prices?.find((row) => row.id === 'local')
+    if (local?.code) return { usd: 'USD', local: local.code }
+  }
+  return { usd: 'USD', local: 'USD' }
+}
+
+/**
+ * Turn raw on-chain amounts into priced balances, one entry per token in
+ * `tokens` order.
  *
  * Kept separate from the fetch so that switching currency re-prices the cached
  * amounts instead of triggering a new round of RPC reads.
@@ -77,58 +106,50 @@ export async function fetchTokenBalances(
 export function toTokenBalances(
   tokens: readonly TokenConfig[],
   raw: RawTokenBalances,
-  getTokenInfo: GetTokenInfo
+  getTokenInfo: GetTokenInfo,
+  codes: PairCodes
 ): TokenBalance[] {
   return tokens.map((token) => {
-    const amount = Number(formatUnits(raw[token.id] ?? 0n, token.decimals ?? 18))
+    const rawAmount = raw[token.id] ?? 0n
+    const amount = Number(formatUnits(rawAmount, token.decimals ?? 18))
 
-    const values: Record<string, TokenBalanceValue> = {}
-    for (const price of getTokenInfo(token.id)?.prices ?? []) {
-      const value = amount * (price.price ?? 0)
-      values[price.code] = {
-        value,
-        formated: formatCurrencyShort(value, price.code),
-        id: price.id,
-        code: price.code,
-        symbol: price.symbol,
-        price: price.price ?? 0,
-        formatedPrice: formatCurrencyShort(price.price ?? 0, price.code)
-      }
+    const rows = getTokenInfo(token.id)?.prices ?? []
+    const usdPrice = rows.find((row) => row.id === 'usd')?.price ?? 0
+    const localPrice = rows.find((row) => row.id === 'local')?.price ?? 0
+
+    return {
+      token,
+      raw: rawAmount,
+      amount,
+      price: pair(usdPrice, localPrice, codes),
+      value: pair(amount * usdPrice, amount * localPrice, codes)
     }
-
-    return { amount, token, values }
   })
 }
 
-/**
- * Sum every token balance per currency code.
- *
- * The currency set is taken from the first balance — all tokens are priced by
- * the same store call, so they carry the same codes. `price` / `formatedPrice`
- * are carried over from that first entry: a total spans several tokens, so it
- * has no unit price of its own.
- */
+/** Sum the held value of every token, in both currencies. */
 export function sumTokenBalances(
-  balances: readonly TokenBalance[]
-): Record<string, TokenBalanceValue> {
-  const totals: Record<string, TokenBalanceValue> = {}
-  const first = balances[0]
-  if (!first) return totals
+  balances: readonly TokenBalance[],
+  codes: PairCodes
+): CurrencyPair {
+  const usd = balances.reduce((acc, balance) => acc + balance.value.usd.value, 0)
+  const local = balances.reduce((acc, balance) => acc + balance.value.local.value, 0)
+  return pair(usd, local, codes)
+}
 
-  for (const code of Object.keys(first.values)) {
-    const reference = first.values[code]
-    if (!reference) continue
-    const sum = balances.reduce((acc, balance) => acc + (balance.values[code]?.value ?? 0), 0)
-    totals[code] = {
-      value: sum,
-      formated: formatCurrencyShort(sum, code),
-      id: reference.id,
-      code: reference.code,
-      symbol: reference.symbol,
-      price: reference.price,
-      formatedPrice: formatCurrencyShort(reference.price, code)
-    }
-  }
-
-  return totals
+/**
+ * Full derivation: priced balances plus the aggregate across tokens.
+ *
+ * This is what `useContractBalance` exposes as `data`; it is a pure function of
+ * the cached amounts and the current prices, so it re-runs on a currency switch
+ * without any refetch.
+ */
+export function toContractBalances(
+  tokens: readonly TokenConfig[],
+  raw: RawTokenBalances,
+  getTokenInfo: GetTokenInfo
+): ContractBalances {
+  const codes = resolveCodes(tokens, getTokenInfo)
+  const balances = toTokenBalances(tokens, raw, getTokenInfo, codes)
+  return { balances, total: sumTokenBalances(balances, codes) }
 }

--- a/app/src/lib/balances/tokenBalances.ts
+++ b/app/src/lib/balances/tokenBalances.ts
@@ -1,6 +1,6 @@
 import { erc20Abi, formatUnits, type Address } from 'viem'
 import { getBalance, readContract, type Config } from '@wagmi/core'
-import { SUPPORTED_TOKENS, type TokenConfig, type TokenId } from '@/constant'
+import type { TokenConfig, TokenId } from '@/constant'
 import { formatCurrencyShort } from '@/utils/currencyUtil'
 import type { ContractBalances, CurrencyPair, Money, TokenBalance } from '@/types'
 
@@ -42,10 +42,10 @@ export async function fetchTokenBalances(
   params: {
     address: Address
     chainId?: number
-    tokens?: readonly TokenConfig[]
+    tokens: readonly TokenConfig[]
   }
 ): Promise<RawTokenBalances> {
-  const { address, chainId, tokens = SUPPORTED_TOKENS } = params
+  const { address, chainId, tokens } = params
 
   const entries = await Promise.all(
     tokens.map(async (token): Promise<[string, bigint]> => {
@@ -111,7 +111,7 @@ export function toTokenBalances(
 ): TokenBalance[] {
   return tokens.map((token) => {
     const rawAmount = raw[token.id] ?? 0n
-    const amount = Number(formatUnits(rawAmount, token.decimals ?? 18))
+    const amount = Number(formatUnits(rawAmount, token.decimals))
 
     const rows = getTokenInfo(token.id)?.prices ?? []
     const usdPrice = rows.find((row) => row.id === 'usd')?.price ?? 0

--- a/app/src/lib/balances/tokenBalances.ts
+++ b/app/src/lib/balances/tokenBalances.ts
@@ -1,0 +1,134 @@
+import { erc20Abi, formatUnits, type Address } from 'viem'
+import { getBalance, readContract, type Config } from '@wagmi/core'
+import { SUPPORTED_TOKENS, type TokenConfig, type TokenId } from '@/constant'
+import { formatCurrencyShort } from '@/utils/currencyUtil'
+import type { TokenBalance, TokenBalanceValue } from '@/types'
+
+/**
+ * On-chain balances for one address, in each token's smallest unit, keyed by
+ * `TokenConfig.id`. Deliberately raw: decimals and fiat conversion are applied
+ * by the derivation helpers below, so the cached value never goes stale when
+ * the user switches currency.
+ */
+export type RawTokenBalances = Record<string, bigint>
+
+/** Price rows as exposed by `useCurrencyStore().getTokenInfo()`. */
+export interface TokenPriceRow {
+  id: string
+  price: number | null
+  code: string
+  symbol: string
+}
+
+/**
+ * Narrow structural view of `useCurrencyStore().getTokenInfo` — injected rather
+ * than imported so the derivation stays a pure function.
+ */
+export type GetTokenInfo = (tokenId: TokenId) => { prices?: TokenPriceRow[] } | null
+
+/**
+ * Read every supported token's balance for `address` in one pass.
+ *
+ * Native goes through `getBalance`, ERC-20s through `balanceOf`. The calls are
+ * fired in the same tick, so the batching http transport (see `wagmi.config`)
+ * collapses them into a single JSON-RPC round-trip.
+ *
+ * A failing read rejects the whole call: a partial result would silently report
+ * a 0 balance for the broken token and, worse, a wrong total. Callers surface
+ * the rejection instead.
+ */
+export async function fetchTokenBalances(
+  config: Config,
+  params: {
+    address: Address
+    chainId?: number
+    tokens?: readonly TokenConfig[]
+  }
+): Promise<RawTokenBalances> {
+  const { address, chainId, tokens = SUPPORTED_TOKENS } = params
+
+  const entries = await Promise.all(
+    tokens.map(async (token): Promise<[string, bigint]> => {
+      if (token.id === 'native') {
+        const native = await getBalance(config, { address, chainId })
+        return [token.id, native.value]
+      }
+      const balance = await readContract(config, {
+        address: token.address,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [address],
+        chainId
+      })
+      return [token.id, balance]
+    })
+  )
+
+  return Object.fromEntries(entries)
+}
+
+/**
+ * Turn raw on-chain amounts into display balances, one entry per supported
+ * token in `tokens` order.
+ *
+ * Kept separate from the fetch so that switching currency re-prices the cached
+ * amounts instead of triggering a new round of RPC reads.
+ */
+export function toTokenBalances(
+  tokens: readonly TokenConfig[],
+  raw: RawTokenBalances,
+  getTokenInfo: GetTokenInfo
+): TokenBalance[] {
+  return tokens.map((token) => {
+    const amount = Number(formatUnits(raw[token.id] ?? 0n, token.decimals ?? 18))
+
+    const values: Record<string, TokenBalanceValue> = {}
+    for (const price of getTokenInfo(token.id)?.prices ?? []) {
+      const value = amount * (price.price ?? 0)
+      values[price.code] = {
+        value,
+        formated: formatCurrencyShort(value, price.code),
+        id: price.id,
+        code: price.code,
+        symbol: price.symbol,
+        price: price.price ?? 0,
+        formatedPrice: formatCurrencyShort(price.price ?? 0, price.code)
+      }
+    }
+
+    return { amount, token, values }
+  })
+}
+
+/**
+ * Sum every token balance per currency code.
+ *
+ * The currency set is taken from the first balance — all tokens are priced by
+ * the same store call, so they carry the same codes. `price` / `formatedPrice`
+ * are carried over from that first entry: a total spans several tokens, so it
+ * has no unit price of its own.
+ */
+export function sumTokenBalances(
+  balances: readonly TokenBalance[]
+): Record<string, TokenBalanceValue> {
+  const totals: Record<string, TokenBalanceValue> = {}
+  const first = balances[0]
+  if (!first) return totals
+
+  for (const code of Object.keys(first.values)) {
+    const reference = first.values[code]
+    if (!reference) continue
+    const sum = balances.reduce((acc, balance) => acc + (balance.values[code]?.value ?? 0), 0)
+    totals[code] = {
+      value: sum,
+      formated: formatCurrencyShort(sum, code),
+      id: reference.id,
+      code: reference.code,
+      symbol: reference.symbol,
+      price: reference.price,
+      formatedPrice: formatCurrencyShort(reference.price, code)
+    }
+  }
+
+  return totals
+}

--- a/app/src/queries/__tests__/safe.queries.spec.ts
+++ b/app/src/queries/__tests__/safe.queries.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { contractBalanceKeys } from '@/composables/useContractBalance'
 import { safeKeys } from '../safe.queries'
 
 describe('safeKeys', () => {
@@ -16,15 +17,13 @@ describe('safeKeys', () => {
     ])
   })
 
-  it('builds native balance and token balance keys', () => {
+  it('builds the balance key the contract-balance query owns', () => {
+    // Native and ERC-20 holdings share one key, so there is no separate
+    // per-token key to invalidate.
+    expect(safeKeys.balance('0xSafe', 137)).toEqual(contractBalanceKeys.detail('0xSafe', 137))
     expect(safeKeys.balance('0xSafe', 137)).toEqual([
       'balance',
       { address: '0xSafe', chainId: 137 }
-    ])
-
-    expect(safeKeys.tokenBalance('0xToken', '0xSafe', 137)).toEqual([
-      'readContract',
-      { address: '0xToken', args: ['0xSafe'], chainId: 137 }
     ])
   })
 })

--- a/app/src/queries/safe.mutations.ts
+++ b/app/src/queries/safe.mutations.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/vue-query'
 import { useChainId, useConnection } from '@wagmi/vue'
-import { isAddress, type Address } from 'viem'
+import { isAddress } from 'viem'
 import { SAFE_VERSION } from '@/types/safe'
 import externalApiClient from '@/lib/external.axios.ts'
 import type {
@@ -22,12 +22,7 @@ import {
   proposeSafeTransaction,
   waitForTransaction
 } from '@/utils/safe.mutations'
-import {
-  getExecutedErc20TransferTokenAddress,
-  getTxServiceUrl,
-  randomSaltNonce,
-  transformToSafeMultisigResponse
-} from '@/utils/safe'
+import { getTxServiceUrl, randomSaltNonce, transformToSafeMultisigResponse } from '@/utils/safe'
 import { getConnectedSigner } from '@/utils/walletUtil'
 import { safeKeys } from './safe.queries'
 
@@ -172,10 +167,10 @@ export function useExecuteTransactionMutation() {
       return txHash
     },
     onSuccess: async (_, variables) => {
-      const safeAddress = variables.pathParams.safeAddress as Address
       const chainId = variables.queryParams.chainId
-      const tokenAddress = getExecutedErc20TransferTokenAddress(variables.body.transactionData)
 
+      // One balance key per Safe now covers native and every ERC-20 it holds,
+      // so an executed transfer needs no per-token invalidation.
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: safeKeys.info(variables.pathParams.safeAddress)
@@ -185,14 +180,7 @@ export function useExecuteTransactionMutation() {
         }),
         queryClient.invalidateQueries({
           queryKey: safeKeys.balance(variables.pathParams.safeAddress, chainId)
-        }),
-        ...(tokenAddress
-          ? [
-              queryClient.invalidateQueries({
-                queryKey: safeKeys.tokenBalance(tokenAddress, safeAddress, chainId)
-              })
-            ]
-          : [])
+        })
       ])
     }
   })
@@ -327,10 +315,6 @@ export function useTransferFromSafeMutation() {
       return { hash, executed: true }
     },
     onSuccess: async (result, variables) => {
-      const safeAddress = variables.pathParams.safeAddress as Address
-      const tokenId = variables.body.options.tokenId ?? 'native'
-      const tokenAddress = getTokenAddress(tokenId)
-
       // Pending transactions (needed for proposals when threshold >= 2)
       await queryClient.invalidateQueries({
         queryKey: safeKeys.transactions(variables.pathParams.safeAddress)
@@ -340,15 +324,11 @@ export function useTransferFromSafeMutation() {
         return
       }
 
+      // Covers the transferred token whichever it was: native and ERC-20
+      // amounts share the Safe's single balance query.
       await queryClient.invalidateQueries({
         queryKey: safeKeys.balance(variables.pathParams.safeAddress, chainId.value)
       })
-
-      if (tokenAddress) {
-        await queryClient.invalidateQueries({
-          queryKey: safeKeys.tokenBalance(tokenAddress, safeAddress, chainId.value)
-        })
-      }
     }
   })
 }

--- a/app/src/queries/safe.queries.ts
+++ b/app/src/queries/safe.queries.ts
@@ -1,5 +1,7 @@
 import { useQuery } from '@tanstack/vue-query'
 import { toValue } from 'vue'
+import type { Address } from 'viem'
+import { contractBalanceKeys } from '@/composables/useContractBalance'
 import externalApiClient from '@/lib/external.axios.ts'
 import type { SafeInfo, SafeTransaction } from '@/types/safe'
 import { TX_SERVICE_BY_CHAIN } from '@/types/safe'
@@ -36,13 +38,12 @@ export const safeKeys = {
   outgoingTransactionLists: () => [...safeKeys.all, 'outgoing-transactions'] as const,
   outgoingTransactions: (safeAddress: string | undefined, limit?: number) =>
     [...safeKeys.outgoingTransactionLists(), { safeAddress, limit }] as const,
+  /**
+   * The Safe's token holdings — native and ERC-20 alike — live on the one key
+   * `useContractBalance` owns, so this delegates rather than restating it.
+   */
   balance: (address: string | undefined, chainId: number | undefined) =>
-    ['balance', { address, chainId }] as const,
-  tokenBalance: (
-    tokenAddress: string | undefined,
-    safeAddress: string | undefined,
-    chainId: number | undefined
-  ) => ['readContract', { address: tokenAddress, args: [safeAddress], chainId }] as const
+    contractBalanceKeys.detail(address as Address | undefined, chainId)
 }
 
 // ============================================================================

--- a/app/src/tests/mocks/composables.mock.ts
+++ b/app/src/tests/mocks/composables.mock.ts
@@ -1,14 +1,59 @@
 import { vi } from 'vitest'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+import type { TokenConfig } from '@/constant'
+import type { CurrencyPair, Money, TokenBalance } from '@/types'
+
+const FALLBACK_TOKEN: TokenConfig = {
+  id: 'native',
+  name: 'Ether',
+  symbol: 'ETH',
+  code: 'ETH',
+  coingeckoId: 'ethereum',
+  decimals: 18,
+  address: '0x0000000000000000000000000000000000000000'
+}
+
+const fixtureMoney = (value: number): Money => ({ value, formatted: `$${value}` })
+
+/**
+ * Build a `TokenBalance` fixture.
+ *
+ * Give it the amount and the unit prices — `raw` and the derived `value` side
+ * are computed, so a spec can never leave them contradicting each other. Only
+ * the fields a spec actually asserts on need overriding.
+ */
+export const makeTokenBalance = (
+  input: {
+    token?: Partial<TokenConfig>
+    amount?: number
+    raw?: bigint
+    usdPrice?: number
+    localPrice?: number
+  } = {}
+): TokenBalance => {
+  const token = { ...FALLBACK_TOKEN, ...input.token }
+  const amount = input.amount ?? 0
+  const usdPrice = input.usdPrice ?? 0
+  const localPrice = input.localPrice ?? usdPrice
+
+  return {
+    token,
+    amount,
+    raw: input.raw ?? BigInt(Math.round(amount * 10 ** token.decimals)),
+    price: { usd: fixtureMoney(usdPrice), local: fixtureMoney(localPrice) },
+    value: { usd: fixtureMoney(amount * usdPrice), local: fixtureMoney(amount * localPrice) }
+  }
+}
 
 /**
  * Default builders for the contract-balance mock state. Exposed as functions so
  * that `resetComposableMocks()` can restore a FRESH copy on every test, even
  * after a spec has mutated `balances.value` / `total.value` in place.
  */
-const defaultContractBalances = () => [
+const defaultContractBalances = (): TokenBalance[] => [
   {
     amount: 0.5,
+    raw: 500_000_000_000_000_000n,
     token: {
       id: 'native',
       name: 'SepoliaETH',
@@ -18,20 +63,12 @@ const defaultContractBalances = () => [
       decimals: 18,
       address: '0x0000000000000000000000000000000000000000'
     },
-    values: {
-      USD: {
-        value: 500,
-        formated: '$500',
-        id: 'usd',
-        code: 'USD',
-        symbol: '$',
-        price: 1000,
-        formatedPrice: '$1K'
-      }
-    }
+    price: { usd: { value: 1000, formatted: '$1K' }, local: { value: 1000, formatted: '$1K' } },
+    value: { usd: { value: 500, formatted: '$500' }, local: { value: 500, formatted: '$500' } }
   },
   {
     amount: 50,
+    raw: 50_000_000n,
     token: {
       id: 'usdc',
       name: 'USD Coin',
@@ -41,54 +78,47 @@ const defaultContractBalances = () => [
       decimals: 6,
       address: '0xA3492D046095AFFE351cFac15de9b86425E235dB'
     },
-    values: {
-      USD: {
-        value: 50000,
-        formated: '$50K',
-        id: 'usd',
-        code: 'USD',
-        symbol: '$',
-        price: 1000,
-        formatedPrice: '$1K'
-      }
-    }
+    price: { usd: { value: 1000, formatted: '$1K' }, local: { value: 1000, formatted: '$1K' } },
+    value: { usd: { value: 50000, formatted: '$50K' }, local: { value: 50000, formatted: '$50K' } }
   }
 ]
 
-const defaultContractTotal = () => ({
-  USD: {
-    value: 50500,
-    formated: '$50.5K',
-    id: 'usd',
-    code: 'USD',
-    symbol: '$',
-    price: 1000,
-    formatedPrice: '$1K'
-  }
-})
-
-const defaultDividendsTotal = () => ({
-  USD: {
-    value: 100,
-    formated: '$100',
-    id: 'usd',
-    code: 'USD',
-    symbol: '$',
-    price: 1000,
-    formatedPrice: '$1K'
-  }
+const defaultContractTotal = (): CurrencyPair => ({
+  usd: { value: 50500, formatted: '$50.5K' },
+  local: { value: 50500, formatted: '$50.5K' }
 })
 
 /**
- * Mock useContractBalance composable
+ * Mock useContractBalance composable.
+ *
+ * The composable returns a TanStack query whose `data` holds `{ balances,
+ * total }`. Specs steer it through the `balances` / `total` refs — `data` is
+ * derived from them, so setting either one is picked up by the component under
+ * test without rebuilding the whole payload.
+ *
+ * Set `hasData` to false to reproduce the pre-first-read state, where the real
+ * composable leaves `data` undefined.
  */
-export const mockUseContractBalance = {
+const contractBalanceState = {
   balances: ref(defaultContractBalances()),
   total: ref(defaultContractTotal()),
-  dividendsTotal: ref(defaultDividendsTotal()),
-  dividends: ref([]),
+  hasData: ref(true),
   isLoading: ref(false),
-  error: ref(null)
+  error: ref(null),
+  isFetching: ref(false),
+  refetch: vi.fn()
+}
+
+export const mockUseContractBalance = {
+  ...contractBalanceState,
+  data: computed(() =>
+    contractBalanceState.hasData.value
+      ? {
+          balances: contractBalanceState.balances.value,
+          total: contractBalanceState.total.value
+        }
+      : undefined
+  )
 }
 
 /**
@@ -211,10 +241,11 @@ export const resetComposableMocks = () => {
   // Reset contract balance state (fresh copies so in-place mutations don't leak)
   mockUseContractBalance.balances.value = defaultContractBalances()
   mockUseContractBalance.total.value = defaultContractTotal()
-  mockUseContractBalance.dividendsTotal.value = defaultDividendsTotal()
+  mockUseContractBalance.hasData.value = true
   mockUseContractBalance.isLoading.value = false
   mockUseContractBalance.error.value = null
-  mockUseContractBalance.dividends.value = []
+  mockUseContractBalance.isFetching.value = false
+  mockUseContractBalance.refetch.mockClear()
 
   // Reset native transaction states
   mockUseSafeSendTransaction.isPending.value = false

--- a/app/src/tests/setup/composables.setup.ts
+++ b/app/src/tests/setup/composables.setup.ts
@@ -299,9 +299,15 @@ vi.mock('@/composables/useAuth', () => ({
 /**
  * Mock useContractBalance composable
  */
-vi.mock('@/composables/useContractBalance', () => ({
-  useContractBalance: vi.fn(() => mockUseContractBalance)
-}))
+// `importOriginal` keeps `contractBalanceKeys` real: specs assert on the key the
+// component invalidates, and a hand-written factory would leave it undefined.
+vi.mock('@/composables/useContractBalance', async (importOriginal) => {
+  const actual: object = await importOriginal()
+  return {
+    ...actual,
+    useContractBalance: vi.fn(() => mockUseContractBalance)
+  }
+})
 
 /**
  * Mock useDeployContract composable

--- a/app/src/types/contract-balance.ts
+++ b/app/src/types/contract-balance.ts
@@ -1,17 +1,40 @@
-import type { SUPPORTED_TOKENS } from '@/constant'
+import type { TokenConfig } from '@/constant'
 
-export type TokenBalanceValue = {
+/** A monetary amount, with its display string precomputed. */
+export interface Money {
   value: number
-  formated: string
-  id: string
-  code: string
-  symbol: string
-  price: number
-  formatedPrice: string
+  /** `formatCurrencyShort(value, code)` — e.g. "$1.2K". */
+  formatted: string
 }
 
+/**
+ * The two currencies the currency store ever prices a token in: USD, and
+ * whatever the user selected.
+ *
+ * Keyed by role rather than by currency code on purpose — the store emits
+ * exactly these two rows, and when the local currency *is* USD a code-keyed
+ * map collapses them into one entry.
+ */
+export interface CurrencyPair {
+  usd: Money
+  local: Money
+}
+
+/** What one address holds of one token, priced. */
 export interface TokenBalance {
+  token: TokenConfig
+  /** Exact on-chain amount, in the token's smallest unit. */
+  raw: bigint
+  /** `raw` scaled by the token's decimals. Lossy — compare against `raw`. */
   amount: number
-  token: (typeof SUPPORTED_TOKENS)[number]
-  values: Record<string, TokenBalanceValue>
+  /** Price of a single token. */
+  price: CurrencyPair
+  /** Value of the holding: `amount` × price. */
+  value: CurrencyPair
+}
+
+/** Everything one address holds, plus the aggregate across tokens. */
+export interface ContractBalances {
+  balances: TokenBalance[]
+  total: CurrencyPair
 }

--- a/app/src/utils/expenseUtil.ts
+++ b/app/src/utils/expenseUtil.ts
@@ -55,7 +55,7 @@ export const getTokens = (
           balance: Number(balance),
           spendableBalance: spendableBalance,
           tokenId: tokenId as TokenId,
-          price: balances.find((b) => b.token.id === tokenId)?.values['USD']?.price || 0,
+          price: balances.find((b) => b.token.id === tokenId)?.price.usd.value || 0,
           code: balances.find((b) => b.token.id === tokenId)?.token.code || ''
         }
       ]


### PR DESCRIPTION
# Description

## Intial Issue Description

Fixes #2411

`useContractBalance` built one wagmi composable per token inside a `.map()` — a `useBalance` plus one `useReadContract` per ERC-20. The address was captured once through `unref()` (hence the standing `// TODO: support reactive address changes`), each token carried its own loading and error state, and a failing read reported an amount of 0 rather than an error, quietly producing a wrong total.

The returned shape had a defect of its own: `values` was keyed by currency **code**, but the currency store only ever emits two price rows identified by `id` — `local` and `usd`. When the local currency *is* USD (the default), both rows carry `code: 'USD'` and the second overwrote the first. `SafeBalanceSection`'s `?? total['USD']?.formated ?? 0` fallback existed purely to paper over that missed lookup.

## PR Summary Or Solution description

The composable is now one TanStack query per address, reading through `@wagmi/core` directly, and it returns **the query itself**.

```ts
const { data, isLoading, error, refetch } = useContractBalance(addr)

data.value // ContractBalances | undefined
// {
//   balances: [{ token, raw: 12500000n, amount: 12.5,
//                price: { usd: {value,formatted}, local: {…} },
//                value: { usd: {…}, local: {…} } }, …],
//   total:    { usd: { value: 2012.5, formatted: '$2.01K' }, local: {…} }
// }
```

**One query, one round-trip.** All token reads are issued in the same tick, so the batching http transport collapses them into a single JSON-RPC POST. One loading state, one error state. A failing read now fails the query instead of reporting a silent 0 and a wrong total.

**`data` is priced but reactive.** The query caches raw `bigint`s; `data` is a `computed` over them. `useQuery` returns `toRefs(...)` — an object of refs — so the query can be spread and `data` replaced without losing reactivity. Switching currency re-prices from cache with no refetch; a test asserts `getBalance` is not called again.

**`data` is `undefined` until the first read lands**, per TanStack semantics. A balance that is loading is no longer indistinguishable from a balance of 0.

**Amounts are keyed by currency role, not code.** `{ usd, local }` cannot collide, so call sites lose the optional chaining and the fallbacks on the currency dimension:

```diff
- total[currency.code]?.formated ?? total['USD']?.formated ?? 0
+ data?.total.local.formatted ?? 0
```

Fields with no reader anywhere (`id`, `code`, `symbol`) are gone, `code` no longer duplicates the map key, and a total no longer carries a unit price inherited from the first token. `raw` (the exact on-chain `bigint`) is exposed so "max" buttons and amount validations can stop comparing floats rebuilt from 18 decimals — `OwnerTreasuryWithdrawAction` already uses it.

Fetching and currency derivation moved to `app/src/lib/balances/tokenBalances.ts` as pure functions, unit-tested without Vue.

## Issues introduced and fixed

Three latent bugs surfaced and were fixed along the way:

- **`chainId` passed as a ref into invalidation keys.** `DepositBankForm` and `DepositSafeForm` put the `Ref` itself in the key object, so `partialDeepEqual` compared a `Ref` against a `number` and those invalidations never matched anything.
- **The global module mock swallowed `contractBalanceKeys`.** `vi.mock('@/composables/useContractBalance', () => ({ useContractBalance }))` returned only the function, leaving the constant `undefined`; `contractBalanceKeys.detail(...)` threw a `TypeError` the component's `catch` absorbed, so the invalidation silently never fired and the test still passed. Now goes through `importOriginal`.
- **`GenericTokenHoldingsSection` sorted on fields the row never had.** The `price` and `balance` accessors pointed at properties absent from `TokenBalance`, so sorting was a no-op. Rows are built in a computed with sortable scalars.

Worth knowing: `tsconfig.app.json` excludes `__tests__` and `*.spec.ts`, so spec fixtures are **not** type-checked — several carried the old shape without any compile error. The new shared `makeTokenBalance` derives `raw` and `value` from the amount and price, so a fixture can no longer contradict itself.

## Contribution

Four atomic commits, each reviewable on its own:

| commit | scope |
|---|---|
| `7239efb7b` | composable → TanStack Query + `@wagmi/core`, pure layer in `lib/balances/` |
| `2720ff9e8` | data structure keyed by currency role |
| `f725f59ae` | 16 view consumers, specs, shared test mocks |
| `aaa71ab4f` | invalidations routed through `contractBalanceKeys` |

**Invalidation contract.** The query key deliberately keeps wagmi's `['balance', { address, chainId }]` shape, because a dozen call sites invalidate it by hand after a transfer, deposit or withdrawal — they keep working untouched. A `contractBalanceKeys` factory is exported so new call sites stop hand-rolling the literal, and `safeKeys.balance` now delegates to it. `safeKeys.tokenBalance` is removed: it built a per-ERC-20 `readContract` key that no longer backs any balance display, and both Safe mutations already invalidated `safeKeys.balance` alongside it.

**One judgement call worth a reviewer's eye:** `SafeBalanceSection.transfer.spec.ts` had an ETH fixture with `id: 'ethereum'`, which is not a valid `TokenId` — the old fixture was untyped. It is now `'native'`, and the `tokenId` assertion follows. If an `'ethereum'` token id genuinely circulates on the Safe path, that is a bug elsewhere; the typing says it does not.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Breaking in the sense that the composable's public shape changed; every consumer in the repo is migrated in this PR.

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Verification

- `npm run build-only` then `npm run type-check` — 0 errors
- `npm run test:unit` — 311 files, 2646 passed, 1 skipped
- `prettier --check src` — clean
- `eslint src` — 0 errors (1 pre-existing warning in an unrelated spec)


## Large PR justification

This changes the public shape of a composable used by 16 components, so the migration is atomic by construction: **every intermediate split leaves the repo unable to type-check.**

I did try the suggested decompositions:

- **Stack PRs** — the natural base would be commits `7239efb7b` + `2720ff9e8` (composable and data structure). Merged to `develop` on its own, that base breaks the build: all 16 consumers still destructure `{ balances, total }`, which no longer exists. A stack whose base cannot be merged independently is not a stack, it is this PR with extra review surface.
- **Extract prep work** — the new pure layer (`lib/balances/tokenBalances.ts`) and the shared `makeTokenBalance` fixture builder *could* land first, but they are 130 production lines with no caller until the composable switches over. Landing dead code first does not reduce what a reviewer has to hold in their head; it spreads it across two PRs.
- **Separate refactors from behavior changes** — there is no behavior change to separate out. The three bug fixes listed above are one-line consequences of the same shape change (a ref that had to be unwrapped, a mock factory that had to reexport, table accessors that had to point at real fields).
- **Split by layer** — everything here is `app/`.

On the numbers: the 843 test lines are almost entirely fixture rewrites forced by the same shape change, and they are a **net reduction** — the diff is 294 insertions against 473 deletions overall. Three specs had grown their own hand-rolled balance builders; those are replaced by one shared `makeTokenBalance`.

The four commits are individually reviewable and are best read in order — each has a message explaining its own rationale.
