### PR TITLE
feat: ✨ withdraw funds left on a team's archived contract generations

### DIFF
--- a/app/src/components/CashOutStepList.vue
+++ b/app/src/components/CashOutStepList.vue
@@ -1,0 +1,59 @@
+<template>
+  <ul class="space-y-2">
+    <li
+      v-for="step in steps"
+      :key="step.key"
+      class="flex items-start gap-3 rounded-lg border border-gray-200 px-3 py-2 dark:border-gray-800"
+      :data-test="`${testPrefix}-step-${step.key}`"
+    >
+      <UIcon
+        :name="STEP_ICON[step.status]"
+        :class="['mt-0.5 size-5 shrink-0', STEP_ICON_CLASS[step.status]]"
+      />
+      <div class="min-w-0 flex-1">
+        <p class="font-medium">{{ step.label }}</p>
+        <p v-if="step.status === 'active' && step.detail" class="text-xs text-gray-500">
+          {{ step.detail }}
+        </p>
+        <p
+          v-if="step.status === 'failed' && step.error"
+          class="text-error text-xs"
+          :data-test="`${testPrefix}-error-${step.key}`"
+        >
+          {{ step.error }}
+        </p>
+      </div>
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import type { CashOutRunStep, CashOutStepStatus } from '@/composables/cashOut'
+
+/**
+ * Progress of a running cash-out sequence, one row per account.
+ *
+ * Purely presentational: every flow driving `useCashOutAll` renders the same
+ * stepper, so the markup and the status→icon mapping live here rather than
+ * being restated per call site. `testPrefix` keeps each flow's `data-test`
+ * hooks distinct.
+ */
+defineProps<{
+  steps: CashOutRunStep[]
+  testPrefix: string
+}>()
+
+const STEP_ICON: Record<CashOutStepStatus, string> = {
+  pending: 'i-heroicons-clock',
+  active: 'i-heroicons-arrow-path',
+  success: 'i-heroicons-check-circle',
+  failed: 'i-heroicons-x-circle'
+}
+
+const STEP_ICON_CLASS: Record<CashOutStepStatus, string> = {
+  pending: 'text-gray-400',
+  active: 'animate-spin text-warning',
+  success: 'text-success',
+  failed: 'text-error'
+}
+</script>

--- a/app/src/components/sections/ContractManagementView/LegacyGenerationWithdrawAction.vue
+++ b/app/src/components/sections/ContractManagementView/LegacyGenerationWithdrawAction.vue
@@ -1,0 +1,322 @@
+<template>
+  <UTooltip :text="blockedReason">
+    <UButton
+      color="warning"
+      variant="outline"
+      size="sm"
+      icon="i-heroicons-banknotes"
+      :disabled="!!blockedReason"
+      data-test="legacy-withdraw-button"
+      label="Withdraw funds"
+      @click="openModal"
+    />
+  </UTooltip>
+
+  <UModal
+    v-if="modal.mount"
+    v-model:open="modal.show"
+    title="Withdraw funds from this generation"
+    :description="
+      phase === 'review'
+        ? 'Review what will be moved back into the current treasury before signing.'
+        : 'Each account is a separate transaction to confirm in your wallet.'
+    "
+    :close="phase === 'progress' && cashOut.isRunning.value ? false : { onClick: closeModal }"
+  >
+    <template #body>
+      <!-- Review phase -->
+      <div v-if="phase === 'review'" class="space-y-4" data-test="legacy-withdraw-review">
+        <UAlert
+          color="warning"
+          variant="soft"
+          icon="i-heroicons-exclamation-triangle"
+          title="This empties the archived accounts into your current Bank."
+          description="The old Cash Remuneration and Expense Account first sweep into the Bank of their own generation, then that Bank forwards everything to the Bank this team uses today. You will sign one transaction per account (the Bank may need one signature per token)."
+        />
+
+        <div
+          class="divide-y divide-gray-100 rounded-lg border border-gray-200 dark:divide-gray-800 dark:border-gray-800"
+        >
+          <div
+            v-for="row in reviewRows"
+            :key="row.key"
+            class="flex items-center justify-between px-3 py-2 text-sm"
+            :data-test="`legacy-withdraw-review-${row.key}`"
+          >
+            <span class="text-gray-500 dark:text-gray-400">{{ row.label }}</span>
+            <span class="font-medium">{{ row.value }}</span>
+          </div>
+          <div
+            class="flex items-center justify-between px-3 py-2 text-sm"
+            data-test="legacy-withdraw-review-destination"
+          >
+            <span class="font-medium">Old Bank → current Bank</span>
+            <span class="font-semibold">~{{ projectedFormatted }}</span>
+          </div>
+        </div>
+
+        <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+          <span>Destination</span>
+          <AddressToolTip v-if="destination" :address="destination" class="text-xs" />
+        </div>
+
+        <p class="text-xs text-gray-500 dark:text-gray-400">
+          The Bank charges a small transfer fee, so the received amount is slightly lower.
+        </p>
+
+        <div class="flex justify-end gap-2">
+          <UButton
+            color="neutral"
+            variant="outline"
+            data-test="legacy-withdraw-cancel"
+            @click="closeModal"
+          >
+            Cancel
+          </UButton>
+          <UButton
+            color="warning"
+            :disabled="!hasAnyBalance"
+            data-test="legacy-withdraw-confirm"
+            label="Withdraw funds"
+            @click="confirm"
+          />
+        </div>
+      </div>
+
+      <!-- Progress phase -->
+      <div v-else class="space-y-4" data-test="legacy-withdraw-progress">
+        <ul class="space-y-2">
+          <li
+            v-for="step in cashOut.steps.value"
+            :key="step.key"
+            class="flex items-start gap-3 rounded-lg border border-gray-200 px-3 py-2 dark:border-gray-800"
+            :data-test="`legacy-withdraw-step-${step.key}`"
+          >
+            <UIcon
+              :name="stepIcon(step.status)"
+              :class="['mt-0.5 size-5 shrink-0', stepIconClass(step.status)]"
+            />
+            <div class="min-w-0 flex-1">
+              <p class="font-medium">{{ step.label }}</p>
+              <p v-if="step.status === 'active' && step.detail" class="text-xs text-gray-500">
+                {{ step.detail }}
+              </p>
+              <p
+                v-if="step.status === 'failed' && step.error"
+                class="text-error text-xs"
+                :data-test="`legacy-withdraw-error-${step.key}`"
+              >
+                {{ step.error }}
+              </p>
+            </div>
+          </li>
+        </ul>
+
+        <UAlert
+          v-if="cashOut.isComplete.value"
+          color="success"
+          variant="soft"
+          icon="i-heroicons-check-circle"
+          title="Withdrawal complete"
+          description="Everything this generation still held is now in the team's current Bank."
+          data-test="legacy-withdraw-complete"
+        />
+
+        <div class="flex justify-end gap-2">
+          <UButton
+            v-if="cashOut.hasFailed.value"
+            color="warning"
+            :loading="cashOut.isRunning.value"
+            data-test="legacy-withdraw-retry"
+            label="Retry"
+            @click="retry"
+          />
+          <UButton
+            color="neutral"
+            variant="outline"
+            :disabled="cashOut.isRunning.value"
+            data-test="legacy-withdraw-done"
+            :label="cashOut.isComplete.value ? 'Done' : 'Close'"
+            @click="closeModal"
+          />
+        </div>
+      </div>
+    </template>
+  </UModal>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { Address } from 'viem'
+import { useToast } from '@nuxt/ui/composables'
+import AddressToolTip from '@/components/AddressToolTip.vue'
+import { useContractBalance } from '@/composables/useContractBalance'
+import { useBankOwner } from '@/composables/bank/reads'
+import {
+  buildCashOutPlan,
+  legacyGenerationAddresses,
+  supportsOwnerWithdrawAll,
+  useCashOutAll,
+  type CashOutStepStatus
+} from '@/composables/cashOut'
+import { useOfficerBeaconFolderQuery } from '@/composables/contracts/useOfficerBeaconFolder'
+import { TEAM_ARCHIVED_TOOLTIP, useTeamWriteGuard } from '@/composables/useTeamWriteGuard'
+import { useCurrencyStore, useTeamStore, useUserDataStore } from '@/stores'
+import { formatCurrencyShort } from '@/utils/currencyUtil'
+
+/**
+ * Drains the contracts of ONE archived Officer generation back into the team's
+ * current Bank. Rendered per legacy generation card, so every instance owns its
+ * own balances, version resolution and run state.
+ */
+const props = defineProps<{
+  /** Officer that governs this generation — identifies it on-chain. */
+  officerAddress: string
+  /** Contracts this generation deployed, as returned by GET /contract/officers. */
+  contracts: ReadonlyArray<{ address: string; type: string }>
+}>()
+
+const teamStore = useTeamStore()
+const userStore = useUserDataStore()
+const currencyStore = useCurrencyStore()
+const { isWriteDisabled } = useTeamWriteGuard()
+const toast = useToast()
+
+const addresses = computed(() => legacyGenerationAddresses(props.contracts))
+const bankAddress = computed(() => addresses.value.bank as Address | undefined)
+const expenseAddress = computed(() => addresses.value.expense as Address | undefined)
+const cashRemAddress = computed(() => addresses.value.cashRemuneration as Address | undefined)
+
+/** Where the funds land: the Bank of the generation the team runs today. */
+const destination = computed(
+  () => teamStore.getContractAddressByType('Bank') as Address | undefined
+)
+
+// `ownerWithdrawAllToBank` only exists from V1 on, and a generation's proxies
+// sit behind frozen beacons — so the generation, not the team, decides whether
+// the automated drain is possible.
+const {
+  folder,
+  isPending: isResolvingVersion,
+  isError: versionResolutionFailed
+} = useOfficerBeaconFolderQuery(computed(() => props.officerAddress))
+
+const bankBalance = useContractBalance(bankAddress)
+const expenseBalance = useContractBalance(expenseAddress)
+const cashRemBalance = useContractBalance(cashRemAddress)
+
+const { data: bankOwner } = useBankOwner(bankAddress)
+
+const currencyCode = computed(() => currencyStore.localCurrency.code)
+const fiat = (balance: ReturnType<typeof useContractBalance>) =>
+  balance.data.value?.total.local.value ?? 0
+const fiatFormatted = (balance: ReturnType<typeof useContractBalance>) =>
+  balance.data.value?.total.local.formatted ?? '—'
+
+const isOwner = computed(() => {
+  if (!bankOwner.value || !userStore.address) return false
+  return String(bankOwner.value).toLowerCase() === userStore.address.toLowerCase()
+})
+
+const balancesFiat = computed(() => ({
+  cashRemuneration: cashRemAddress.value ? fiat(cashRemBalance) : 0,
+  expense: expenseAddress.value ? fiat(expenseBalance) : 0,
+  bank: fiat(bankBalance)
+}))
+
+const plan = computed(() => buildCashOutPlan(balancesFiat.value))
+const hasAnyBalance = computed(() => plan.value.length > 0)
+
+/**
+ * Why the button is unavailable, or `undefined` when it is actionable. Doubles
+ * as the tooltip text, so every disabled state explains itself instead of
+ * leaving the owner guessing.
+ */
+const blockedReason = computed(() => {
+  if (!bankAddress.value) return 'This generation has no Bank to withdraw through'
+  if (!destination.value) return 'This team has no current Bank to receive the funds'
+  if (destination.value.toLowerCase() === bankAddress.value.toLowerCase())
+    return 'This generation already holds the current Bank'
+  if (isResolvingVersion.value) return 'Checking which contract generation this is…'
+  if (versionResolutionFailed.value) return 'Could not read this generation from the chain'
+  if (!supportsOwnerWithdrawAll(folder.value))
+    return `Contracts from generation ${folder.value ?? 'unknown'} predate automated withdrawal — move the funds manually from the addresses below`
+  if (!isOwner.value) return 'Only the owner of these contracts can withdraw'
+  if (isWriteDisabled.value) return TEAM_ARCHIVED_TOOLTIP
+  if (!hasAnyBalance.value) return 'These contracts hold no funds'
+  return undefined
+})
+
+const cashOut = useCashOutAll({
+  sources: {
+    bank: bankAddress,
+    expense: expenseAddress,
+    cashRemuneration: cashRemAddress
+  },
+  to: destination
+})
+
+const modal = ref({ mount: false, show: false })
+const phase = ref<'review' | 'progress'>('review')
+
+const projectedFormatted = computed(() =>
+  formatCurrencyShort(
+    balancesFiat.value.cashRemuneration + balancesFiat.value.expense + balancesFiat.value.bank,
+    currencyCode.value
+  )
+)
+
+const reviewRows = computed(() => {
+  const rows: { key: string; label: string; value: string }[] = []
+  if (balancesFiat.value.cashRemuneration > 0)
+    rows.push({
+      key: 'cashRemuneration',
+      label: 'Cash Remuneration',
+      value: fiatFormatted(cashRemBalance)
+    })
+  if (balancesFiat.value.expense > 0)
+    rows.push({ key: 'expense', label: 'Expense Account', value: fiatFormatted(expenseBalance) })
+  if (balancesFiat.value.bank > 0)
+    rows.push({ key: 'bank', label: 'Bank', value: fiatFormatted(bankBalance) })
+  return rows
+})
+
+const openModal = () => {
+  if (blockedReason.value) return
+  cashOut.reset()
+  phase.value = 'review'
+  modal.value = { mount: true, show: true }
+}
+
+const closeModal = () => {
+  modal.value = { mount: false, show: false }
+  phase.value = 'review'
+  cashOut.reset()
+}
+
+const confirm = async () => {
+  phase.value = 'progress'
+  await cashOut.start(plan.value)
+  if (cashOut.isComplete.value) {
+    toast.add({ title: 'Legacy funds moved to the current Bank', color: 'success' })
+  }
+}
+
+const retry = () => cashOut.retry()
+
+const stepIcon = (status: CashOutStepStatus) =>
+  ({
+    pending: 'i-heroicons-clock',
+    active: 'i-heroicons-arrow-path',
+    success: 'i-heroicons-check-circle',
+    failed: 'i-heroicons-x-circle'
+  })[status]
+
+const stepIconClass = (status: CashOutStepStatus) =>
+  ({
+    pending: 'text-gray-400',
+    active: 'animate-spin text-warning',
+    success: 'text-success',
+    failed: 'text-error'
+  })[status]
+</script>

