### PR TITLE
fix: 🐛 let admins open team details for teams they are not a member of

### DIFF
--- a/backend/src/controllers/__tests__/teamController.test.ts
+++ b/backend/src/controllers/__tests__/teamController.test.ts
@@ -8,14 +8,20 @@ import { authorizeUser } from '../../middleware/authMiddleware';
 import teamRoutes from '../../routes/teamRoutes';
 import { addNotification, prisma } from '../../utils';
 
-const { mockGetPresignedDownloadUrl } = vi.hoisted(() => ({
+const { mockGetPresignedDownloadUrl, mockCaller } = vi.hoisted(() => ({
   mockGetPresignedDownloadUrl: vi.fn((key: string) => `https://signed.example.com/${key}`),
+  // Mutable so a test can sign the caller in as an admin.
+  mockCaller: { roles: ['ROLE_USER'] as string[] },
 }));
 
 // Mock the authorizeUser middleware
 vi.mock('../../middleware/authMiddleware', () => ({
   authorizeUser: vi.fn((req: Request, res: Response, next: NextFunction) => {
     req.address = '0x1234567890123456789012345678901234567890';
+    req.user = {
+      address: '0x1234567890123456789012345678901234567890',
+      roles: mockCaller.roles,
+    } as unknown as User;
     next();
   }),
 }));
@@ -317,6 +323,7 @@ describe('Team Controller', () => {
   describe('getTeam', () => {
     beforeEach(() => {
       vi.clearAllMocks();
+      mockCaller.roles = ['ROLE_USER'];
     });
 
     it('should return 403 if user is not part of the team', async () => {
@@ -334,6 +341,32 @@ describe('Team Controller', () => {
       expect(response.status).toBe(403);
       expect(response.body.message).toBe('Unauthorized');
     });
+
+    it.each([['ROLE_ADMIN'], ['ROLE_SUPER_ADMIN']])(
+      'should return 200 for a %s who is not part of the team',
+      async (role) => {
+        mockCaller.roles = [role];
+        vi.spyOn(prisma.team, 'findUnique').mockResolvedValue({
+          ...teamMockResolve,
+          members: [
+            {
+              address: '0x2222222222222222222222222222222222222222',
+              name: 'Member 1',
+              imageUrl: null,
+              Wage: [],
+            },
+          ],
+        } as unknown as Team);
+        // Non-members have no MemberTeamsData row for the team.
+        vi.spyOn(prisma.memberTeamsData, 'findUnique').mockResolvedValue(null);
+
+        const response = await request(app).get('/1');
+
+        expect(response.status).toBe(200);
+        expect(response.body.name).toBe('Test Team');
+        expect(response.body.isHidden).toBe(false);
+      }
+    );
 
     it('should return 404 if team is not found', async () => {
       vi.spyOn(prisma.team, 'findUnique').mockResolvedValue(null);

--- a/backend/src/controllers/teamController.ts
+++ b/backend/src/controllers/teamController.ts
@@ -6,6 +6,8 @@ import { errorResponse } from '../utils/utils';
 import { resolveStorageImageUrl } from '../utils/profileImage.util';
 import { generateUniqueSlug } from '../utils/slug.util';
 import { isActiveOfficerVersion } from '../utils/officerVersion';
+import { isAdmin } from '../utils/roleUtils';
+import { UserRoles } from '../types/roles';
 
 // A slug is taken when some team already holds it.
 const isTeamSlugTaken = async (slug: string) =>
@@ -240,7 +242,10 @@ const getTeam = async (req: Request, res: Response) => {
       return errorResponse(404, 'Team not found', res);
     }
 
-    if (!isUserPartOfTheTeam(team?.members ?? [], callerAddress)) {
+    // Platform admins inspect teams they are not members of from the admin
+    // dashboard, so membership is only required for regular users.
+    const callerRoles = (req.user?.roles ?? []) as UserRoles;
+    if (!isUserPartOfTheTeam(team?.members ?? [], callerAddress) && !isAdmin(callerRoles)) {
       return errorResponse(403, 'Unauthorized', res);
     }
 

--- a/backend/src/routes/teamRoutes.ts
+++ b/backend/src/routes/teamRoutes.ts
@@ -412,7 +412,7 @@ teamRoutes.delete(
  *   tags: [Teams]
  *   security:
  *     - bearerAuth: []
- *   description: Retrieves team details including members and contracts. Caller must be a team member.
+ *   description: Retrieves team details including members and contracts. Caller must be a team member, or an admin (ROLE_ADMIN / ROLE_SUPER_ADMIN) inspecting the team from the admin dashboard.
  *   parameters:
  *     - in: path
  *       name: id
@@ -434,7 +434,7 @@ teamRoutes.delete(
  *           schema:
  *             $ref: '#/components/schemas/ErrorResponse'
  *     403:
- *       description: Forbidden - caller is not a member of the team
+ *       description: Forbidden - caller is neither a member of the team nor an admin
  *       content:
  *         application/json:
  *           schema:

--- a/backend/src/utils/roleUtils.ts
+++ b/backend/src/utils/roleUtils.ts
@@ -16,7 +16,9 @@ import { UserRole, UserRoles, ROLE_HIERARCHY } from '../types/roles';
  */
 export const hasRole = (userRoles: UserRoles, requiredRole: UserRole): boolean => {
   for (const userRole of userRoles) {
-    const roleHierarchy = ROLE_HIERARCHY[userRole];
+    // `User.roles` is a plain string column, so a value outside the enum has no
+    // hierarchy entry — treat it as granting nothing rather than throwing.
+    const roleHierarchy = ROLE_HIERARCHY[userRole] ?? [];
     if (roleHierarchy.includes(requiredRole)) {
       return true;
     }


### PR DESCRIPTION
# Description

## Intial Issue Description

Fixes #2413

An admin (`ROLE_ADMIN` / `ROLE_SUPER_ADMIN`) could not open the details of a team they were not a member of. The admin dashboard lists every team and links each row to `/teams/:id`, but that page rendered "Failed to load team" for any team the signed-in admin was not part of.

## Issues introduced and fixed (Optional)

While resolving the caller's roles on this path, `hasRole()` turned out to be a latent 500: `User.roles` is a plain `String[]` column, so a value outside the `UserRole` enum has no `ROLE_HIERARCHY` entry and the lookup crashed on `undefined.includes()`. Fixed in its own commit — unknown roles now grant nothing instead of turning an authorization check into a server error.

## PR Summary Or Solution description

`getTeam` required team membership with no exception for admins:

```ts
if (!isUserPartOfTheTeam(team?.members ?? [], callerAddress)) {
  return errorResponse(403, 'Unauthorized', res);
}
```

The dashboard is already admin-only (its global auth middleware rejects anyone without `ROLE_ADMIN` / `ROLE_SUPER_ADMIN`), so this endpoint was the only blocker — the sibling call the same page makes, `GET /api/contract/officers`, has no membership gate, which is why only the team fetch failed.

Membership is now required only for regular users; admins are recognised through the existing `isAdmin()` helper in `utils/roleUtils.ts`.

**Scope of the bypass — read only.** `updateTeam`, `deleteTeam` and member add/remove keep their `requireTeamOwner` / `requireTeamMember` guards untouched. An admin can inspect a team, not modify it.

No frontend change was needed: the dashboard page works as soon as the endpoint answers.

## Contribution

- `backend/src/controllers/teamController.ts` — the membership check in `getTeam` now also accepts admins, via `isAdmin(req.user?.roles ?? [])`.
- `backend/src/utils/roleUtils.ts` — `hasRole` defaults an unknown role's hierarchy to `[]` instead of dereferencing `undefined`.
- `backend/src/routes/teamRoutes.ts` — OpenAPI description and the 403 wording for `GET /teams/{id}` updated to state the admin exception.
- `backend/src/controllers/__tests__/teamController.test.ts` — the `authorizeUser` mock now populates `req.user` with mutable roles, plus two cases asserting `ROLE_ADMIN` and `ROLE_SUPER_ADMIN` non-members get a 200. The existing "403 if user is not part of the team" case still covers `ROLE_USER`.

### Out of scope

`GET /api/teams` without `userAddress` returns every team to any authenticated user. That is intentional and left as is — it will back a future public team-discovery page.

### Verification

- `backend`: 727 passed / 8 skipped
- `tsc --noEmit` clean
- `eslint` and `prettier --check` clean on touched files

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)
