### PR TITLE
feat: ✨ add an "as of" date picker to the accounting Summary

### DIFF
--- a/dashboard/app/components/accounting/AccountingSummary.vue
+++ b/dashboard/app/components/accounting/AccountingSummary.vue
@@ -1,5 +1,22 @@
 <template>
   <div class="space-y-4">
+    <!-- Reporting date — "as of" snapshot, same picker as the Balance Sheet. -->
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+      <h3 class="font-semibold text-black dark:text-white">
+        Summary
+      </h3>
+      <AccountingDatePicker
+        v-model="asOf"
+        mode="date"
+        storage-key="dashboard-accounting-summary-asof"
+      />
+    </div>
+
+    <p v-if="!snapshot.isCurrent" class="text-xs text-muted">
+      Snapshot as of a past date: bets still open then are carried at cost, because Polymarket
+      publishes no historical market price. Figures that only exist for today are shown as “—”.
+    </p>
+
     <!-- Headline: Polymarket comparison + our bottom line -->
     <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
       <div class="flex items-center gap-2">
@@ -8,16 +25,16 @@
         </p>
         <AccountingMetricExplainer
           title="Total return"
-          description="The bottom-line answer to 'did I make or lose money on Polymarket?'. It compares what your wallet is worth right now to what you originally put in."
+          description="The bottom-line answer to 'did I make or lose money on Polymarket?'. It compares what your wallet was worth on the reporting date to what you originally put in."
           formula="Portfolio value − Net deposits"
           example="If you deposited $1,000 and your wallet (cash + open bets) is now worth $1,150, total return is +$150."
         />
       </div>
-      <p class="text-3xl font-bold tabular-nums" :class="signClass(summary.totalReturn)">
-        {{ formatSignedUsd(summary.totalReturn) }}
+      <p class="text-3xl font-bold tabular-nums" :class="headline.totalReturn.valueClass">
+        {{ headline.totalReturn.value }}
       </p>
       <p class="text-xs text-muted">
-        Portfolio value − net deposits
+        {{ headline.totalReturn.hint }}
       </p>
     </UPageCard>
 
@@ -29,15 +46,15 @@
           </p>
           <AccountingMetricExplainer
             title="Polymarket displayed profit/loss"
-            description="All-time profit or loss — the same figure Polymarket shows on your profile page Profit/Loss chart. Pulled from Polymarket's user-pnl API (not reconstructed from /positions), so it stays in sync with polymarket.com/profile even when individual position rows are purged or carry stale per-market P&L."
+            description="All-time profit or loss — the same figure Polymarket shows on your profile page Profit/Loss chart. Pulled from Polymarket's user-pnl API (not reconstructed from /positions), so it stays in sync with polymarket.com/profile even when individual position rows are purged or carry stale per-market P&L. It is an all-time figure only, so a past snapshot leaves it blank."
             formula="Latest point from user-pnl-api.polymarket.com"
           />
         </div>
-        <p class="text-3xl font-bold tabular-nums" :class="signClass(summary.polymarketPnl)">
-          {{ formatSignedUsd(summary.polymarketPnl) }}
+        <p class="text-3xl font-bold tabular-nums" :class="headline.polymarketPnl.valueClass">
+          {{ headline.polymarketPnl.value }}
         </p>
         <p class="text-xs text-muted">
-          All-time (Polymarket)
+          {{ headline.polymarketPnl.hint }}
         </p>
       </UPageCard>
       <UPageCard variant="subtle" :ui="{ container: 'gap-1' }">
@@ -53,10 +70,10 @@
           />
         </div>
         <p class="text-3xl font-bold tabular-nums">
-          {{ formatUsd(summary.totalFees) }}
+          {{ headline.fees.value }}
         </p>
         <p class="text-xs text-muted">
-          {{ summary.feeTransactionCount === 1 ? '1 transaction' : `${summary.feeTransactionCount} transactions` }}
+          {{ headline.fees.hint }}
         </p>
       </UPageCard>
     </div>
@@ -96,156 +113,30 @@
 </template>
 
 <script setup lang="ts">