--- a/app/src/components/sections/ContractManagementView/LegacyGenerationWithdrawAction.vue
+++ b/app/src/components/sections/ContractManagementView/LegacyGenerationWithdrawAction.vue
@@ -27,11 +27,21 @@
       <!-- Review phase -->
       <div v-if="phase === 'review'" class="space-y-4" data-test="legacy-withdraw-review">
         <UAlert
+          v-if="canSweepSources"
           color="warning"
           variant="soft"
           icon="i-heroicons-exclamation-triangle"
           title="This empties the archived accounts into your current Bank."
           description="The old Cash Remuneration and Expense Account first sweep into the Bank of their own generation, then that Bank forwards everything to the Bank this team uses today. You will sign one transaction per account (the Bank may need one signature per token)."
+        />
+        <UAlert
+          v-else
+          color="warning"
+          variant="soft"
+          icon="i-heroicons-exclamation-triangle"
+          title="Only this generation's Bank can be emptied automatically."
+          :description="`Contracts from generation ${folder} predate the owner withdrawal added in V1, so the Expense Account and Cash Remuneration can only be emptied by hand — with a budget approval and a signed wage claim. The Bank forwards to the Bank this team uses today (one signature per token).`"
+          data-test="legacy-withdraw-bank-only-notice"
         />
 
         <div
@@ -52,6 +62,27 @@
           >
             <span class="font-medium">Old Bank → current Bank</span>
             <span class="font-semibold">~{{ projectedFormatted }}</span>
+          </div>
+        </div>
+
+        <!-- What this run will NOT reach, so the owner does not read a green
+             "complete" as "the generation is empty now". -->
+        <div
+          v-if="strandedRows.length"
+          class="rounded-lg border border-dashed border-gray-300 px-3 py-2 dark:border-gray-700"
+          data-test="legacy-withdraw-stranded"
+        >
+          <p class="mb-1 text-xs font-medium text-gray-500 dark:text-gray-400">
+            Stays behind — move these by hand
+          </p>
+          <div
+            v-for="row in strandedRows"
+            :key="row.key"
+            class="flex items-center justify-between py-1 text-sm"
+            :data-test="`legacy-withdraw-stranded-${row.key}`"
+          >
+            <span class="text-gray-500 dark:text-gray-400">{{ row.label }}</span>
+            <span class="font-medium">{{ row.value }}</span>
           </div>
         </div>
 
@@ -85,32 +116,7 @@
 
       <!-- Progress phase -->
       <div v-else class="space-y-4" data-test="legacy-withdraw-progress">
-        <ul class="space-y-2">
-          <li
-            v-for="step in cashOut.steps.value"
-            :key="step.key"
-            class="flex items-start gap-3 rounded-lg border border-gray-200 px-3 py-2 dark:border-gray-800"
-            :data-test="`legacy-withdraw-step-${step.key}`"
-          >
-            <UIcon
-              :name="stepIcon(step.status)"
-              :class="['mt-0.5 size-5 shrink-0', stepIconClass(step.status)]"
-            />
-            <div class="min-w-0 flex-1">
-              <p class="font-medium">{{ step.label }}</p>
-              <p v-if="step.status === 'active' && step.detail" class="text-xs text-gray-500">
-                {{ step.detail }}
-              </p>
-              <p
-                v-if="step.status === 'failed' && step.error"
-                class="text-error text-xs"
-                :data-test="`legacy-withdraw-error-${step.key}`"
-              >
-                {{ step.error }}
-              </p>
-            </div>
-          </li>
-        </ul>
+        <CashOutStepList :steps="cashOut.steps.value" test-prefix="legacy-withdraw" />
 
         <UAlert
           v-if="cashOut.isComplete.value"
@@ -118,7 +124,7 @@
           variant="soft"
           icon="i-heroicons-check-circle"
           title="Withdrawal complete"
-          description="Everything this generation still held is now in the team's current Bank."
+          :description="completionDescription"
           data-test="legacy-withdraw-complete"
         />
 
