### PR TITLE
fix: 🐛 make the company card actions functional

### DIFF
--- a/app/src/components/__tests__/TeamCard.spec.ts
+++ b/app/src/components/__tests__/TeamCard.spec.ts
@@ -256,6 +256,37 @@ describe('TeamCard', () => {
       ])
     })
 
+    // An action that has already been taken has to offer the way back out,
+    // otherwise a hidden or archived team is stranded in that state.
+    it('offers the reverse action once the team is hidden or archived', () => {
+      expect(menuItems(makeTeam({ isHidden: true })).map((item) => item.label)).toEqual([
+        'Update',
+        'Archive',
+        'Show',
+        'Delete'
+      ])
+      expect(menuItems(makeTeam({ isArchived: true })).map((item) => item.label)).toEqual([
+        'Update',
+        'Unarchive',
+        'Hide',
+        'Delete'
+      ])
+      expect(menuItems(makeTeam({ isHidden: true, ownerAddress: OUTSIDER })).map((i) => i.label)) //
+        .toEqual(['Show'])
+    })
+
+    // The backend answers a metadata write on an archived team with a 409, so
+    // the card must not offer it as a live action.
+    it('disables Update while the team is archived', () => {
+      const disabledOf = (team: Team) =>
+        (menuItems(team) as Array<{ label: string; disabled?: boolean }>).find(
+          (item) => item.label === 'Update'
+        )?.disabled
+
+      expect(disabledOf(makeTeam({ isArchived: true }))).toBe(true)
+      expect(disabledOf(makeTeam())).toBe(false)
+    })
+
     // The whole card is the navigation target, so a click meant for the menu
     // must not also open the team.
     it('keeps menu clicks from reaching the card underneath', async () => {

--- a/app/src/components/sections/DashboardView/TeamMetaArchiveModal.vue
+++ b/app/src/components/sections/DashboardView/TeamMetaArchiveModal.vue
@@ -1,6 +1,6 @@
 <template>
   <UModal
-    v-model:open="showArchiveTeamConfirmModal"
+    v-model:open="open"
     :title="isArchived ? 'Unarchive Company' : 'Archive Company'"
     :description="
       isArchived
@@ -8,13 +8,15 @@
         : 'This action will remove the company from the dashboard and prevent it from being used.'
     "
   >
-    <UButton
-      size="sm"
-      :color="isArchived ? 'success' : 'warning'"
-      :icon="isArchived ? 'i-lucide-archive-restore' : 'i-lucide-archive'"
-      :label="isArchived ? 'Unarchive' : 'Archive'"
-      data-test="team-meta-archive-open"
-    />
+    <template v-if="withTrigger" #default>
+      <UButton
+        size="sm"
+        :color="isArchived ? 'success' : 'warning'"
+        :icon="isArchived ? 'i-lucide-archive-restore' : 'i-lucide-archive'"
+        :label="isArchived ? 'Unarchive' : 'Archive'"
+        data-test="team-meta-archive-open"
+      />
+    </template>
     <template #body>
       <UAlert
         v-if="updateTeamError"
@@ -37,28 +39,33 @@
           :disabled="teamIsUpdating"
           :label="isArchived ? 'Unarchive' : 'Archive'"
         />
-        <UButton
-          color="primary"
-          variant="outline"
-          @click="showArchiveTeamConfirmModal = false"
-          label="Cancel"
-        />
+        <UButton color="primary" variant="outline" @click="open = false" label="Cancel" />
       </div>
     </template>
   </UModal>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import type { Team } from '@/types/team'
 import { useTeamStore } from '@/stores'
 import { useUpdateTeamMutation } from '@/queries/team.queries'
 
-const props = defineProps<{
-  currentTeam: Team | null | undefined
-}>()
+const props = withDefaults(
+  defineProps<{
+    currentTeam: Team | null | undefined
+    /**
+     * Team to act on when it is not the one the dashboard has open — the teams
+     * list drives this modal per card, where `teamStore.currentTeamId` is stale.
+     */
+    teamId?: string | number | null
+    /** Clear it when the parent opens the modal itself and owns the trigger. */
+    withTrigger?: boolean
+  }>(),
+  { teamId: null, withTrigger: true }
+)
 
-const showArchiveTeamConfirmModal = ref(false)
+const open = defineModel<boolean>('open', { default: false })
 const teamStore = useTeamStore()
 const toast = useToast()
 
@@ -72,7 +79,7 @@ const {
 const isArchived = computed(() => props.currentTeam?.isArchived ?? false)
 
 function getRequiredTeamId(): string | null {
-  const teamId = teamStore.currentTeamId
+  const teamId = props.teamId ?? teamStore.currentTeamId
   if (!teamId) {
     toast.add({ title: 'Company ID is required', color: 'error' })
     return null
@@ -88,7 +95,7 @@ function archiveTeam() {
     {
       onSuccess: () => {
         toast.add({ title: 'Company archived successfully', color: 'success' })
-        showArchiveTeamConfirmModal.value = false
+        open.value = false
         reset()
       }
     }
@@ -103,7 +110,7 @@ function unarchiveTeam() {
     {
       onSuccess: () => {
         toast.add({ title: 'Company unarchived successfully', color: 'success' })
-        showArchiveTeamConfirmModal.value = false
+        open.value = false
         reset()
       }
     }

--- a/app/src/components/sections/DashboardView/TeamMetaDeleteModal.vue
+++ b/app/src/components/sections/DashboardView/TeamMetaDeleteModal.vue
@@ -1,16 +1,18 @@
 <template>
   <UModal
-    v-model:open="showDeleteTeamConfirmModal"
+    v-model:open="open"
     title="Confirmation"
     description="This action cannot be undone. Please confirm that you want to permanently delete this company."
   >
-    <UButton
-      size="sm"
-      color="error"
-      icon="i-lucide-trash"
-      label="Delete"
-      data-test="team-meta-delete-open"
-    />
+    <template v-if="withTrigger" #default>
+      <UButton
+        size="sm"
+        color="error"
+        icon="i-lucide-trash"
+        label="Delete"
+        data-test="team-meta-delete-open"
+      />
+    </template>
     <template #body>
       <UAlert
         v-if="deleteTeamError"
@@ -33,30 +35,34 @@
           :disabled="teamIsDeleting"
           label="Delete"
         />
-        <UButton
-          color="primary"
-          variant="outline"
-          @click="showDeleteTeamConfirmModal = false"
-          label="Cancel"
-        />
+        <UButton color="primary" variant="outline" @click="open = false" label="Cancel" />
       </div>
     </template>
   </UModal>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
 import type { Team } from '@/types/team'
 import { useRouter } from 'vue-router'
 import { useTeamStore } from '@/stores'
 import { useDeleteTeamMutation } from '@/queries/team.queries'
 import { getAxiosErrorMessage } from '@/utils/httpErrorUtil'
 
-defineProps<{
-  currentTeam: Team | null | undefined
-}>()
+const props = withDefaults(
+  defineProps<{
+    currentTeam: Team | null | undefined
+    /**
+     * Team to act on when it is not the one the dashboard has open — the teams
+     * list drives this modal per card, where `teamStore.currentTeamId` is stale.
+     */
+    teamId?: string | number | null
+    /** Clear it when the parent opens the modal itself and owns the trigger. */
+    withTrigger?: boolean
+  }>(),
+  { teamId: null, withTrigger: true }
+)
 
-const showDeleteTeamConfirmModal = ref(false)
+const open = defineModel<boolean>('open', { default: false })
 const teamStore = useTeamStore()
 const router = useRouter()
 const toast = useToast()
@@ -68,7 +74,7 @@ const {
 } = useDeleteTeamMutation()
 
 function getRequiredTeamId(): string | null {
-  const teamId = teamStore.currentTeamId
+  const teamId = props.teamId ?? teamStore.currentTeamId
   if (!teamId) {
     toast.add({ title: 'Company ID is required', color: 'error' })
     return null
@@ -84,7 +90,7 @@ function deleteTeam() {
     {
       onSuccess: async () => {
         toast.add({ title: 'Company deleted successfully', color: 'success' })
-        showDeleteTeamConfirmModal.value = false
+        open.value = false
         await router.push('/teams')
       }
     }

--- a/app/src/components/sections/DashboardView/TeamMetaUpdateModal.vue
+++ b/app/src/components/sections/DashboardView/TeamMetaUpdateModal.vue
@@ -1,20 +1,21 @@
 <template>
   <UModal
-    v-model:open="showUpdateModal"
+    v-model:open="open"
     title="Update Company Details"
     description="Update your company name and description to keep your profile current and accurate"
   >
-    <TeamArchivedTooltip v-slot="{ disabled: archivedDisabled }">
-      <UButton
-        size="sm"
-        color="secondary"
-        icon="i-lucide-edit"
-        label="Update"
-        data-test="team-meta-update-open"
-        :disabled="archivedDisabled"
-        @click="prefillUpdateForm"
-      />
-    </TeamArchivedTooltip>
+    <template v-if="withTrigger" #default>
+      <TeamArchivedTooltip v-slot="{ disabled: archivedDisabled }">
+        <UButton
+          size="sm"
+          color="secondary"
+          icon="i-lucide-edit"
+          label="Update"
+          data-test="team-meta-update-open"
+          :disabled="archivedDisabled"
+        />
+      </TeamArchivedTooltip>
+    </template>
     <template #body>
       <UAlert
         v-if="archivedTeamErrorMessage"
@@ -73,15 +74,31 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { z } from 'zod'
+import type { Team } from '@/types/team'
 import { useTeamStore } from '@/stores'
 import { useUpdateTeamMutation } from '@/queries/team.queries'
 import TeamArchivedTooltip from '@/components/TeamArchivedTooltip.vue'
 import { useArchivedTeamMutationError } from '@/composables/useArchivedTeamMutationError'
 import { getAxiosErrorMessage } from '@/utils/httpErrorUtil'
 
-const showUpdateModal = ref(false)
+const props = withDefaults(
+  defineProps<{
+    /** Team to edit; falls back to the one the dashboard has open. */
+    currentTeam?: Team | null
+    /**
+     * Team to act on when it is not the one the dashboard has open — the teams
+     * list drives this modal per card, where `teamStore.currentTeamId` is stale.
+     */
+    teamId?: string | number | null
+    /** Clear it when the parent opens the modal itself and owns the trigger. */
+    withTrigger?: boolean
+  }>(),
+  { currentTeam: null, teamId: null, withTrigger: true }
+)
+
+const open = defineModel<boolean>('open', { default: false })
 const updateTeamInput = ref({ name: '', description: '' })
 const teamStore = useTeamStore()
 const toast = useToast()
@@ -101,7 +118,7 @@ const {
 const archivedTeamErrorMessage = useArchivedTeamMutationError(() => updateTeamError.value)
 
 function getRequiredTeamId(): string | null {
-  const teamId = teamStore.currentTeamId
+  const teamId = props.teamId ?? teamStore.currentTeamId
   if (!teamId) {
     toast.add({ title: 'Company ID is required', color: 'error' })
     return null
@@ -117,7 +134,7 @@ function executeUpdateTeam() {
     {
       onSuccess: () => {
         toast.add({ title: 'Company updated successfully', color: 'success' })
-        showUpdateModal.value = false
+        open.value = false
         reset()
       }
     }
@@ -125,8 +142,14 @@ function executeUpdateTeam() {
 }
 
 function prefillUpdateForm() {
-  const meta = teamStore.currentTeamMeta.data
+  const meta = props.currentTeam ?? teamStore.currentTeamMeta.data
   updateTeamInput.value.name = meta?.name || ''
   updateTeamInput.value.description = meta?.description || ''
 }
+
+// Prefill off the open state rather than the trigger's click: the teams list
+// opens this modal programmatically, so there is no click to hang it on.
+watch(open, (isOpen) => {
+  if (isOpen) prefillUpdateForm()
+})
 </script>

--- a/app/src/components/sections/DashboardView/TeamMetaVisibilityModal.vue
+++ b/app/src/components/sections/DashboardView/TeamMetaVisibilityModal.vue
@@ -1,6 +1,6 @@
 <template>
   <UModal
-    v-model:open="showVisibilityTeamConfirmModal"
+    v-model:open="open"
     :title="companyIsShown ? 'Hide Company' : 'Show Company'"
     :description="
       companyIsShown
@@ -8,13 +8,15 @@
         : 'This action will show the company on your dashboard again.'
     "
   >
-    <UButton
-      size="sm"
-      :color="companyIsShown ? 'success' : 'warning'"
-      :icon="companyIsShown ? 'i-lucide-eye-off' : 'i-lucide-eye'"
-      :label="companyIsShown ? 'Hide' : 'Show'"
-      data-test="team-meta-visibility-open"
-    />
+    <template v-if="withTrigger" #default>
+      <UButton
+        size="sm"
+        :color="companyIsShown ? 'success' : 'warning'"
+        :icon="companyIsShown ? 'i-lucide-eye-off' : 'i-lucide-eye'"
+        :label="companyIsShown ? 'Hide' : 'Show'"
+        data-test="team-meta-visibility-open"
+      />
+    </template>
     <template #body>
       <UAlert
         v-if="updateTeamError"
@@ -37,28 +39,33 @@
           :disabled="teamIsUpdating"
           :label="companyIsShown ? 'Hide' : 'Show'"
         />
-        <UButton
-          color="primary"
-          variant="outline"
-          @click="showVisibilityTeamConfirmModal = false"
-          label="Cancel"
-        />
+        <UButton color="primary" variant="outline" @click="open = false" label="Cancel" />
       </div>
     </template>
   </UModal>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import type { Team } from '@/types/team'
 import { useTeamStore } from '@/stores'
 import { useUpdateTeamMutation } from '@/queries/team.queries'
 
-const props = defineProps<{
-  currentTeam: Team | null | undefined
-}>()
+const props = withDefaults(
+  defineProps<{
+    currentTeam: Team | null | undefined
+    /**
+     * Team to act on when it is not the one the dashboard has open — the teams
+     * list drives this modal per card, where `teamStore.currentTeamId` is stale.
+     */
+    teamId?: string | number | null
+    /** Clear it when the parent opens the modal itself and owns the trigger. */
+    withTrigger?: boolean
+  }>(),
+  { teamId: null, withTrigger: true }
+)
 
-const showVisibilityTeamConfirmModal = ref(false)
+const open = defineModel<boolean>('open', { default: false })
 const teamStore = useTeamStore()
 const toast = useToast()
 
@@ -72,7 +79,7 @@ const {
 const companyIsShown = computed(() => !(props.currentTeam?.isHidden ?? false))
 
 function getRequiredTeamId(): string | null {
-  const teamId = teamStore.currentTeamId
+  const teamId = props.teamId ?? teamStore.currentTeamId
   if (!teamId) {
     toast.add({ title: 'Company ID is required', color: 'error' })
     return null
@@ -88,7 +95,7 @@ function hideTeam() {
     {
       onSuccess: () => {
         toast.add({ title: 'Company hidden successfully', color: 'success' })
-        showVisibilityTeamConfirmModal.value = false
+        open.value = false
         reset()
       }
     }
@@ -103,7 +110,7 @@ function showTeam() {
     {
       onSuccess: () => {
         toast.add({ title: 'Company is visible again', color: 'success' })
-        showVisibilityTeamConfirmModal.value = false
+        open.value = false
         reset()
       }
     }

--- a/app/src/components/sections/DashboardView/__tests__/TeamMetaArchiveModal.spec.ts
+++ b/app/src/components/sections/DashboardView/__tests__/TeamMetaArchiveModal.spec.ts
@@ -154,6 +154,40 @@ describe('TeamMetaArchiveModal.vue', () => {
     expect(wrapper.find('[data-test="archive-team-button"]').exists()).toBe(false)
   })
 
+  // The teams list reuses this modal per card, where the store's "current team"
+  // is either absent or a different team entirely.
+  describe('driven by a parent', () => {
+    const mountControlled = (team: Team = teamProps()) =>
+      mount(TeamMetaArchiveModal, {
+        props: { currentTeam: team, teamId: '99', withTrigger: false, open: true }
+      })
+
+    it('acts on the supplied team rather than the store’s current one', async () => {
+      const wrapper = mountControlled()
+      await wrapper.find('[data-test="archive-team-button"]').trigger('click')
+
+      expect(mutateSpy).toHaveBeenCalledWith(
+        { pathParams: { id: '99' }, body: { isArchived: true } },
+        expect.any(Object)
+      )
+    })
+
+    it('renders no trigger of its own', () => {
+      expect(mountControlled().find('[data-test="team-meta-archive-open"]').exists()).toBe(false)
+    })
+
+    it('reports closing back to the parent', async () => {
+      mutateSpy.mockImplementationOnce((_payload, options) => {
+        options?.onSuccess?.()
+      })
+
+      const wrapper = mountControlled()
+      await wrapper.find('[data-test="archive-team-button"]').trigger('click')
+
+      expect(wrapper.emitted('update:open')).toContainEqual([false])
+    })
+  })
+
   it('disables archive action while pending', async () => {
     vi.mocked(useUpdateTeamMutation).mockReturnValueOnce({
       mutate: mutateSpy,

--- a/app/src/components/sections/DashboardView/__tests__/TeamMetaDeleteModal.spec.ts
+++ b/app/src/components/sections/DashboardView/__tests__/TeamMetaDeleteModal.spec.ts
@@ -150,4 +150,22 @@ describe('TeamMetaDeleteModal.vue', () => {
     const deleteBtn = wrapper.get('[data-test="delete-team-button"]')
     expect(deleteBtn.attributes('disabled')).toBeDefined()
   })
+
+  // Deleting the team the store happens to point at instead of the card the
+  // user acted on would destroy the wrong company, so pin the precedence down.
+  it('deletes the supplied team rather than the store’s current one', async () => {
+    const wrapper = mount(TeamMetaDeleteModal, {
+      props: {
+        currentTeam: teamProps({ id: '123' }),
+        teamId: '123',
+        withTrigger: false,
+        open: true
+      }
+    })
+
+    expect(wrapper.find('[data-test="team-meta-delete-open"]').exists()).toBe(false)
+    await wrapper.find('[data-test="delete-team-button"]').trigger('click')
+
+    expect(mutateSpy).toHaveBeenCalledWith({ pathParams: { teamId: '123' } }, expect.any(Object))
+  })
 })

--- a/app/src/components/sections/DashboardView/__tests__/TeamMetaUpdateModal.spec.ts
+++ b/app/src/components/sections/DashboardView/__tests__/TeamMetaUpdateModal.spec.ts
@@ -163,6 +163,50 @@ describe('TeamMetaUpdateModal.vue', () => {
     expect(wrapper.text()).toContain('10 / 200')
   })
 
+  // Opened from the teams list there is no trigger click to prefill on, and the
+  // store's "current team" is not the card that was acted on.
+  describe('driven by a parent', () => {
+    const currentTeam = {
+      ...mockTeamData,
+      id: '99',
+      name: 'Card Name',
+      description: 'Description carried in on the prop'
+    }
+
+    const mountControlled = () =>
+      mount(TeamMetaUpdateModal, {
+        props: { currentTeam, teamId: '99', withTrigger: false, open: false },
+        global: { stubs: formStubs }
+      })
+
+    it('prefills from the supplied team when the parent opens it', async () => {
+      const wrapper = mountControlled()
+      expect(wrapper.find('[data-test="team-meta-update-open"]').exists()).toBe(false)
+
+      await wrapper.setProps({ open: true })
+
+      expect((wrapper.find('input').element as HTMLInputElement).value).toBe('Card Name')
+      expect((wrapper.find('textarea').element as HTMLTextAreaElement).value).toBe(
+        'Description carried in on the prop'
+      )
+    })
+
+    it('submits against the supplied team rather than the store’s current one', async () => {
+      const wrapper = mountControlled()
+      await wrapper.setProps({ open: true })
+      await wrapper.get('form.flex.flex-col.gap-5').trigger('submit')
+      await flushPromises()
+
+      expect(mutateSpy).toHaveBeenCalledWith(
+        {
+          pathParams: { id: '99' },
+          body: { name: 'Card Name', description: 'Description carried in on the prop' }
+        },
+        expect.any(Object)
+      )
+    })
+  })
+
   it('disables save while pending', async () => {
     vi.mocked(useUpdateTeamMutation).mockReturnValueOnce({
       mutate: mutateSpy,

--- a/app/src/components/sections/TeamView/TeamCard.vue
+++ b/app/src/components/sections/TeamView/TeamCard.vue
@@ -300,17 +300,26 @@ const wage = computed(() => {
 
 // --- Actions --------------------------------------------------------------
 // Owners manage the team; everyone else can only drop it from their own list.
+// Each entry names the transition it performs, so a team that is already
+// hidden or archived offers the way back out rather than a no-op.
 const menuItems = computed<DropdownMenuItem[]>(() => {
-  const hide: DropdownMenuItem = {
-    label: 'Hide',
-    icon: 'i-heroicons-eye-slash',
-    onSelect: () => emit('hide')
-  }
-  if (!isOwner.value) return [hide]
+  const visibility: DropdownMenuItem = props.team.isHidden
+    ? { label: 'Show', icon: 'i-heroicons-eye', onSelect: () => emit('hide') }
+    : { label: 'Hide', icon: 'i-heroicons-eye-slash', onSelect: () => emit('hide') }
+  if (!isOwner.value) return [visibility]
   return [
-    { label: 'Update', icon: 'i-heroicons-pencil-square', onSelect: () => emit('update') },
-    { label: 'Archive', icon: 'i-heroicons-archive-box', onSelect: () => emit('archive') },
-    hide,
+    {
+      label: 'Update',
+      icon: 'i-heroicons-pencil-square',
+      // The backend rejects metadata writes on an archived team (409), so the
+      // entry stays visible but inert until the team is unarchived.
+      disabled: props.team.isArchived,
+      onSelect: () => emit('update')
+    },
+    props.team.isArchived
+      ? { label: 'Unarchive', icon: 'i-lucide-archive-restore', onSelect: () => emit('archive') }
+      : { label: 'Archive', icon: 'i-heroicons-archive-box', onSelect: () => emit('archive') },
+    visibility,
     {
       label: 'Delete',
       icon: 'i-heroicons-trash',

--- a/app/src/views/team/ListIndex.vue
+++ b/app/src/views/team/ListIndex.vue
@@ -102,6 +102,10 @@
         :data-test="`team-card-${team.id}`"
         class="cursor-pointer transition duration-300 hover:-translate-y-0.5 hover:shadow-md"
         @click="navigateToTeam(team.id)"
+        @update="openAction(team, 'update')"
+        @archive="openAction(team, 'archive')"
+        @hide="openAction(team, 'hide')"
+        @delete="openAction(team, 'delete')"
       />
 
       <div class="flex" data-test="add-team-button">
@@ -123,6 +127,34 @@
         </UModal>
       </div>
     </div>
+
+    <!-- Card actions. One modal per action, retargeted at whichever card raised
+         it: these are the dashboard's own modals, which default to the open
+         team — a list has none, so the team is passed explicitly. -->
+    <TeamMetaUpdateModal
+      v-model:open="updateIsOpen"
+      :current-team="actionTeam"
+      :team-id="actionTeam?.id"
+      :with-trigger="false"
+    />
+    <TeamMetaArchiveModal
+      v-model:open="archiveIsOpen"
+      :current-team="actionTeam"
+      :team-id="actionTeam?.id"
+      :with-trigger="false"
+    />
+    <TeamMetaVisibilityModal
+      v-model:open="visibilityIsOpen"
+      :current-team="actionTeam"
+      :team-id="actionTeam?.id"
+      :with-trigger="false"
+    />
+    <TeamMetaDeleteModal
+      v-model:open="deleteIsOpen"
+      :current-team="actionTeam"
+      :team-id="actionTeam?.id"
+      :with-trigger="false"
+    />
   </div>
 </template>
 
@@ -131,7 +163,12 @@ import { useRouter, useRoute } from 'vue-router'
 import { useUserDataStore } from '@/stores'
 import AddTeamCard from '@/components/sections/TeamView/AddTeamCard.vue'
 import TeamCard from '@/components/sections/TeamView/TeamCard.vue'
+import TeamMetaArchiveModal from '@/components/sections/DashboardView/TeamMetaArchiveModal.vue'
+import TeamMetaDeleteModal from '@/components/sections/DashboardView/TeamMetaDeleteModal.vue'
+import TeamMetaUpdateModal from '@/components/sections/DashboardView/TeamMetaUpdateModal.vue'
+import TeamMetaVisibilityModal from '@/components/sections/DashboardView/TeamMetaVisibilityModal.vue'
 import { useGetTeamsQuery } from '@/queries/team.queries'
+import type { Team } from '@/types/team'
 import { computed, ref, watch } from 'vue'
 
 const openModal = ref(false)
@@ -179,4 +216,32 @@ watch(
 const navigateToTeam = (id: number | string) => {
   router.push(`/teams/${id}`)
 }
+
+// --- Card actions ---------------------------------------------------------
+// The cards only announce what was chosen; the list owns the modals so they
+// sit outside the card and their clicks never reach its navigation handler.
+type TeamAction = 'update' | 'archive' | 'hide' | 'delete'
+
+const actionTeam = ref<Team | null>(null)
+const activeAction = ref<TeamAction | null>(null)
+
+const openAction = (team: Team, action: TeamAction) => {
+  actionTeam.value = team
+  activeAction.value = action
+}
+
+// One shared `activeAction` rather than a flag per modal, so opening one action
+// cannot leave another still open behind it.
+const actionIsOpen = (action: TeamAction) =>
+  computed({
+    get: () => activeAction.value === action,
+    set: (isOpen: boolean) => {
+      activeAction.value = isOpen ? action : null
+    }
+  })
+
+const updateIsOpen = actionIsOpen('update')
+const archiveIsOpen = actionIsOpen('archive')
+const visibilityIsOpen = actionIsOpen('hide')
+const deleteIsOpen = actionIsOpen('delete')
 </script>

--- a/app/src/views/team/__tests__/ListIndex.actions.spec.ts
+++ b/app/src/views/team/__tests__/ListIndex.actions.spec.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ListIndex from '@/views/team/ListIndex.vue'
+import { mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+import { createMockQueryResponse } from '@/tests/mocks/query.mock'
+import { mockTeamData, mockRouterPush } from '@/tests/mocks'
+import type { Team } from '@/types'
+import { useRoute } from 'vue-router'
+
+import { useGetTeamsQuery } from '@/queries/team.queries'
+
+// The card only announces which action was chosen; the list owns the modals.
+// These cover that hand-off — that the right modal opens, against the right
+// team, and that nothing else on the page reacts.
+describe('ListIndex - card actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useRoute).mockReturnValue({
+      params: { id: '0' },
+      meta: { name: 'Team List View' }
+    } as ReturnType<typeof useRoute>)
+  })
+
+  const MODAL_FOR = {
+    update: 'TeamMetaUpdateModal',
+    archive: 'TeamMetaArchiveModal',
+    hide: 'TeamMetaVisibilityModal',
+    delete: 'TeamMetaDeleteModal'
+  } as const
+  type CardAction = keyof typeof MODAL_FOR
+
+  const modalStub = (name: string) => ({
+    name,
+    props: ['open', 'currentTeam', 'teamId', 'withTrigger'],
+    template: '<div />'
+  })
+
+  const mountWithActions = (teams: Team[]) => {
+    vi.mocked(useGetTeamsQuery).mockReturnValueOnce(createMockQueryResponse(teams))
+
+    return mount(ListIndex, {
+      global: {
+        plugins: [createTestingPinia({ createSpy: vi.fn })],
+        stubs: {
+          AddTeamCard: true,
+          AddTeamForm: true,
+          TeamCard: {
+            name: 'TeamCard',
+            props: ['team'],
+            template: '<div :data-test="`team-card-${team.id}`" />'
+          },
+          ...Object.fromEntries(Object.values(MODAL_FOR).map((name) => [name, modalStub(name)]))
+        }
+      }
+    })
+  }
+
+  const cardFor = (wrapper: ReturnType<typeof mountWithActions>, teamId: string) =>
+    wrapper
+      .findAllComponents({ name: 'TeamCard' })
+      .find((card) => card.props('team').id === teamId)!
+
+  const TEAM = { ...mockTeamData, id: '42', name: 'Acted On' }
+
+  it.each(Object.keys(MODAL_FOR) as CardAction[])(
+    'opens the %s modal against the team that raised it',
+    async (action) => {
+      const wrapper = mountWithActions([TEAM])
+      cardFor(wrapper, '42').vm.$emit(action)
+      await wrapper.vm.$nextTick()
+
+      const modal = wrapper.findComponent({ name: MODAL_FOR[action] })
+      expect(modal.props('open')).toBe(true)
+      expect(modal.props('teamId')).toBe('42')
+      expect(modal.props('currentTeam')).toMatchObject({ id: '42', name: 'Acted On' })
+      // The list drives the modal, so the modal's own trigger button stays off.
+      expect(modal.props('withTrigger')).toBe(false)
+    }
+  )
+
+  it('leaves the other three modals closed', async () => {
+    const wrapper = mountWithActions([TEAM])
+    cardFor(wrapper, '42').vm.$emit('archive')
+    await wrapper.vm.$nextTick()
+
+    const openNames = Object.values(MODAL_FOR).filter(
+      (name) => wrapper.findComponent({ name }).props('open') === true
+    )
+    expect(openNames).toEqual(['TeamMetaArchiveModal'])
+  })
+
+  // The modals are shared across every card, so the team they point at has to
+  // follow the last card acted on rather than stick to the first.
+  it('retargets the modal when a different card raises the same action', async () => {
+    const wrapper = mountWithActions([TEAM, { ...mockTeamData, id: '7', name: 'Second' }])
+
+    cardFor(wrapper, '42').vm.$emit('delete')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.findComponent({ name: 'TeamMetaDeleteModal' }).props('teamId')).toBe('42')
+
+    cardFor(wrapper, '7').vm.$emit('delete')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.findComponent({ name: 'TeamMetaDeleteModal' }).props('teamId')).toBe('7')
+  })
+
+  it('closes the modal when it reports itself closed', async () => {
+    const wrapper = mountWithActions([TEAM])
+    cardFor(wrapper, '42').vm.$emit('hide')
+    await wrapper.vm.$nextTick()
+
+    const modal = wrapper.findComponent({ name: 'TeamMetaVisibilityModal' })
+    modal.vm.$emit('update:open', false)
+    await wrapper.vm.$nextTick()
+
+    expect(modal.props('open')).toBe(false)
+  })
+
+  // Opening a card's menu must never also open the team behind it.
+  it('does not navigate when a card raises an action', async () => {
+    const wrapper = mountWithActions([TEAM])
+    cardFor(wrapper, '42').vm.$emit('update')
+    await wrapper.vm.$nextTick()
+
+    expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
# Description

## Intial Issue Description

Fixes #2416 — follow-up on #2134, which shipped the redesigned company card (#2409) with a kebab menu whose four entries do nothing.

`TeamCard.vue` emits `update` / `archive` / `hide` / `delete`; `ListIndex.vue` — its only consumer — listens to none of them. From the companies list a user cannot rename, archive, hide or delete a company at all.

## PR Summary Or Solution description

**Wire the four actions.** The list now handles each emit by opening the matching `TeamMeta*Modal` against the card that raised it.

The four modals already implement these flows for the dashboard, so per the goal's *reuse over rebuild* convention they were made reusable rather than duplicated. They were tied to the dashboard in two ways, each fixed with an opt-in prop that leaves existing dashboard usage untouched:

| Prop | Why |
| --- | --- |
| `v-model:open` | The modals owned their open state. Falls back to local state when unbound, so `TeamMetaSection` is unchanged. |
| `teamId` | The target was resolved from `teamStore.currentTeamId` — absent (or a *different* company) on a list. Takes precedence when supplied. |
| `withTrigger` | The modals embedded their own trigger button. Omits the **default slot entirely** — Nuxt UI renders its `DialogTrigger` off `!!slots.default`, so a `v-if` *inside* the slot is not enough. |

`TeamMetaUpdateModal` additionally takes the team to edit and prefills off the *open state* rather than the trigger's click, since a programmatic open has no click to hang it on.

On the list side, one set of modals is retargeted per card rather than one set per card, and they render outside the card so their clicks never reach its navigation handler. A single `activeAction` doubles as the open flag, so two actions can never be open at once.

## Issues introduced and fixed (Optional)

Two correctness gaps in the same menu, both aligned with what the backend actually accepts:

- **A hidden or archived company was stranded.** The menu always read *Hide* / *Archive*, so a company surfaced by the Hidden/Archived toggles had no way back. Entries now name the transition they perform: **Show** and **Unarchive**.
- **Update is now disabled while a company is archived.** `PUT /teams/:id` answers a metadata write on an archived team with `409 Team is archived — unarchive to modify` (`teamController.ts`), so offering it as a live action could only fail.

## Contribution

Reviewer notes, per file:

- `TeamMeta{Update,Archive,Visibility,Delete}Modal.vue` — the three opt-in props above. `getRequiredTeamId()` becomes `props.teamId ?? teamStore.currentTeamId`, so the dashboard path is byte-for-byte unchanged when the prop is absent.
- `TeamCard.vue` — menu entries derived from `isHidden` / `isArchived`; `Update` gains `disabled`. Emits are unchanged, so the card stays presentational.
- `ListIndex.vue` — the four handlers, the shared `actionTeam` / `activeAction` pair, and the four modals.
- `ListIndex.actions.spec.ts` — new file rather than an addition to `ListIndex.spec.ts`, which would have pushed it past the 300-line `max-lines` cap.

**Worth a reviewer's attention:** the delete path. Six of the new tests mount the *real* modals in controlled mode to prove `teamId` takes precedence over the store — deleting the company the store happens to point at instead of the card acted on would destroy the wrong company.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Contribution checklist

`app/` quality gate passes with zero errors: `lint` (1 pre-existing warning in an untouched file), `format-check`, `type-check`, `test:unit` — **2707 passed**, 16 of them new. Verified at the test level; not exercised in a running browser.