-import { type AccountingSummary, formatSignedUsd, formatUsd, signClass } from '~/utils/accounting'
+import type { AccountingSummary, LedgerEntry } from '~/utils/accounting'
+import type { RealizedTrade } from '~/utils/incomeStatement'
+import { defaultValueForMode, toUnixSeconds } from '~/utils/datePicker'
+import { buildSummarySnapshot } from '~/utils/summaryAsOf'
+import { buildSummaryHeadline, buildSummaryStats } from '~/utils/summaryStats'
 import AccountingMetricExplainer from './AccountingMetricExplainer.vue'
 
-const props = defineProps<{ summary: AccountingSummary }>()
+const props = defineProps<{
+  /** Live all-time summary — what a "Today" snapshot renders unchanged. */
+  summary: AccountingSummary
+  ledgerEntries: LedgerEntry[]
+  realizedTrades: RealizedTrade[]
+}>()
 
-interface Explainer {
-  description: string
-  formula?: string
-  example?: string
-}
+// Point-in-time "as of" date (date mode) — defaults to end of today (current snapshot).
+const asOf = ref<Date>(defaultValueForMode('date') as Date)
 
-interface Stat {
-  label: string
-  value: string
-  hint?: string
-  valueClass?: string
-  explainer: Explainer
-}
+const snapshot = computed(() => buildSummarySnapshot({
+  summary: props.summary,
+  ledgerEntries: props.ledgerEntries,
+  realizedTrades: props.realizedTrades,
+  asOf: toUnixSeconds(asOf.value)
+}))
 