@@ -150,14 +156,14 @@ import { computed, ref } from 'vue'
 import type { Address } from 'viem'
 import { useToast } from '@nuxt/ui/composables'
 import AddressToolTip from '@/components/AddressToolTip.vue'
+import CashOutStepList from '@/components/CashOutStepList.vue'
 import { useContractBalance } from '@/composables/useContractBalance'
 import { useBankOwner } from '@/composables/bank/reads'
 import {
-  buildCashOutPlan,
+  buildLegacyWithdrawPlan,
   legacyGenerationAddresses,
   supportsOwnerWithdrawAll,
-  useCashOutAll,
-  type CashOutStepStatus
+  useCashOutAll
 } from '@/composables/cashOut'
 import { useOfficerBeaconFolderQuery } from '@/composables/contracts/useOfficerBeaconFolder'
 import { TEAM_ARCHIVED_TOOLTIP, useTeamWriteGuard } from '@/composables/useTeamWriteGuard'
@@ -194,12 +200,14 @@ const destination = computed(
 
 // `ownerWithdrawAllToBank` only exists from V1 on, and a generation's proxies
 // sit behind frozen beacons — so the generation, not the team, decides whether
-// the automated drain is possible.
+// the source accounts can be swept. The Bank hop works on every generation.
 const {
   folder,
   isPending: isResolvingVersion,
   isError: versionResolutionFailed
 } = useOfficerBeaconFolderQuery(computed(() => props.officerAddress))
+
+const canSweepSources = computed(() => supportsOwnerWithdrawAll(folder.value))
 
 const bankBalance = useContractBalance(bankAddress)
 const expenseBalance = useContractBalance(expenseAddress)
@@ -224,7 +232,9 @@ const balancesFiat = computed(() => ({
   bank: fiat(bankBalance)
 }))
 
-const plan = computed(() => buildCashOutPlan(balancesFiat.value))
+const plan = computed(() =>
+  buildLegacyWithdrawPlan(balancesFiat.value, { canSweepSources: canSweepSources.value })
+)
 const hasAnyBalance = computed(() => plan.value.length > 0)
 
 /**
@@ -239,19 +249,23 @@ const blockedReason = computed(() => {
     return 'This generation already holds the current Bank'
   if (isResolvingVersion.value) return 'Checking which contract generation this is…'
   if (versionResolutionFailed.value) return 'Could not read this generation from the chain'
-  if (!supportsOwnerWithdrawAll(folder.value))
-    return `Contracts from generation ${folder.value ?? 'unknown'} predate automated withdrawal — move the funds manually from the addresses below`
   if (!isOwner.value) return 'Only the owner of these contracts can withdraw'
   if (isWriteDisabled.value) return TEAM_ARCHIVED_TOOLTIP
-  if (!hasAnyBalance.value) return 'These contracts hold no funds'
+  if (!hasAnyBalance.value)
+    return canSweepSources.value
+      ? 'These contracts hold no funds'
+      : `Contracts from generation ${folder.value} can only have their Bank emptied, and it is empty`
   return undefined
 })
 
 const cashOut = useCashOutAll({
   sources: {
     bank: bankAddress,
-    expense: expenseAddress,
-    cashRemuneration: cashRemAddress
+    // A generation that cannot sweep its source accounts must not be handed
+    // their addresses: the sequence would call a function their proxies do not
+    // implement.
+    expense: computed(() => (canSweepSources.value ? expenseAddress.value : undefined)),
+    cashRemuneration: computed(() => (canSweepSources.value ? cashRemAddress.value : undefined))
   },
   to: destination
 })
@@ -259,27 +273,54 @@ const cashOut = useCashOutAll({
 const modal = ref({ mount: false, show: false })
 const phase = ref<'review' | 'progress'>('review')
 
-const projectedFormatted = computed(() =>
-  formatCurrencyShort(
-    balancesFiat.value.cashRemuneration + balancesFiat.value.expense + balancesFiat.value.bank,
-    currencyCode.value
-  )
-)
-
-const reviewRows = computed(() => {
-  const rows: { key: string; label: string; value: string }[] = []
+/** The source accounts, whether or not this generation can sweep them. */
+const sourceRows = computed(() => {
+  const rows: { key: string; label: string; value: string; amount: number }[] = []
   if (balancesFiat.value.cashRemuneration > 0)
     rows.push({
       key: 'cashRemuneration',
       label: 'Cash Remuneration',
-      value: fiatFormatted(cashRemBalance)
+      value: fiatFormatted(cashRemBalance),
+      amount: balancesFiat.value.cashRemuneration
     })
   if (balancesFiat.value.expense > 0)
-    rows.push({ key: 'expense', label: 'Expense Account', value: fiatFormatted(expenseBalance) })
-  if (balancesFiat.value.bank > 0)
-    rows.push({ key: 'bank', label: 'Bank', value: fiatFormatted(bankBalance) })
+    rows.push({
+      key: 'expense',
+      label: 'Expense Account',
+      value: fiatFormatted(expenseBalance),
+      amount: balancesFiat.value.expense
+    })
   return rows
 })
+
+/** What this run moves — the Bank always, the source accounts when sweepable. */
+const reviewRows = computed(() => {
+  const rows = canSweepSources.value ? [...sourceRows.value] : []
+  if (balancesFiat.value.bank > 0)
+    rows.push({
+      key: 'bank',
+      label: 'Bank',
+      value: fiatFormatted(bankBalance),
+      amount: balancesFiat.value.bank
+    })
+  return rows
+})
+
+/** What this run leaves on-chain, so a green "complete" is never misread. */
+const strandedRows = computed(() => (canSweepSources.value ? [] : sourceRows.value))
+
+const completionDescription = computed(() =>
+  strandedRows.value.length
+    ? "This generation's Bank is now empty. Its Expense Account and Cash Remuneration still hold funds — move those by hand."
+    : "Everything this generation still held is now in the team's current Bank."
+)
+
+const projectedFormatted = computed(() =>
+  formatCurrencyShort(
+    reviewRows.value.reduce((total, row) => total + row.amount, 0),
+    currencyCode.value
+  )
+)
 
 const openModal = () => {
   if (blockedReason.value) return
@@ -303,20 +344,4 @@ const confirm = async () => {
 }
 
 const retry = () => cashOut.retry()
-
-const stepIcon = (status: CashOutStepStatus) =>
-  ({
-    pending: 'i-heroicons-clock',
-    active: 'i-heroicons-arrow-path',
-    success: 'i-heroicons-check-circle',
-    failed: 'i-heroicons-x-circle'
-  })[status]
-
-const stepIconClass = (status: CashOutStepStatus) =>
-  ({
-    pending: 'text-gray-400',
-    active: 'animate-spin text-warning',
-    success: 'text-success',
-    failed: 'text-error'
-  })[status]
 </script>

--- a/app/src/components/sections/ContractManagementView/MainContractSection.vue
+++ b/app/src/components/sections/ContractManagementView/MainContractSection.vue
@@ -51,6 +51,14 @@
                 Redeploy Contracts
               </UButton>
             </TeamArchivedTooltip>
+
+            <!-- Funds left behind by an archived generation are unreachable from
+                 the rest of the UI — this is the only way back to them. -->
+            <LegacyGenerationWithdrawAction
+              v-else
+              :officer-address="gen.officerAddress"
+              :contracts="gen.contracts"
+            />
           </div>
         </template>
 
@@ -67,6 +75,7 @@ import { useUserDataStore } from '@/stores/user'
 import { useTeamStore } from '@/stores'
 import MainContractTable from './MainContractTable.vue'
 import RedeployOfficerModal from './RedeployOfficerModal.vue'
+import LegacyGenerationWithdrawAction from './LegacyGenerationWithdrawAction.vue'
 import TeamArchivedTooltip from '@/components/TeamArchivedTooltip.vue'
 import AddressToolTip from '@/components/AddressToolTip.vue'
 import { useTeamWriteGuard } from '@/composables/useTeamWriteGuard'

--- a/app/src/components/sections/ContractManagementView/__tests__/LegacyGenerationWithdrawAction.spec.ts
+++ b/app/src/components/sections/ContractManagementView/__tests__/LegacyGenerationWithdrawAction.spec.ts
@@ -119,12 +119,55 @@ describe('LegacyGenerationWithdrawAction', () => {
     expect(blockedReason(wrapper)).toBeUndefined()
   })
 
-  it('blocks generations that predate ownerWithdrawAllToBank', () => {
+  it('offers a Bank-only withdrawal on generations that predate ownerWithdrawAllToBank', async () => {
     mockBeaconFolder.folder.value = 'V0.1'
     const wrapper = createWrapper()
 
+    expect(wrapper.get(BUTTON).attributes('disabled')).toBeUndefined()
+    await wrapper.get(BUTTON).trigger('click')
+    await wrapper.get(CONFIRM).trigger('click')
+    await flushPromises()
+
+    const plan = mockCashOut.start.mock.calls[0][0] as { key: string }[]
+    expect(plan.map((s) => s.key)).toEqual(['bank'])
+  })
+
+  it('never hands a non-sweeping generation its source accounts', () => {
+    mockBeaconFolder.folder.value = 'V0'
+    createWrapper()
+
+    const { sources } = vi.mocked(useCashOutAll).mock.calls[0][0] as {
+      sources: Record<string, { value?: string }>
+    }
+    expect(sources.bank.value).toBe(LEGACY_BANK)
+    expect(sources.expense.value).toBeUndefined()
+    expect(sources.cashRemuneration.value).toBeUndefined()
+  })
+
+  it('warns which accounts a non-sweeping generation leaves behind', async () => {
+    mockBeaconFolder.folder.value = 'V0'
+    const wrapper = createWrapper()
+    await wrapper.get(BUTTON).trigger('click')
+
+    expect(wrapper.find('[data-test="legacy-withdraw-bank-only-notice"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="legacy-withdraw-stranded-expense"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="legacy-withdraw-stranded-cashRemuneration"]').exists()).toBe(
+      true
+    )
+    // The source accounts are not presented as things this run withdraws.
+    expect(wrapper.find('[data-test="legacy-withdraw-review-expense"]').exists()).toBe(false)
+  })
+
+  it('blocks a non-sweeping generation whose Bank is already empty', () => {
+    mockBeaconFolder.folder.value = 'V0'
+    mockUseContractBalance.total.value = {
+      usd: { value: 0, formatted: '$0' },
+      local: { value: 0, formatted: '$0' }
+    }
+    const wrapper = createWrapper()
+
     expect(wrapper.get(BUTTON).attributes('disabled')).toBeDefined()
-    expect(blockedReason(wrapper)).toContain('predate automated withdrawal')
+    expect(blockedReason(wrapper)).toContain('can only have their Bank emptied')
   })
 
   it('blocks while the generation is still being resolved', () => {

--- a/app/src/components/sections/ContractManagementView/__tests__/LegacyGenerationWithdrawAction.spec.ts
+++ b/app/src/components/sections/ContractManagementView/__tests__/LegacyGenerationWithdrawAction.spec.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import type { FolderVersion } from '@/artifacts/registry'
+import type { CashOutRunStep } from '@/composables/cashOut'
+import { mockBankReads, mockTeamStore, mockUseContractBalance, mockUserStore } from '@/tests/mocks'
+import { useCurrencyStore } from '@/stores'
+
+const OWNER_ADDRESS = '0x742d35cc6bf8c55c6c2e013e5492d2b6637e0886'
+const NON_OWNER = '0x00000000000000000000000000000000000000bb'
+const CURRENT_BANK = '0x1111111111111111111111111111111111111111'
+const LEGACY_OFFICER = '0x00000000000000000000000000000000000000f0'
+const LEGACY_BANK = '0x00000000000000000000000000000000000000b1'
+const LEGACY_EXPENSE = '0x00000000000000000000000000000000000000b2'
+const LEGACY_CASH_REM = '0x00000000000000000000000000000000000000b3'
+
+// Controllable orchestrator stub — the sequence itself is covered by
+// useCashOutAll.spec.ts; here we only drive the component UI from its state.
+const mockCashOut = {
+  steps: ref<CashOutRunStep[]>([]),
+  currentIndex: ref(0),
+  isRunning: ref(false),
+  isComplete: ref(false),
+  hasFailed: ref(false),
+  failedStep: ref<CashOutRunStep | null>(null),
+  start: vi.fn(),
+  retry: vi.fn(),
+  reset: vi.fn()
+}
+
+vi.mock('@/composables/cashOut', async (importOriginal) => {
+  const actual: object = await importOriginal()
+  return { ...actual, useCashOutAll: vi.fn(() => mockCashOut) }
+})
+
+const mockBeaconFolder = {
+  folder: ref<FolderVersion | undefined>('V1'),
+  isPending: ref(false),
+  isError: ref(false)
+}
+
+vi.mock('@/composables/contracts/useOfficerBeaconFolder', () => ({
+  useOfficerBeaconFolderQuery: vi.fn(() => mockBeaconFolder),
+  useOfficerBeaconFolder: vi.fn(() => mockBeaconFolder.folder)
+}))
+
+import LegacyGenerationWithdrawAction from '../LegacyGenerationWithdrawAction.vue'
+import { useCashOutAll } from '@/composables/cashOut'
+
+const BUTTON = '[data-test="legacy-withdraw-button"]'
+const CONFIRM = '[data-test="legacy-withdraw-confirm"]'
+
+const legacyContracts = [
+  { address: LEGACY_BANK, type: 'Bank' },
+  { address: LEGACY_EXPENSE, type: 'ExpenseAccountEIP712' },
+  { address: LEGACY_CASH_REM, type: 'CashRemunerationEIP712' }
+]
+
+const createWrapper = (contracts = legacyContracts) =>
+  mount(LegacyGenerationWithdrawAction, {
+    props: { officerAddress: LEGACY_OFFICER, contracts },
+    global: { stubs: { teleport: true } }
+  })
+
+/**
+ * Why the action is unavailable — the component funnels every disabled state
+ * through the tooltip, so this is the user-visible explanation.
+ */
+const blockedReason = (wrapper: ReturnType<typeof createWrapper>) =>
+  wrapper.findComponent({ name: 'UTooltip' }).props('text') as string | undefined
+
+const step = (over: Partial<CashOutRunStep>): CashOutRunStep => ({
+  key: 'bank',
+  label: 'Bank',
+  status: 'pending',
+  detail: '',
+  error: '',
+  ...over
+})
+
+describe('LegacyGenerationWithdrawAction', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    // Pinia auto-unwraps the store's `localCurrency` ref in production; the
+    // shared mock does not, so return a plain object for `.code` lookups.
+    vi.mocked(useCurrencyStore).mockReturnValue({
+      localCurrency: { code: 'USD', name: 'US Dollar', symbol: '$' }
+    } as unknown as ReturnType<typeof useCurrencyStore>)
+    mockBankReads.owner.data.value = OWNER_ADDRESS
+    mockUserStore.address = OWNER_ADDRESS
+    mockBeaconFolder.folder.value = 'V1'
+    mockBeaconFolder.isPending.value = false
+    mockBeaconFolder.isError.value = false
+    mockCashOut.steps.value = []
+    mockCashOut.isRunning.value = false
+    mockCashOut.isComplete.value = false
+    mockCashOut.hasFailed.value = false
+  })
+
+  it('drives the sequence over the legacy generation, into the current Bank', () => {
+    createWrapper()
+
+    expect(vi.mocked(useCashOutAll)).toHaveBeenCalledWith({
+      sources: {
+        bank: expect.objectContaining({ value: LEGACY_BANK }),
+        expense: expect.objectContaining({ value: LEGACY_EXPENSE }),
+        cashRemuneration: expect.objectContaining({ value: LEGACY_CASH_REM })
+      },
+      to: expect.objectContaining({ value: CURRENT_BANK })
+    })
+  })
+
+  it('enables the button for the owner of a supported generation holding funds', () => {
+    const wrapper = createWrapper()
+
+    expect(wrapper.get(BUTTON).attributes('disabled')).toBeUndefined()
+    expect(blockedReason(wrapper)).toBeUndefined()
+  })
+
+  it('blocks generations that predate ownerWithdrawAllToBank', () => {
+    mockBeaconFolder.folder.value = 'V0.1'
+    const wrapper = createWrapper()
+
+    expect(wrapper.get(BUTTON).attributes('disabled')).toBeDefined()
+    expect(blockedReason(wrapper)).toContain('predate automated withdrawal')
+  })
+
+  it('blocks while the generation is still being resolved', () => {
+    mockBeaconFolder.folder.value = undefined
+    mockBeaconFolder.isPending.value = true
+    const wrapper = createWrapper()
+
+    expect(wrapper.get(BUTTON).attributes('disabled')).toBeDefined()
+    expect(blockedReason(wrapper)).toContain('Checking which contract generation')
+  })
+
+  it('blocks when the generation could not be read from the chain', () => {
+    mockBeaconFolder.folder.value = undefined
+    mockBeaconFolder.isError.value = true
+    const wrapper = createWrapper()
+
+    expect(wrapper.get(BUTTON).attributes('disabled')).toBeDefined()
+    expect(blockedReason(wrapper)).toContain('Could not read this generation')
+  })
+
+  it('blocks anyone who does not own the legacy contracts', () => {
+    mockUserStore.address = NON_OWNER
+    const wrapper = createWrapper()
+
+    expect(wrapper.get(BUTTON).attributes('disabled')).toBeDefined()
+    expect(blockedReason(wrapper)).toContain('Only the owner')
+  })
+
+  it('blocks a generation with no Bank to withdraw through', () => {
+    const wrapper = createWrapper([{ address: LEGACY_EXPENSE, type: 'ExpenseAccountEIP712' }])
+
+    expect(wrapper.get(BUTTON).attributes('disabled')).toBeDefined()
+    expect(blockedReason(wrapper)).toContain('no Bank to withdraw through')
+  })
+
+  it('blocks a generation whose Bank is the one the team uses today', () => {
+    const wrapper = createWrapper([{ address: CURRENT_BANK, type: 'Bank' }])
+
+    expect(wrapper.get(BUTTON).attributes('disabled')).toBeDefined()
+    expect(blockedReason(wrapper)).toContain('already holds the current Bank')
+  })
+
+  it('blocks when the legacy contracts are empty', () => {
+    mockUseContractBalance.total.value = {
+      usd: { value: 0, formatted: '$0' },
+      local: { value: 0, formatted: '$0' }
+    }
+    const wrapper = createWrapper()
+
+    expect(wrapper.get(BUTTON).attributes('disabled')).toBeDefined()
+    expect(blockedReason(wrapper)).toContain('hold no funds')
+  })
+
+  it('blocks writes on an archived team', () => {
+    mockTeamStore.currentTeamMeta = {
+      isPending: false,
+      data: { ...mockTeamStore.currentTeam, isArchived: true }
+    }
+    const wrapper = createWrapper()
+
+    expect(wrapper.get(BUTTON).attributes('disabled')).toBeDefined()
+  })
+
+  it('reviews each funded account before signing', async () => {
+    const wrapper = createWrapper()
+    await wrapper.get(BUTTON).trigger('click')
+
+    expect(wrapper.find('[data-test="legacy-withdraw-review"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="legacy-withdraw-review-cashRemuneration"]').exists()).toBe(
+      true
+    )
+    expect(wrapper.find('[data-test="legacy-withdraw-review-expense"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="legacy-withdraw-review-destination"]').text()).toContain(
+      'Old Bank → current Bank'
+    )
+  })
+
+  it('starts the sequence with the built plan and moves to the progress phase', async () => {
+    const wrapper = createWrapper()
+    await wrapper.get(BUTTON).trigger('click')
+    await wrapper.get(CONFIRM).trigger('click')
+    await flushPromises()
+
+    expect(mockCashOut.start).toHaveBeenCalledTimes(1)
+    const plan = mockCashOut.start.mock.calls[0][0] as { key: string }[]
+    expect(plan.map((s) => s.key)).toEqual(['cashRemuneration', 'expense', 'bank'])
+    expect(wrapper.find('[data-test="legacy-withdraw-progress"]').exists()).toBe(true)
+  })
+
+  it('surfaces a failed step and offers a retry', async () => {
+    const wrapper = createWrapper()
+    await wrapper.get(BUTTON).trigger('click')
+    await wrapper.get(CONFIRM).trigger('click')
+
+    mockCashOut.steps.value = [
+      step({ key: 'cashRemuneration', label: 'Cash Remuneration', status: 'success' }),
+      step({ key: 'expense', label: 'Expense Account', status: 'failed', error: 'Contract paused' })
+    ]
+    mockCashOut.hasFailed.value = true
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="legacy-withdraw-error-expense"]').text()).toContain(
+      'Contract paused'
+    )
+
+    await wrapper.get('[data-test="legacy-withdraw-retry"]').trigger('click')
+    expect(mockCashOut.retry).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a completion notice when the sequence finishes', async () => {
+    const wrapper = createWrapper()
+    await wrapper.get(BUTTON).trigger('click')
+    await wrapper.get(CONFIRM).trigger('click')
+
+    mockCashOut.steps.value = [step({ key: 'bank', label: 'Bank', status: 'success' })]
+    mockCashOut.isComplete.value = true
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="legacy-withdraw-complete"]').exists()).toBe(true)
+  })
+})