-const detailRows = computed<Stat[][]>(() => {
-  const s = props.summary
-  return [
-    // Row 1 — portfolio building blocks
-    [
-      {
-        label: 'Net deposits',
-        value: formatUsd(s.netDeposits),
-        hint: 'Capital committed',
-        explainer: {
-          description: 'The capital you\'ve actually committed to Polymarket: every USDC you sent to your Polymarket wallet, minus every USDC you withdrew.',
-          formula: 'Total deposits − Total withdrawals',
-          example: 'Deposit $500, then later withdraw $100, your net deposits are $400.'
-        }
-      },
-      {
-        label: 'Free cash balance',
-        value: formatUsd(s.currentCashBalance),
-        hint: 'On-chain USDC',
-        explainer: {
-          description: 'USDC currently sitting idle in your wallet — what you could withdraw or use to place a new bet without selling anything. Read directly from on-chain transfers, so it always matches Polygon.',
-          formula: 'Σ USDC received − Σ USDC sent (Etherscan)'
-        }
-      },
-      {
-        label: 'Open positions value',
-        value: formatUsd(s.openPositionsValue),
-        hint: 'Mark-to-market',
-        explainer: {
-          description: 'What your still-open bets would be worth if you sold them right now, at current market prices. A bet on a question that hasn\'t resolved yet is worth somewhere between $0 and $1 per share — this is the live market quote.',
-          formula: 'Σ (open shares × current price) per market'
-        }
-      }
-    ],
-    // Row 2 — portfolio total + realized
-    [
-      {
-        label: 'Open contracts at cost',
-        value: formatUsd(s.openContractsAtCost),
-        hint: 'Cost basis',
-        explainer: {
-          description: 'What you originally paid for the bets you still hold — their cost basis, not their current market price. Compare it to \'Open positions value\' to see your paper gain or loss: paying more than they\'re now worth means you\'re sitting on an unrealized loss. This is also the value the balance sheet books open contracts at.',
-          formula: 'Σ acquisitions − Σ disposals (cost basis)',
-          example: 'You paid $3.86 for bets now quoted at $0.71 → you\'re holding a ~$3.15 unrealized loss.'
-        }
-      },
-      {
-        label: 'Portfolio value',
-        value: formatUsd(s.totalPortfolioValue),
-        hint: 'Cash + positions',
-        explainer: {
-          description: 'Everything your Polymarket wallet is worth right now: idle cash plus the current market value of every open bet.',
-          formula: 'Free cash balance + Open positions value'
-        }
-      },
-      {
-        label: 'Realized P&L',
-        value: formatSignedUsd(s.realizedPnl),
-        valueClass: signClass(s.realizedPnl),
-        hint: 'Lot accounting — same as Income Statement',
-        explainer: {
-          description: 'Money you actually locked in: when you sold shares, when a market resolved and you redeemed, when you merged shares back to cash, or when a losing bet resolved without redemption. Computed with weighted-average-cost lot accounting on every trade.',
-          formula: 'Σ (proceeds − cost basis) per disposed lot',
-          example: 'You bought 100 "Yes" shares for $40 ($0.40 each) and sold them later for $60 ($0.60 each). Realized P&L on this trade = +$20.'
-        }
-      }
-    ],
-    // Row 3 — capital flow + unrealized
-    [
-      {
-        label: 'Total deposits',
-        value: formatUsd(s.totalDeposits),
-        valueClass: 'text-emerald-600 dark:text-emerald-400',
-        explainer: {
-          description: 'Every USDC you ever sent to your Polymarket wallet from an outside address. We get this from Polygon (Etherscan) directly — it never relies on Polymarket reporting.',
-          formula: 'Σ incoming USDC transfers (Etherscan)'
-        }
-      },
-      {
-        label: 'Total withdrawals',
-        value: formatUsd(s.totalWithdrawals),
-        valueClass: 'text-rose-600 dark:text-rose-400',
-        explainer: {
-          description: 'Every USDC you ever sent out of your Polymarket wallet to an outside address.',
-          formula: 'Σ outgoing USDC transfers (Etherscan)'
-        }
-      },
-      {
-        label: 'Unrealized P&L',
-        value: formatSignedUsd(s.unrealizedPnl),
-        valueClass: signClass(s.unrealizedPnl),
-        hint: 'Open positions',
-        explainer: {
-          description: 'Paper profit or loss on bets still in play, i.e. how much the current market price differs from what you originally paid. It can swing either way until the market resolves.',
-          formula: 'Σ (current value − initial cost) per open position',
-          example: 'You paid $0.40 per share for 100 "Yes" shares. The market now trades at $0.55. Unrealized P&L = +$15.'
-        }
-      }
-    ],
-    // Row 4 — activity & reconciliation
-    [
-      {
-        label: 'Rewards earned',
-        value: formatUsd(s.totalRewards),
-        valueClass: 'text-emerald-600 dark:text-emerald-400',
-        explainer: {
-          description: 'Free USDC Polymarket has paid you: liquidity-provider rewards, maker rebates, and referral payouts. Not the result of any trade — it just lands in your wallet.',
-          formula: 'Σ REWARD + MAKER_REBATE + REFERRAL_REWARD activity rows'
-        }
-      },
-      {
-        label: 'Trading volume',
-        value: formatUsd(s.tradingVolume),
-        hint: `${s.tradeCount} trades`,
-        explainer: {
-          description: 'Gross USD value you have traded — buys + sells combined. This is a turnover number, not a profit number: a $1,000 round trip (buy and resell) counts as $2,000 of volume.',
-          formula: 'Σ BUY usdcSize + Σ SELL usdcSize'
-        }
-      },
-      {
-        label: 'Position basis drift',
-        value: formatSignedUsd(s.positionBasisDrift),
-        valueClass: signClass(s.positionBasisDrift),
-        hint: 'Polymarket basis vs ours',
-        explainer: {
-          description: 'Reconciliation entry for the gap between Polymarket\'s own reported cost basis on open positions (their cashPnl) and what our weighted-average-cost lot accounting derives from /activity. Without it, the Total return identity would gap by exactly this amount.',
-          formula: 'openPositionsValue − openContractsAtCost − unrealizedPnl',
-          example: 'Polymarket says you have $100 of open positions with $20 of unrealized profit (basis $80). Our /activity lot accounting computes a basis of $75. Drift = $100 − $75 − $20 = +$5.'
-        }
-      }
-    ]
-  ]
-})
+const headline = computed(() => buildSummaryHeadline(snapshot.value.summary, snapshot.value.isCurrent))
+const detailRows = computed(() => buildSummaryStats(snapshot.value.summary, snapshot.value.isCurrent))
 </script>