--- a/app/src/components/sections/DashboardView/CashOutAllAction.vue
+++ b/app/src/components/sections/DashboardView/CashOutAllAction.vue
@@ -79,32 +79,7 @@
 
         <!-- Progress phase -->
         <div v-else class="space-y-4" data-test="cash-out-progress">
-          <ul class="space-y-2">
-            <li
-              v-for="step in cashOut.steps.value"
-              :key="step.key"
-              class="flex items-start gap-3 rounded-lg border border-gray-200 px-3 py-2 dark:border-gray-800"
-              :data-test="`cash-out-step-${step.key}`"
-            >
-              <UIcon
-                :name="stepIcon(step.status)"
-                :class="['mt-0.5 size-5 shrink-0', stepIconClass(step.status)]"
-              />
-              <div class="min-w-0 flex-1">
-                <p class="font-medium">{{ step.label }}</p>
-                <p v-if="step.status === 'active' && step.detail" class="text-xs text-gray-500">
-                  {{ step.detail }}
-                </p>
-                <p
-                  v-if="step.status === 'failed' && step.error"
-                  class="text-error text-xs"
-                  :data-test="`cash-out-error-${step.key}`"
-                >
-                  {{ step.error }}
-                </p>
-              </div>
-            </li>
-          </ul>
+          <CashOutStepList :steps="cashOut.steps.value" test-prefix="cash-out" />
 
           <UAlert
             v-if="cashOut.isComplete.value"
@@ -146,9 +121,9 @@ import type { Address } from 'viem'
 import { useContractBalance } from '@/composables'
 import { useBankOwner } from '@/composables/bank/reads'
 import { buildCashOutPlan, useCashOutAll } from '@/composables/cashOut'
-import type { CashOutStepStatus } from '@/composables/cashOut'
 import { useCurrencyStore, useTeamStore, useUserDataStore } from '@/stores'
 import { formatCurrencyShort } from '@/utils/currencyUtil'
+import CashOutStepList from '@/components/CashOutStepList.vue'
 import TeamArchivedTooltip from '@/components/TeamArchivedTooltip.vue'
 
 const teamStore = useTeamStore()
@@ -232,20 +207,4 @@ const confirm = async () => {
 }
 
 const retry = () => cashOut.retry()
-
-const stepIcon = (status: CashOutStepStatus) =>
-  ({
-    pending: 'i-heroicons-clock',
-    active: 'i-heroicons-arrow-path',
-    success: 'i-heroicons-check-circle',
-    failed: 'i-heroicons-x-circle'
-  })[status]
-
-const stepIconClass = (status: CashOutStepStatus) =>
-  ({
-    pending: 'text-gray-400',
-    active: 'animate-spin text-warning',
-    success: 'text-success',
-    failed: 'text-error'
-  })[status]
 </script>

--- a/app/src/composables/bank/reads.ts
+++ b/app/src/composables/bank/reads.ts
@@ -1,6 +1,6 @@
-import { computed } from 'vue'
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
 import { useReadContract } from '@wagmi/vue'