--- a/dashboard/app/pages/accounting.vue
+++ b/dashboard/app/pages/accounting.vue
@@ -111,7 +111,11 @@ const errorMessage = computed(() => {
       <UTabs :items="tabs" variant="link" class="w-full">
         <template #summary>
           <div v-if="hasAddress" class="mt-4 space-y-6">
-            <AccountingSummary :summary="summary" />
+            <AccountingSummary
+              :summary="summary"
+              :ledger-entries="entries"
+              :realized-trades="realizedTrades"
+            />
             <!-- Live audit: each line proves one of the 8 accounting equations
                  over the loaded data. A non-zero gap points at the failing source
                  (truncated history, missing market, lot-accounting regression). -->

--- a/dashboard/app/utils/summaryAsOf.ts
+++ b/dashboard/app/utils/summaryAsOf.ts
@@ -1,0 +1,155 @@
+import type { AccountingSummary, LedgerCategory, LedgerEntry } from '~/utils/accounting'
+import type { RealizedTrade } from '~/utils/incomeStatement'
+
+/**
+ * Point-in-time snapshot of the accounting Summary — issue #2103.
+ *
+ * The Summary is otherwise an all-time view. Bounding it by a date reuses the
+ * same principle as the Balance Sheet (`~/utils/balanceSheet`): every figure is
+ * rebuilt from the *dated* feeds (the ledger entries and the lot-accounting
+ * disposals), keeping only what had already happened on the reporting date.
+ *
+ * Two families of figures live in the Summary:
+ *
+ *  - **Dated** — deposits, withdrawals, cash, rewards, fees, volume, realized
+ *    P&L, cost of open contracts. All of them carry a timestamp, so they can be
+ *    replayed for any date.
+ *  - **Live** — open-position market value, unrealized P&L and the profile P&L
+ *    figure. These come from the `/positions` and `user-pnl` feeds, which only
+ *    ever describe *now*: Polymarket exposes no historical quote per market.
+ *
+ * A past snapshot therefore carries open contracts **at cost**, exactly like the
+ * Balance Sheet does, and reports the live figures as unavailable rather than
+ * pretending today's market prices applied back then. Under that convention the
+ * accounting identity still closes to the cent:
+ * `cash + contractsAtCost ≡ netDeposits + realizedPnl + rewards + settlements`.
+ */
+
+export interface SummarySnapshot {
+  /** Summary bounded by {@link asOf}. */
+  summary: AccountingSummary
+  /** Reporting date (unix seconds). */
+  asOf: number
+  /**
+   * True when the snapshot reaches the present, i.e. the live mark-to-market
+   * figures are meaningful and the Summary renders exactly as it always has.
+   */
+  isCurrent: boolean
+}
+
+interface BuildSummarySnapshotInput {
+  /** The live all-time summary — returned untouched for a current snapshot. */
+  summary: AccountingSummary
+  ledgerEntries: LedgerEntry[]
+  realizedTrades: RealizedTrade[]
+  /** Reporting date (unix seconds); omit for all-time / now. */
+  asOf?: number
+  /** Injectable clock, so the snapshot is deterministic under test. */
+  now?: number
+}
+
+const REWARD_CATEGORIES: ReadonlySet<LedgerCategory> = new Set<LedgerCategory>([
+  'REWARD',
+  'MAKER_REBATE',
+  'REFERRAL_REWARD'
+])
+
+/** Zeroed base — every field is filled in below, this only keeps the shape honest. */
+function emptySummary(): AccountingSummary {
+  return {
+    totalDeposits: 0,
+    totalWithdrawals: 0,
+    netDeposits: 0,
+    realizedPnl: 0,
+    positionsRealizedPnl: 0,
+    unrealizedPnl: 0,
+    polymarketPnl: 0,
+    openPositionsValue: 0,
+    openContractsAtCost: 0,
+    totalRewards: 0,
+    tradingVolume: 0,
+    tradeCount: 0,
+    settlementAdjustments: 0,
+    settlementAdjustmentCount: 0,
+    totalFees: 0,
+    feeTransactionCount: 0,
+    positionBasisDrift: 0,
+    currentCashBalance: 0,
+    totalPortfolioValue: 0,
+    totalReturn: 0,
+    reconciliationGap: 0
+  }
+}
+
+/**
+ * Rebuilds the Summary as of the given date.
+ *
+ * When the date reaches the present the live summary is returned as-is — the
+ * default "Today" selection must render precisely what the Summary rendered
+ * before this option existed.
+ */
+export function buildSummarySnapshot(input: BuildSummarySnapshotInput): SummarySnapshot {
+  const now = input.now ?? Math.floor(Date.now() / 1000)
+  const asOf = input.asOf ?? Number.POSITIVE_INFINITY
+
+  if (asOf >= now) {
+    return { summary: input.summary, asOf: Number.isFinite(asOf) ? asOf : now, isCurrent: true }
+  }
+
+  const summary = emptySummary()
+  let acquisitionCost = 0
+  for (const entry of input.ledgerEntries) {
+    if (entry.timestamp > asOf) {
+      continue
+    }
+    summary.currentCashBalance += entry.cashFlow
+
+    if (entry.category === 'DEPOSIT') {
+      summary.totalDeposits += entry.amount
+    } else if (entry.category === 'WITHDRAWAL') {
+      summary.totalWithdrawals += entry.amount
+    } else if (entry.category === 'TRADE_BUY' || entry.category === 'TRADE_SELL') {
+      summary.tradingVolume += entry.amount
+      summary.tradeCount += 1
+      // Fees are baked into the fill price, so they are the gap between the
+      // quoted value and what actually moved — same derivation as buildLedger().
+      if (entry.unitPrice != null && entry.quantity != null) {
+        const fee = Math.abs(entry.quantity * entry.unitPrice - entry.amount)
+        summary.totalFees += fee
+        if (fee > 1e-4) {
+          summary.feeTransactionCount += 1
+        }
+      }
+    } else if (REWARD_CATEGORIES.has(entry.category)) {
+      summary.totalRewards += entry.amount
+    } else if (entry.category === 'SETTLEMENT_ADJUSTMENT') {
+      summary.settlementAdjustments += entry.cashFlow
+      summary.settlementAdjustmentCount += 1
+    }
+
+    if (entry.category === 'TRADE_BUY' || entry.category === 'SPLIT') {
+      acquisitionCost += entry.amount
+    }
+  }
+
+  let disposedCost = 0
+  for (const trade of input.realizedTrades) {
+    if (trade.timestamp > asOf) {
+      continue
+    }
+    disposedCost += trade.costBasis
+    summary.realizedPnl += trade.realizedPnl
+  }
+
+  summary.netDeposits = summary.totalDeposits - summary.totalWithdrawals
+  summary.openContractsAtCost = acquisitionCost - disposedCost
+  // Contracts held on that date are carried at cost: no historical quote exists,
+  // and at cost the balance-sheet identity holds exactly (see the module doc).
+  summary.openPositionsValue = summary.openContractsAtCost
+  summary.totalPortfolioValue = summary.currentCashBalance + summary.openPositionsValue
+  summary.totalReturn = summary.totalPortfolioValue - summary.netDeposits
+  summary.reconciliationGap = summary.totalReturn
+    - (summary.realizedPnl + summary.totalRewards + summary.settlementAdjustments)
+
+  return { summary, asOf, isCurrent: false }
+}

--- a/dashboard/app/utils/summaryStats.ts
+++ b/dashboard/app/utils/summaryStats.ts
@@ -1,0 +1,195 @@
+import type { AccountingSummary } from '~/utils/accounting'
+import { formatSignedUsd, signClass } from '~/utils/accounting'
+import { EMPTY_VALUE, formatUsd } from '~/utils/format'
+
+/**
+ * Presentation model for the accounting Summary cards — the labels, values and
+ * explainer copy `AccountingSummary.vue` renders, kept out of the component so
+ * it stays a description of the layout.
+ *
+ * Every card is derived from a {@link AccountingSummary} snapshot. `isCurrent`
+ * says whether that snapshot reaches the present: a past snapshot has no
+ * mark-to-market data (see `~/utils/summaryAsOf`), so the live-only cards render
+ * a dash and say why instead of showing today's prices under a past date.
+ */
+
+export interface SummaryStatExplainer {
+  description: string
+  formula?: string
+  example?: string
+}
+
+export interface SummaryStat {
+  label: string
+  value: string
+  hint?: string
+  valueClass?: string
+  explainer: SummaryStatExplainer
+}
+
+const POSITIVE_CLASS = 'text-emerald-600 dark:text-emerald-400'
+const NEGATIVE_CLASS = 'text-rose-600 dark:text-rose-400'
+
+/** Hint carried by every card whose source feed only ever describes *now*. */
+const LIVE_ONLY_HINT = 'Live figure — today only'
+
+/** Renders a live-only figure, or a dash when the snapshot is dated in the past. */
+function live(isCurrent: boolean, value: () => string): string {
+  return isCurrent ? value() : EMPTY_VALUE
+}
+
+/** The 12 detail cards, laid out as 4 rows of 3 (portfolio → capital → activity). */
+export function buildSummaryStats(s: AccountingSummary, isCurrent: boolean): SummaryStat[][] {
+  return [
+    // Row 1 — portfolio building blocks
+    [
+      {
+        label: 'Net deposits',
+        value: formatUsd(s.netDeposits),
+        hint: 'Capital committed',
+        explainer: {
+          description: 'The capital you\'ve actually committed to Polymarket: every USDC you sent to your Polymarket wallet, minus every USDC you withdrew.',
+          formula: 'Total deposits − Total withdrawals',
+          example: 'Deposit $500, then later withdraw $100, your net deposits are $400.'
+        }
+      },
+      {
+        label: 'Free cash balance',
+        value: formatUsd(s.currentCashBalance),
+        hint: isCurrent ? 'On-chain USDC' : 'On-chain USDC on that date',
+        explainer: {
+          description: 'USDC sitting idle in your wallet — what you could withdraw or use to place a new bet without selling anything. Read directly from on-chain transfers, so it always matches Polygon.',
+          formula: 'Σ USDC received − Σ USDC sent (Etherscan)'
+        }
+      },
+      {
+        label: 'Open positions value',
+        value: formatUsd(isCurrent ? s.openPositionsValue : s.openContractsAtCost),
+        hint: isCurrent ? 'Mark-to-market' : 'At cost — no historical quote',
+        explainer: {
+          description: 'What your still-open bets would be worth if you sold them right now, at current market prices. A bet on a question that hasn\'t resolved yet is worth somewhere between $0 and $1 per share — this is the live market quote. On a past date there is no quote to read, so the bets held then are carried at what they cost, like the Balance Sheet does.',
+          formula: 'Σ (open shares × current price) per market'
+        }
+      }
+    ],
+    // Row 2 — portfolio total + realized
+    [
+      {
+        label: 'Open contracts at cost',
+        value: formatUsd(s.openContractsAtCost),
+        hint: 'Cost basis',
+        explainer: {
+          description: 'What you originally paid for the bets you still hold — their cost basis, not their current market price. Compare it to \'Open positions value\' to see your paper gain or loss: paying more than they\'re now worth means you\'re sitting on an unrealized loss. This is also the value the balance sheet books open contracts at.',
+          formula: 'Σ acquisitions − Σ disposals (cost basis)',
+          example: 'You paid $3.86 for bets now quoted at $0.71 → you\'re holding a ~$3.15 unrealized loss.'
+        }
+      },
+      {
+        label: 'Portfolio value',
+        value: formatUsd(s.totalPortfolioValue),
+        hint: 'Cash + positions',
+        explainer: {
+          description: 'Everything your Polymarket wallet was worth on the reporting date: idle cash plus the value of every open bet — at market price for today, at cost for a past date.',
+          formula: 'Free cash balance + Open positions value'
+        }
+      },
+      {
+        label: 'Realized P&L',
+        value: formatSignedUsd(s.realizedPnl),
+        valueClass: signClass(s.realizedPnl),
+        hint: 'Lot accounting — same as Income Statement',
+        explainer: {
+          description: 'Money you actually locked in: when you sold shares, when a market resolved and you redeemed, when you merged shares back to cash, or when a losing bet resolved without redemption. Computed with weighted-average-cost lot accounting on every trade.',
+          formula: 'Σ (proceeds − cost basis) per disposed lot',
+          example: 'You bought 100 "Yes" shares for $40 ($0.40 each) and sold them later for $60 ($0.60 each). Realized P&L on this trade = +$20.'
+        }
+      }
+    ],
+    // Row 3 — capital flow + unrealized
+    [
+      {
+        label: 'Total deposits',
+        value: formatUsd(s.totalDeposits),
+        valueClass: POSITIVE_CLASS,
+        explainer: {
+          description: 'Every USDC you ever sent to your Polymarket wallet from an outside address. We get this from Polygon (Etherscan) directly — it never relies on Polymarket reporting.',
+          formula: 'Σ incoming USDC transfers (Etherscan)'
+        }
+      },
+      {
+        label: 'Total withdrawals',
+        value: formatUsd(s.totalWithdrawals),
+        valueClass: NEGATIVE_CLASS,
+        explainer: {
+          description: 'Every USDC you ever sent out of your Polymarket wallet to an outside address.',
+          formula: 'Σ outgoing USDC transfers (Etherscan)'
+        }
+      },
+      {
+        label: 'Unrealized P&L',
+        value: live(isCurrent, () => formatSignedUsd(s.unrealizedPnl)),
+        valueClass: isCurrent ? signClass(s.unrealizedPnl) : 'text-muted',
+        hint: isCurrent ? 'Open positions' : LIVE_ONLY_HINT,
+        explainer: {
+          description: 'Paper profit or loss on bets still in play, i.e. how much the current market price differs from what you originally paid. It can swing either way until the market resolves. Only available for today: Polymarket publishes no historical price per market, so a past snapshot carries open bets at cost instead.',
+          formula: 'Σ (current value − initial cost) per open position',
+          example: 'You paid $0.40 per share for 100 "Yes" shares. The market now trades at $0.55. Unrealized P&L = +$15.'
+        }
+      }
+    ],
+    // Row 4 — activity & reconciliation
+    [
+      {
+        label: 'Rewards earned',
+        value: formatUsd(s.totalRewards),
+        valueClass: POSITIVE_CLASS,
+        explainer: {
+          description: 'Free USDC Polymarket has paid you: liquidity-provider rewards, maker rebates, and referral payouts. Not the result of any trade — it just lands in your wallet.',
+          formula: 'Σ REWARD + MAKER_REBATE + REFERRAL_REWARD activity rows'
+        }
+      },
+      {
+        label: 'Trading volume',
+        value: formatUsd(s.tradingVolume),
+        hint: s.tradeCount === 1 ? '1 trade' : `${s.tradeCount} trades`,
+        explainer: {
+          description: 'Gross USD value you have traded — buys + sells combined. This is a turnover number, not a profit number: a $1,000 round trip (buy and resell) counts as $2,000 of volume.',
+          formula: 'Σ BUY usdcSize + Σ SELL usdcSize'
+        }
+      },
+      {
+        label: 'Position basis drift',
+        value: live(isCurrent, () => formatSignedUsd(s.positionBasisDrift)),
+        valueClass: isCurrent ? signClass(s.positionBasisDrift) : 'text-muted',
+        hint: isCurrent ? 'Polymarket basis vs ours' : LIVE_ONLY_HINT,
+        explainer: {
+          description: 'Reconciliation entry for the gap between Polymarket\'s own reported cost basis on open positions (their cashPnl) and what our weighted-average-cost lot accounting derives from /activity. Without it, the Total return identity would gap by exactly this amount. It only applies to today\'s snapshot — a past one already books open bets at our own cost basis, so there is nothing to reconcile.',
+          formula: 'openPositionsValue − openContractsAtCost − unrealizedPnl',
+          example: 'Polymarket says you have $100 of open positions with $20 of unrealized profit (basis $80). Our /activity lot accounting computes a basis of $75. Drift = $100 − $75 − $20 = +$5.'
+        }
+      }
+    ]
+  ]
+}
+
+/** The three headline cards: total return, profile P&L, fees. */
+export function buildSummaryHeadline(s: AccountingSummary, isCurrent: boolean) {
+  return {
+    totalReturn: {
+      value: formatSignedUsd(s.totalReturn),
+      valueClass: signClass(s.totalReturn),
+      hint: isCurrent
+        ? 'Portfolio value − net deposits'
+        : 'Cash + contracts at cost − net deposits'
+    },
+    polymarketPnl: {
+      value: live(isCurrent, () => formatSignedUsd(s.polymarketPnl)),
+      valueClass: isCurrent ? signClass(s.polymarketPnl) : 'text-muted',
+      hint: isCurrent ? 'All-time (Polymarket)' : LIVE_ONLY_HINT
+    },
+    fees: {
+      value: formatUsd(s.totalFees),
+      hint: s.feeTransactionCount === 1 ? '1 transaction' : `${s.feeTransactionCount} transactions`
+    }
+  }
+}


### PR DESCRIPTION
The Summary was all-time only, with no way to see where the portfolio stood on a given date. It now carries the same date picker as the Balance Sheet (mode "date", default Today, selection persisted), and every figure is replayed from the dated feeds for the chosen date.

A past snapshot carries still-open bets at cost, exactly like the Balance Sheet does, because Polymarket publishes no historical market price. The figures that only exist for today (unrealized P&L, profile P&L, position basis drift) are shown as a dash with the reason rather than today's numbers under a past date. Picking Today returns the live summary untouched, so the default rendering is unchanged.

Card definitions moved out of the component into a util so it stays a description of the layout.

Closes #2103