-import { isAddress } from 'viem'
+import { isAddress, type Address } from 'viem'
 import { useTeamStore } from '@/stores'
 import { bankAbi } from '@/artifacts/abi/generated'
 /**
@@ -11,8 +11,13 @@ export function useBankAddress() {
   return computed(() => teamStore.getContractAddressByType('Bank'))
 }
 
-export function useBankOwner() {
-  const bankAddress = useBankAddress()
+/**
+ * Owner of a Bank. Defaults to the team's current Bank; pass an address to read
+ * the Bank of an archived Officer generation instead.
+ */
+export function useBankOwner(address?: MaybeRefOrGetter<Address | undefined>) {
+  const currentBankAddress = useBankAddress()
+  const bankAddress = computed(() => toValue(address) ?? currentBankAddress.value)
   return useReadContract({
     address: bankAddress,
     abi: bankAbi,

--- a/app/src/composables/bank/writes.ts
+++ b/app/src/composables/bank/writes.ts
@@ -1,4 +1,5 @@
-import { computed } from 'vue'
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+import type { Address } from 'viem'
 import { bankAbi } from '@/artifacts/abi/generated'
 import {
   useContractWritesV3,
@@ -8,9 +9,21 @@ import { useTeamStore } from '@/stores/teamStore'
 
 type BankFunctionNames = WriteFunctionName<typeof bankAbi>
 
-function useBankContractWrite<F extends BankFunctionNames>(functionName: F) {
+/**
+ * A Bank other than the team's current one — used to drain a Bank belonging to
+ * an archived Officer generation. Omit it and the write targets the current
+ * generation, which is what every regular call site wants.
+ */
+export type BankAddressOverride = MaybeRefOrGetter<Address | undefined>
+
+function useBankContractWrite<F extends BankFunctionNames>(
+  functionName: F,
+  address?: BankAddressOverride
+) {
   const teamStore = useTeamStore()
-  const bankAddress = computed(() => teamStore.getContractAddressByType('Bank'))
+  const bankAddress = computed(
+    () => toValue(address) ?? (teamStore.getContractAddressByType('Bank') as Address | undefined)
+  )
   return useContractWritesV3({
     contractAddress: bankAddress,
     abi: bankAbi,
@@ -30,12 +43,12 @@ export function useDistributeTokenDividends() {
   return useBankContractWrite('distributeTokenDividends')
 }
 
-export function useTransfer() {
-  return useBankContractWrite('transfer')
+export function useTransfer(address?: BankAddressOverride) {
+  return useBankContractWrite('transfer', address)
 }
 
-export function useTransferToken() {
-  return useBankContractWrite('transferToken')
+export function useTransferToken(address?: BankAddressOverride) {
+  return useBankContractWrite('transferToken', address)
 }
 
 export function useFundFixedReturnRepayment() {

--- a/app/src/composables/cashOut/__tests__/legacyGeneration.spec.ts
+++ b/app/src/composables/cashOut/__tests__/legacyGeneration.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { legacyGenerationAddresses, supportsOwnerWithdrawAll } from '../legacyGeneration'
+import {
+  buildLegacyWithdrawPlan,
+  legacyGenerationAddresses,
+  supportsOwnerWithdrawAll
+} from '../legacyGeneration'
 
 describe('supportsOwnerWithdrawAll', () => {
   it('rejects the generations that predate ownerWithdrawAllToBank', () => {
@@ -14,6 +18,37 @@ describe('supportsOwnerWithdrawAll', () => {
 
   it('rejects an unresolved generation rather than assuming support', () => {
     expect(supportsOwnerWithdrawAll(undefined)).toBe(false)
+  })
+})
+
+describe('buildLegacyWithdrawPlan', () => {
+  const keys = (
+    balances: Parameters<typeof buildLegacyWithdrawPlan>[0],
+    canSweepSources: boolean
+  ) => buildLegacyWithdrawPlan(balances, { canSweepSources }).map((step) => step.key)
+
+  it('runs the full sequence for a generation that can sweep its sources', () => {
+    expect(keys({ cashRemuneration: 5, expense: 5, bank: 5 }, true)).toEqual([
+      'cashRemuneration',
+      'expense',
+      'bank'
+    ])
+  })
+
+  it('drains only the Bank for a generation that cannot', () => {
+    expect(keys({ cashRemuneration: 5, expense: 5, bank: 5 }, false)).toEqual(['bank'])
+  })
+
+  it('skips the Bank step entirely when a non-sweeping generation has an empty Bank', () => {
+    // Nothing consolidates into it, so running it would be a guaranteed no-op.
+    expect(keys({ cashRemuneration: 9, expense: 9, bank: 0 }, false)).toEqual([])
+  })
+
+  it('still consolidates into an empty Bank when the sources can be swept', () => {
+    expect(keys({ cashRemuneration: 9, expense: 0, bank: 0 }, true)).toEqual([
+      'cashRemuneration',
+      'bank'
+    ])
   })
 })
 

--- a/app/src/composables/cashOut/__tests__/legacyGeneration.spec.ts
+++ b/app/src/composables/cashOut/__tests__/legacyGeneration.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { legacyGenerationAddresses, supportsOwnerWithdrawAll } from '../legacyGeneration'
+
+describe('supportsOwnerWithdrawAll', () => {
+  it('rejects the generations that predate ownerWithdrawAllToBank', () => {
+    expect(supportsOwnerWithdrawAll('V0')).toBe(false)
+    expect(supportsOwnerWithdrawAll('V0.1')).toBe(false)
+  })
+
+  it('accepts the generations that expose it', () => {
+    expect(supportsOwnerWithdrawAll('V1')).toBe(true)
+    expect(supportsOwnerWithdrawAll('V2')).toBe(true)
+  })
+
+  it('rejects an unresolved generation rather than assuming support', () => {
+    expect(supportsOwnerWithdrawAll(undefined)).toBe(false)
+  })
+})
+
+describe('legacyGenerationAddresses', () => {
+  const BANK = '0x1111111111111111111111111111111111111111'
+  const EXPENSE = '0x2222222222222222222222222222222222222222'
+  const CASH_REM = '0x3333333333333333333333333333333333333333'
+
+  it('picks the three drainable accounts out of a generation', () => {
+    expect(
+      legacyGenerationAddresses([
+        { address: '0x9999999999999999999999999999999999999999', type: 'BoardOfDirectors' },
+        { address: BANK, type: 'Bank' },
+        { address: EXPENSE, type: 'ExpenseAccountEIP712' },
+        { address: CASH_REM, type: 'CashRemunerationEIP712' }
+      ])
+    ).toEqual({ bank: BANK, expense: EXPENSE, cashRemuneration: CASH_REM })
+  })
+
+  it('leaves accounts a generation never deployed undefined', () => {
+    expect(legacyGenerationAddresses([{ address: BANK, type: 'Bank' }])).toEqual({
+      bank: BANK,
+      expense: undefined,
+      cashRemuneration: undefined
+    })
+  })
+
+  it('returns nothing for an empty generation', () => {
+    expect(legacyGenerationAddresses([])).toEqual({
+      bank: undefined,
+      expense: undefined,
+      cashRemuneration: undefined
+    })
+  })
+})

--- a/app/src/composables/cashOut/__tests__/useCashOutAll.spec.ts
+++ b/app/src/composables/cashOut/__tests__/useCashOutAll.spec.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { BaseError, UserRejectedRequestError } from 'viem'
 import { useCashOutAll } from '../useCashOutAll'
+import { useTransfer, useTransferToken } from '@/composables/bank/writes'
+import { useOwnerWithdrawAllToBank as useExpenseOwnerWithdrawAll } from '@/composables/expenseAccount/writes'
+import { useOwnerWithdrawAllToBank as useCashOwnerWithdrawAll } from '@/composables/cashRemuneration/writes'
 import {
   mockBankWrites,
   mockCashRemunerationWrites,
@@ -14,6 +17,9 @@ import { buildCashOutPlan } from '../plan'
 
 const BANK_ADDRESS = '0x1111111111111111111111111111111111111111'
 const RECIPIENT = '0x00000000000000000000000000000000000000aa'
+const LEGACY_BANK = '0x00000000000000000000000000000000000000b1'
+const LEGACY_EXPENSE = '0x00000000000000000000000000000000000000b2'
+const LEGACY_CASH_REM = '0x00000000000000000000000000000000000000b3'
 
 const fullPlan = () => buildCashOutPlan({ cashRemuneration: 5, expense: 5, bank: 5 })
 
@@ -150,5 +156,57 @@ describe('useCashOutAll', () => {
     expect(flow.steps.value).toEqual([])
     expect(flow.currentIndex.value).toBe(0)
     expect(flow.isRunning.value).toBe(false)
+  })
+
+  describe('with an explicit generation and recipient', () => {
+    const legacyFlow = () =>
+      useCashOutAll({
+        sources: {
+          bank: LEGACY_BANK,
+          expense: LEGACY_EXPENSE,
+          cashRemuneration: LEGACY_CASH_REM
+        },
+        to: BANK_ADDRESS
+      })
+
+    it('points every contract write at the supplied generation', () => {
+      legacyFlow()
+
+      const addressOf = (mock: { mock: { calls: unknown[][] } }) => mock.mock.calls[0][0]
+      expect(addressOf(vi.mocked(useCashOwnerWithdrawAll))).toBe(LEGACY_CASH_REM)
+      expect(addressOf(vi.mocked(useExpenseOwnerWithdrawAll))).toBe(LEGACY_EXPENSE)
+      // Bank writes resolve the address through a computed, so assert its value.
+      expect(vi.mocked(useTransfer).mock.calls[0][0]).toHaveProperty('value', LEGACY_BANK)
+      expect(vi.mocked(useTransferToken).mock.calls[0][0]).toHaveProperty('value', LEGACY_BANK)
+    })
+
+    it('reads the supplied Bank balances and forwards them to the recipient', async () => {
+      await legacyFlow().start(fullPlan())
+
+      expect(mockWagmiCore.getBalance).toHaveBeenCalledWith(expect.anything(), {
+        address: LEGACY_BANK
+      })
+      expect(mockWagmiCore.readContract).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ functionName: 'balanceOf', args: [LEGACY_BANK] })
+      )
+      expect(mockBankWrites.transfer.mutateAsync).toHaveBeenCalledWith({
+        args: [BANK_ADDRESS, 5n]
+      })
+      expect(mockBankWrites.transferToken.mutateAsync).toHaveBeenCalledWith({
+        args: [expect.any(String), BANK_ADDRESS, 1000n]
+      })
+    })
+
+    it('never touches the current generation or the connected wallet', async () => {
+      await legacyFlow().start(fullPlan())
+
+      expect(mockWagmiCore.getBalance).not.toHaveBeenCalledWith(expect.anything(), {
+        address: BANK_ADDRESS
+      })
+      expect(mockBankWrites.transfer.mutateAsync).not.toHaveBeenCalledWith({
+        args: [RECIPIENT, 5n]
+      })
+    })
   })
 })

--- a/app/src/composables/cashOut/index.ts
+++ b/app/src/composables/cashOut/index.ts
@@ -1,2 +1,3 @@
+export * from './legacyGeneration'
 export * from './plan'
 export * from './useCashOutAll'

--- a/app/src/composables/cashOut/legacyGeneration.ts
+++ b/app/src/composables/cashOut/legacyGeneration.ts
@@ -3,37 +3,57 @@
  *
  * A team that redeploys its Officer keeps the previous generation on-chain: the
  * old Bank / Expense Account / Cash Remuneration still custody whatever they
- * held, but nothing in the new Officer's UI reaches them. These helpers say
- * whether an automated drain is possible for a given generation and pick out
- * the addresses the cash-out sequence needs.
+ * held, but nothing in the new Officer's UI reaches them. These helpers say how
+ * much of a given generation can be drained, and pick out the addresses the
+ * cash-out sequence needs.
  *
  * Kept free of Vue / wagmi so the version rule stays unit-testable on its own.
  */
 
 import type { FolderVersion } from '@/artifacts/registry'
+import { CASH_OUT_STEP_LABELS, buildCashOutPlan } from './plan'
+import type { CashOutAccountBalances, CashOutPlanStep } from './plan'
 
 /**
  * Generations deployed BEFORE `ownerWithdrawAllToBank` existed on
  * ExpenseAccountEIP712 / CashRemunerationEIP712 — it landed in V1.
  *
  * Every generation is a distinct full redeployment behind its own frozen
- * beacons, so a V0 / V0.1 proxy can never gain the function: its funds have to
- * be moved by hand (an EIP-712 budget approval on the Expense Account, a signed
- * wage claim on Cash Remuneration). The set is a denylist rather than an
- * allowlist so a future generation is treated as supported by default — new
- * generations only ever add to the ABI.
+ * beacons, so a V0 / V0.1 proxy can never gain the function: those two accounts
+ * have to be emptied by hand (an EIP-712 budget approval on the Expense
+ * Account, a signed wage claim on Cash Remuneration). Their Bank is unaffected —
+ * `transfer` / `transferToken` have been there since V0. The set is a denylist
+ * rather than an allowlist so a future generation is treated as supported by
+ * default: new generations only ever add to the ABI.
  */
 const FOLDERS_WITHOUT_OWNER_WITHDRAW = new Set<FolderVersion>(['V0', 'V0.1'])
 
 /**
  * Whether `folder`'s Expense Account and Cash Remuneration expose
- * `ownerWithdrawAllToBank`, i.e. whether the one-click drain is available.
+ * `ownerWithdrawAllToBank`, i.e. whether they can be swept into their Bank.
  *
- * An unresolved folder is NOT supported: never offer a flow whose generation we
- * could not confirm.
+ * An unresolved folder is NOT supported: never sweep an account whose
+ * generation we could not confirm.
  */
 export function supportsOwnerWithdrawAll(folder: FolderVersion | undefined): boolean {
   return folder !== undefined && !FOLDERS_WITHOUT_OWNER_WITHDRAW.has(folder)
+}
+
+/**
+ * Ordered steps for draining ONE archived generation.
+ *
+ * With `canSweepSources`, this is the regular three-account sequence. Without it
+ * — a V0 / V0.1 generation — only the Bank can be emptied: the source accounts
+ * have no owner-drain path, so sweeping them is not on offer and the Bank step
+ * is worth running only when the Bank itself holds something (nothing will
+ * consolidate into it).
+ */
+export function buildLegacyWithdrawPlan(
+  balances: CashOutAccountBalances,
+  { canSweepSources }: { canSweepSources: boolean }
+): CashOutPlanStep[] {
+  if (canSweepSources) return buildCashOutPlan(balances)
+  return balances.bank > 0 ? [{ key: 'bank', label: CASH_OUT_STEP_LABELS.bank }] : []
 }
 
 /** The subset of a generation's contracts the cash-out sequence drives. */

--- a/app/src/composables/cashOut/legacyGeneration.ts
+++ b/app/src/composables/cashOut/legacyGeneration.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure helpers for draining the contracts of an ARCHIVED Officer generation.
+ *
+ * A team that redeploys its Officer keeps the previous generation on-chain: the
+ * old Bank / Expense Account / Cash Remuneration still custody whatever they
+ * held, but nothing in the new Officer's UI reaches them. These helpers say
+ * whether an automated drain is possible for a given generation and pick out
+ * the addresses the cash-out sequence needs.
+ *
+ * Kept free of Vue / wagmi so the version rule stays unit-testable on its own.
+ */
+
+import type { FolderVersion } from '@/artifacts/registry'
+
+/**
+ * Generations deployed BEFORE `ownerWithdrawAllToBank` existed on
+ * ExpenseAccountEIP712 / CashRemunerationEIP712 — it landed in V1.
+ *
+ * Every generation is a distinct full redeployment behind its own frozen
+ * beacons, so a V0 / V0.1 proxy can never gain the function: its funds have to
+ * be moved by hand (an EIP-712 budget approval on the Expense Account, a signed
+ * wage claim on Cash Remuneration). The set is a denylist rather than an
+ * allowlist so a future generation is treated as supported by default — new
+ * generations only ever add to the ABI.
+ */
+const FOLDERS_WITHOUT_OWNER_WITHDRAW = new Set<FolderVersion>(['V0', 'V0.1'])
+
+/**
+ * Whether `folder`'s Expense Account and Cash Remuneration expose
+ * `ownerWithdrawAllToBank`, i.e. whether the one-click drain is available.
+ *
+ * An unresolved folder is NOT supported: never offer a flow whose generation we
+ * could not confirm.
+ */
+export function supportsOwnerWithdrawAll(folder: FolderVersion | undefined): boolean {
+  return folder !== undefined && !FOLDERS_WITHOUT_OWNER_WITHDRAW.has(folder)
+}
+
+/** The subset of a generation's contracts the cash-out sequence drives. */
+export interface LegacyGenerationAddresses {
+  bank?: string
+  expense?: string
+  cashRemuneration?: string
+}
+
+/**
+ * Pick the Bank / Expense Account / Cash Remuneration out of a generation's
+ * contract list. A generation may be missing any of them (older deployments did
+ * not always include every contract), hence the optional fields.
+ */
+export function legacyGenerationAddresses(
+  contracts: ReadonlyArray<{ address: string; type: string }>
+): LegacyGenerationAddresses {
+  const byType = (type: string) => contracts.find((contract) => contract.type === type)?.address
+
+  return {
+    bank: byType('Bank'),
+    expense: byType('ExpenseAccountEIP712'),
+    cashRemuneration: byType('CashRemunerationEIP712')
+  }
+}

--- a/app/src/composables/cashOut/useCashOutAll.ts
+++ b/app/src/composables/cashOut/useCashOutAll.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue'
+import { computed, ref, toValue, type MaybeRefOrGetter } from 'vue'
 import { getBalance, readContract } from '@wagmi/core'
 import type { Address } from 'viem'
 import { useQueryClient } from '@tanstack/vue-query'
@@ -38,6 +38,28 @@ const CONTRACT_KEY: Record<CashOutStepKey, ContractKey> = {
 }
 
 /**
+ * The three accounts the sequence drains. Each defaults to the team's CURRENT
+ * generation; pass explicit addresses to run the same sequence over the
+ * contracts of an archived Officer generation.
+ */
+export interface CashOutSources {
+  bank?: MaybeRefOrGetter<Address | undefined>
+  cashRemuneration?: MaybeRefOrGetter<Address | undefined>
+  expense?: MaybeRefOrGetter<Address | undefined>
+}
+
+export interface CashOutOptions {
+  sources?: CashOutSources
+  /**
+   * Where the Bank step forwards the consolidated funds. Defaults to the
+   * connected wallet (the "cash out to me" case); the legacy-generation flow
+   * points it at the current generation's Bank instead, so the money stays in
+   * the team treasury.
+   */
+  to?: MaybeRefOrGetter<Address | undefined>
+}
+
+/**
  * Orchestrates the "Cash out all" sequence.
  *
  * It is a state machine on top of the existing single-purpose contract
@@ -51,17 +73,30 @@ const CONTRACT_KEY: Record<CashOutStepKey, ContractKey> = {
  *    the Bank step re-reads live balances so already-emptied tokens are skipped.
  *  - The Bank step reads RAW on-chain balances at execution time (after the
  *    source accounts have consolidated into it) and forwards native + each held
- *    ERC-20 to the connected owner via `transfer` / `transferToken`.
+ *    ERC-20 to `options.to` via `transfer` / `transferToken`.
+ *
+ * The source sweeps always land in the Bank of THEIR OWN generation: on-chain,
+ * `ownerWithdrawAllToBank` resolves the Bank through the Officer the contract
+ * was deployed by. Only the final Bank → recipient hop is configurable.
  */
-export function useCashOutAll() {
+export function useCashOutAll(options: CashOutOptions = {}) {
   const teamStore = useTeamStore()
   const userStore = useUserDataStore()
   const queryClient = useQueryClient()
 
-  const cashWithdraw = useCashOwnerWithdrawAll()
-  const expenseWithdraw = useExpenseOwnerWithdrawAll()
-  const bankTransfer = useTransfer()
-  const bankTransferToken = useTransferToken()
+  const bankAddress = computed(
+    () =>
+      toValue(options.sources?.bank) ??
+      (teamStore.getContractAddressByType('Bank') as Address | undefined)
+  )
+  const recipient = computed(
+    () => toValue(options.to) ?? (userStore.address as Address | undefined)
+  )
+
+  const cashWithdraw = useCashOwnerWithdrawAll(options.sources?.cashRemuneration)
+  const expenseWithdraw = useExpenseOwnerWithdrawAll(options.sources?.expense)
+  const bankTransfer = useTransfer(bankAddress)
+  const bankTransferToken = useTransferToken(bankAddress)
 
   const steps = ref<CashOutRunStep[]>([])
   const currentIndex = ref(0)
@@ -74,13 +109,13 @@ export function useCashOutAll() {
   const hasFailed = computed(() => failedStep.value !== null)
 
   /**
-   * Bank step: forward everything the Bank now holds to the connected owner.
-   * Reads happen here (not up front) so they include what the source accounts
-   * just consolidated.
+   * Bank step: forward everything the Bank now holds to the recipient. Reads
+   * happen here (not up front) so they include what the source accounts just
+   * consolidated.
    */
   async function executeBankStep(step: CashOutRunStep) {
-    const bank = teamStore.getContractAddressByType('Bank') as Address | undefined
-    const to = userStore.address as Address | undefined
+    const bank = bankAddress.value
+    const to = recipient.value
     if (!bank) throw new Error('Bank address is undefined')
     if (!to) throw new Error('Recipient address is undefined')
 

--- a/app/src/composables/cashRemuneration/writes.ts
+++ b/app/src/composables/cashRemuneration/writes.ts
@@ -1,4 +1,5 @@
-import { computed } from 'vue'
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+import type { Address } from 'viem'
 import { cashRemunerationEip712Abi } from '@/artifacts/abi/generated'
 import {
   useContractWritesV3,
@@ -8,12 +9,22 @@ import { useTeamStore } from '@/stores/teamStore'
 
 type CashRemunerationFunctionNames = WriteFunctionName<typeof cashRemunerationEip712Abi>
 
+/**
+ * A Cash Remuneration other than the team's current one — used to drain the one
+ * belonging to an archived Officer generation. Omit it and the write targets
+ * the current generation.
+ */
+export type CashRemunerationAddressOverride = MaybeRefOrGetter<Address | undefined>
+
 function useCashRemunerationContractWrite<F extends CashRemunerationFunctionNames>(
-  functionName: F
+  functionName: F,
+  address?: CashRemunerationAddressOverride
 ) {
   const teamStore = useTeamStore()
-  const contractAddress = computed(() =>
-    teamStore.getContractAddressByType('CashRemunerationEIP712')
+  const contractAddress = computed(
+    () =>
+      toValue(address) ??
+      (teamStore.getContractAddressByType('CashRemunerationEIP712') as Address | undefined)
   )
   return useContractWritesV3({
     contractAddress,
@@ -26,8 +37,8 @@ export function useWithdraw() {
   return useCashRemunerationContractWrite('withdraw')
 }
 
-export function useOwnerWithdrawAllToBank() {
-  return useCashRemunerationContractWrite('ownerWithdrawAllToBank')
+export function useOwnerWithdrawAllToBank(address?: CashRemunerationAddressOverride) {
+  return useCashRemunerationContractWrite('ownerWithdrawAllToBank', address)
 }
 
 export function useEnableClaim() {

--- a/app/src/composables/contracts/useOfficerBeaconFolder.ts
+++ b/app/src/composables/contracts/useOfficerBeaconFolder.ts
@@ -12,14 +12,16 @@ import { folderForOfficerBeacon, type FolderVersion } from '@/artifacts/registry
 const BEACON_SLOT = '0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50'
 
 /**
- * Resolve the artifact folder of a team's Officer from its on-chain beacon.
- * Cached per Officer address (a proxy's beacon never changes). Returns undefined
- * until resolved (or on failure). Isolated from useContractVersion so the latter
- * stays a pure computed for consumers/tests.
+ * Resolve the artifact folder of an Officer from its on-chain beacon, keeping
+ * the query state.
+ *
+ * Cached per Officer address (a proxy's beacon never changes). `folder` is
+ * undefined both while the read is in flight and when it fails, so callers that
+ * must not act on a guess — e.g. one deciding whether a generation supports a
+ * given contract function — branch on `isPending` / `isError` instead of
+ * reading `undefined` as "unknown generation".
  */
-export function useOfficerBeaconFolder(
-  officerAddress: ComputedRef<string | undefined>
-): ComputedRef<FolderVersion | undefined> {
+export function useOfficerBeaconFolderQuery(officerAddress: ComputedRef<string | undefined>) {
   const query = useQuery({
     queryKey: computed(() => ['officer-beacon-folder', officerAddress.value]),
     enabled: computed(() => !!officerAddress.value),
@@ -36,5 +38,21 @@ export function useOfficerBeaconFolder(
     }
   })
 
-  return computed(() => query.data.value ?? undefined)
+  return {
+    folder: computed(() => query.data.value ?? undefined),
+    isPending: query.isPending,
+    isError: query.isError
+  }
+}
+
+/**
+ * Resolve the artifact folder of a team's Officer from its on-chain beacon.
+ * Cached per Officer address (a proxy's beacon never changes). Returns undefined
+ * until resolved (or on failure). Isolated from useContractVersion so the latter
+ * stays a pure computed for consumers/tests.
+ */
+export function useOfficerBeaconFolder(
+  officerAddress: ComputedRef<string | undefined>
+): ComputedRef<FolderVersion | undefined> {
+  return useOfficerBeaconFolderQuery(officerAddress).folder
 }

--- a/app/src/composables/expenseAccount/writes.ts
+++ b/app/src/composables/expenseAccount/writes.ts
@@ -1,4 +1,5 @@
-import { computed } from 'vue'
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+import type { Address } from 'viem'
 import { expenseAccountEip712Abi } from '@/artifacts/abi/generated'
 import {
   useContractWritesV3,
@@ -8,9 +9,23 @@ import { useTeamStore } from '@/stores/teamStore'
 
 type ExpenseAccountFunctionNames = WriteFunctionName<typeof expenseAccountEip712Abi>
 
-function useExpenseAccountContractWrite<F extends ExpenseAccountFunctionNames>(functionName: F) {
+/**
+ * An Expense Account other than the team's current one — used to drain the one
+ * belonging to an archived Officer generation. Omit it and the write targets
+ * the current generation.
+ */
+export type ExpenseAccountAddressOverride = MaybeRefOrGetter<Address | undefined>
+
+function useExpenseAccountContractWrite<F extends ExpenseAccountFunctionNames>(
+  functionName: F,
+  address?: ExpenseAccountAddressOverride
+) {
   const teamStore = useTeamStore()
-  const contractAddress = computed(() => teamStore.getContractAddressByType('ExpenseAccountEIP712'))
+  const contractAddress = computed(
+    () =>
+      toValue(address) ??
+      (teamStore.getContractAddressByType('ExpenseAccountEIP712') as Address | undefined)
+  )
   return useContractWritesV3({
     contractAddress,
     abi: expenseAccountEip712Abi,
@@ -18,8 +33,8 @@ function useExpenseAccountContractWrite<F extends ExpenseAccountFunctionNames>(f
   })
 }
 
-export function useOwnerWithdrawAllToBank() {
-  return useExpenseAccountContractWrite('ownerWithdrawAllToBank')
+export function useOwnerWithdrawAllToBank(address?: ExpenseAccountAddressOverride) {
+  return useExpenseAccountContractWrite('ownerWithdrawAllToBank', address)
 }
 
 export function useExpenseAccountTransfer() {


### PR DESCRIPTION
Closes #2419

## What

Adds a **Withdraw funds** action to every archived Officer generation card on the contract management page. Redeploying the Officer leaves the previous generation on-chain holding whatever it held — the page already listed those balances but offered no way to reach them, so the money was stranded.

The action runs the three-step sequence the dashboard "Cash out all" already uses, scoped to the archived generation and pointed at the team's **current Bank**, so the funds stay in the treasury:

1. old Cash Remuneration → sweeps into the Bank of its own generation
2. old Expense Account → sweeps into the Bank of its own generation
3. old Bank → forwards native + every held ERC-20 to the current Bank

Only the last hop is configurable: on-chain, `ownerWithdrawAllToBank` resolves the Bank through the Officer that deployed the contract, so the sweeps always land in their own generation's Bank.

## How

Rather than fork the sequence, the existing pieces were made address-aware:

- `useTransfer` / `useTransferToken` / `useOwnerWithdrawAllToBank` / `useBankOwner` take an optional address override, defaulting to the team store exactly as before. Each hook still wraps one call.
- `useCashOutAll` takes optional `sources` + `to`, defaulting to the current generation and the connected wallet. The dashboard call site is untouched.
- `useOfficerBeaconFolderQuery` exposes `isPending` / `isError` alongside the folder, because an in-flight read and a failed one both surface as `undefined` and this decision must not treat either as "unknown generation".
- The progress stepper, previously restated in full in the dashboard flow, is now one presentational component keyed by a test prefix.

## Generations that predate owner withdrawal

`ownerWithdrawAllToBank` landed in generation **V1**, and each generation is a distinct full redeployment behind its own frozen beacons — a V0 / V0.1 proxy can never gain it.

`Bank.transfer` / `transferToken` have existed since **V0** though, so those generations are not blocked: their card offers a **Bank-only** withdrawal. The plan is restricted to the Bank step, the source addresses are withheld from the sequence so it never calls a function their proxies do not implement, and both the review and the completion notice name the accounts left behind — an empty Bank must never read as an empty generation. Emptying those two by hand (EIP-712 budget approval / signed wage claim) stays out of scope.

The version rule is a denylist (`V0`, `V0.1`), not an allowlist, so a future generation is supported by default — new generations only ever add to the ABI.

## Blocked states

Every disabled state names its reason in the tooltip: no Bank in the generation, no current Bank to receive, the generation already holds the current Bank, generation still resolving, generation unreadable, not the contract owner, team archived, nothing withdrawable left (worded differently for a Bank-only generation).

## Tests

`npm run lint`, `npm run build-only`, `npm run type-check`, `npm run format-check` and the full `npm run test:unit` (317 files, 2737 tests) all pass. New coverage: the version rule, the plan restriction for non-sweeping generations, the account lookup, the parameterized sequence (writes point at the supplied generation, balances read from the supplied Bank, funds forwarded to the supplied recipient, current generation untouched), and the component's blocked states, Bank-only path, review, progress, retry and completion paths.

## Not covered

Safe balances — the Safe is preserved across a redeploy and is not part of an archived generation.
