### PR TITLE
fix: 🐛 Election display glitches and inconsistent sidebar behavior

### DIFF
--- a/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
+++ b/app/src/components/sections/AdministrationView/BoDElectionDetailsCard.vue
@@ -23,8 +23,8 @@
     <UProgress
       class="my-4"
       color="success"
-      :value="election.currentVotes"
-      :max="election.totalVotes"
+      :model-value="election.currentVotes"
+      :max="Math.max(election.totalVotes, 1)"
     />
 
     <!-- Conditional Button/Indicator -->

--- a/app/src/components/ui/SidebarLayout.vue
+++ b/app/src/components/ui/SidebarLayout.vue
@@ -45,6 +45,7 @@
         :collapsed="collapsed"
         :items="items"
         orientation="vertical"
+        :model-value="openSections"
         :ui="{
           list: 'flex flex-col gap-2',
           link: 'text-md gap-3 px-4 py-3 rounded-xl',
@@ -99,10 +100,9 @@
 
 <script setup lang="ts">
 import { useUserDataStore } from '@/stores/user'
-import { computed, ref } from 'vue'
-import { useLocalStorage } from '@vueuse/core'
+import { computed, ref, watch } from 'vue'
 import { formatAddress } from '@/utils/formatAddress'
-import { useSidebarNavItems, ACCOUNTING_MENU_KEY } from '@/composables/useSidebarNavItems'
+import { useSidebarNavItems } from '@/composables/useSidebarNavItems'
 
 const userStore = useUserDataStore()
 
@@ -110,10 +110,27 @@ const open = ref(false)
 
 const items = useSidebarNavItems()
 
-// Persist the Accounting menu's expanded state so it survives a reload. The
-const accountingExpanded = useLocalStorage(ACCOUNTING_MENU_KEY, false)
+// Controlled accordion so every parent menu follows one rule: the section of
+// the page you're on is open, the others are closed. `defaultOpen` on the items
+// marks that active section; navigating re-asserts it, and a manual click opens
+// only the clicked section (one open at a time).
+const activeOpen = computed<string[]>(() =>
+  items.value
+    .flat()
+    .filter((item) => item.defaultOpen && typeof item.value === 'string')
+    .map((item) => item.value as string)
+)
+
+const openSections = ref<string[]>(activeOpen.value)
+watch(activeOpen, (value) => {
+  openSections.value = value
+})
+
 function onMenuToggle(value: unknown): void {
-  if (Array.isArray(value)) accountingExpanded.value = value.includes('accounting')
+  if (!Array.isArray(value)) return
+  // Keep only the newly expanded section so a single one stays open at a time.
+  const added = (value as string[]).find((v) => !openSections.value.includes(v))
+  openSections.value = added ? [added] : []
 }
 
 const formatedUserAddress = computed(() => formatAddress(userStore.address))

--- a/app/src/composables/__tests__/useSidebarNavItems.spec.ts
+++ b/app/src/composables/__tests__/useSidebarNavItems.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { NavigationMenuItem } from '@nuxt/ui'
-import { useSidebarNavItems, ACCOUNTING_MENU_KEY } from '@/composables/useSidebarNavItems'
+import { useSidebarNavItems } from '@/composables/useSidebarNavItems'
 import { mockRoute } from '@/tests/mocks/router.mock'
 import { mockTeamStore, mockUserStore } from '@/tests/mocks/store.mock'
 
@@ -109,32 +109,52 @@ describe('useSidebarNavItems', () => {
     })
   })
 
-  describe('Accounting menu persistence', () => {
+  describe('uniform accordion open/close logic', () => {
     beforeEach(() => {
-      localStorage.clear()
-      // Default to a specific team context.
       mockRoute.params = { id: '42' }
     })
 
-    it('gives the Accounting item a stable accordion value', () => {
-      const accounting = findByLabel(useSidebarNavItems().value, 'Accounting')
-      expect(accounting?.value).toBe('accounting')
+    it('gives every parent menu a stable accordion value', () => {
+      const groups = useSidebarNavItems().value
+      for (const [label, value] of [
+        ['Accounts', 'accounts'],
+        ['Payroll', 'payroll'],
+        ['Community Credit', 'community-credit'],
+        ['Accounting', 'accounting'],
+        ['Administration', 'administration']
+      ] as const) {
+        expect(findByLabel(groups, label)?.value, label).toBe(value)
+      }
     })
 
-    it('stays closed by default even when persisted open on the companies list', () => {
-      localStorage.setItem(ACCOUNTING_MENU_KEY, 'true')
+    it('auto-expands only the section the current route belongs to', () => {
+      mockRoute.name = 'accounting-balance'
+
+      const groups = useSidebarNavItems().value
+      expect(findByLabel(groups, 'Accounting')?.defaultOpen).toBe(true)
+      expect(findByLabel(groups, 'Accounting')?.active).toBe(true)
+      // Every other section stays collapsed.
+      for (const label of ['Accounts', 'Payroll', 'Community Credit', 'Administration']) {
+        expect(findByLabel(groups, label)?.defaultOpen, label).toBe(false)
+      }
+    })
+
+    it('highlights the exact active child of the open section', () => {
+      mockRoute.name = 'accounting-balance'
+
+      const accounting = findByLabel(useSidebarNavItems().value, 'Accounting')
+      const balance = accounting?.children?.find((c) => c.label === 'Balance Sheet')
+      const ledger = accounting?.children?.find((c) => c.label === 'General Ledger')
+      expect(balance?.active).toBe(true)
+      expect(ledger?.active).toBe(false)
+    })
+
+    it('keeps sections collapsed when no company is selected', () => {
+      mockRoute.name = 'bank-account'
       mockRoute.params = {}
       mockTeamStore.currentTeamId = null as unknown as string
 
-      expect(findByLabel(useSidebarNavItems().value, 'Accounting')?.defaultOpen).toBe(false)
-    })
-
-    it('restores the persisted open state inside a company', () => {
-      // No persistence → collapsed, like the other menus.
-      expect(findByLabel(useSidebarNavItems().value, 'Accounting')?.defaultOpen).toBe(false)
-
-      localStorage.setItem(ACCOUNTING_MENU_KEY, 'true')
-      expect(findByLabel(useSidebarNavItems().value, 'Accounting')?.defaultOpen).toBe(true)
+      expect(findByLabel(useSidebarNavItems().value, 'Accounts')?.defaultOpen).toBe(false)
     })
   })
 
@@ -145,7 +165,7 @@ describe('useSidebarNavItems', () => {
 
     const payrollHistoryChild = () => {
       const payroll = findByLabel(useSidebarNavItems().value, 'Payroll')
-      return payroll?.children?.find((c) => c.active !== undefined)
+      return payroll?.children?.find((c) => (c.to as { name?: string })?.name === 'payroll-history')
     }
 
     it('labels the payroll-history entry "Member" for another member', () => {

--- a/app/src/composables/useSidebarNavItems.ts
+++ b/app/src/composables/useSidebarNavItems.ts
@@ -1,12 +1,8 @@
 import { computed, type ComputedRef } from 'vue'
 import { useRoute } from 'vue-router'
-import { useLocalStorage } from '@vueuse/core'
 import type { NavigationMenuItem } from '@nuxt/ui'
 import { useTeamStore } from '@/stores/teamStore'
 import { useUserDataStore } from '@/stores/user'
-
-/** localStorage key for the Accounting sidebar menu's expanded state. */
-export const ACCOUNTING_MENU_KEY = 'sidebar_accounting_expanded'
 
 /**
  * Builds the sidebar navigation as two groups:
@@ -17,16 +13,23 @@ export const ACCOUNTING_MENU_KEY = 'sidebar_accounting_expanded'
  *    have no team to operate on; the group label then shows the active
  *    company's name.
  *
+ * ## Uniform open/close & highlight logic
+ *
+ * Every parent that has children follows the **same** rule, so the menu reads
+ * consistently everywhere:
+ *
+ * - `value` — a stable accordion key, used by {@link SidebarLayout} to drive the
+ *   controlled "one section open at a time" accordion.
+ * - `active` — the parent is highlighted when the current route belongs to its
+ *   section, and `defaultOpen` mirrors it so that section auto-expands.
+ * - each child carries its own `active` for the exact-route highlight.
+ *
  * Kept in a composable so {@link SidebarLayout} stays focused on layout markup.
  */
 export function useSidebarNavItems(): ComputedRef<NavigationMenuItem[][]> {
   const route = useRoute()
   const userStore = useUserDataStore()
   const teamStore = useTeamStore()
-
-  // Persisted expanded state of the Accounting menu — read to seed `defaultOpen`
-  // so a reload restores it; written from {@link SidebarLayout} on toggle.
-  const accountingExpanded = useLocalStorage(ACCOUNTING_MENU_KEY, false)
 
   /**
    * A company is selected when the route is scoped to one (`/teams/:id/…`) or
@@ -40,6 +43,20 @@ export function useSidebarNavItems(): ComputedRef<NavigationMenuItem[][]> {
 
   return computed<NavigationMenuItem[][]>(() => {
     const disabled = !hasCompany.value
+    const name = String(route.name ?? '')
+
+    // Which parent section the current route belongs to. Drives both the active
+    // highlight and the auto-expand, uniformly for every menu with children.
+    const inAccounts = ['bank-account', 'safe-account', 'expense-account'].includes(name)
+    const inPayroll = [
+      'payroll-account',
+      'payroll-history',
+      'team-payroll',
+      'cash-remunerations-member'
+    ].includes(name)
+    const inCommunity = name.startsWith('community-credit')
+    const inAccounting = name.startsWith('accounting')
+    const inAdministration = name.startsWith('bod-')
 
     return [
       [
@@ -67,13 +84,20 @@ export function useSidebarNavItems(): ComputedRef<NavigationMenuItem[][]> {
         {
           label: 'Accounts',
           icon: 'heroicons:currency-dollar',
+          value: 'accounts',
+          active: inAccounts,
           disabled,
           to: { name: 'bank-account', params: teamParams() },
-          defaultOpen: hasCompany.value,
+          defaultOpen: hasCompany.value && inAccounts,
           children: [
-            { label: 'Bank Account', to: { name: 'bank-account', params: teamParams() } },
+            {
+              label: 'Bank Account',
+              active: name === 'bank-account',
+              to: { name: 'bank-account', params: teamParams() }
+            },
             {
               label: 'Safe Account',
+              active: name === 'safe-account',
               to: {
                 name: 'safe-account',
                 params: {
@@ -82,17 +106,27 @@ export function useSidebarNavItems(): ComputedRef<NavigationMenuItem[][]> {
                 }
               }
             },
-            { label: 'Expense Account', to: { name: 'expense-account', params: teamParams() } }
+            {
+              label: 'Expense Account',
+              active: name === 'expense-account',
+              to: { name: 'expense-account', params: teamParams() }
+            }
           ]
         },
         {
           label: 'Payroll',
           icon: 'heroicons:currency-dollar',
+          value: 'payroll',
+          active: inPayroll,
           disabled,
           to: { name: 'payroll-account', params: teamParams() },
-          defaultOpen: hasCompany.value,
+          defaultOpen: hasCompany.value && inPayroll,
           children: [
-            { label: 'Payroll Account', to: { name: 'payroll-account', params: teamParams() } },
+            {
+              label: 'Payroll Account',
+              active: name === 'payroll-account',
+              to: { name: 'payroll-account', params: teamParams() }
+            },
             {
               label:
                 route.name === 'payroll-history' && route.params.memberAddress !== userStore.address
@@ -104,73 +138,109 @@ export function useSidebarNavItems(): ComputedRef<NavigationMenuItem[][]> {
                 params: { id: teamStore.currentTeamId || '1', memberAddress: userStore.address }
               }
             },
-            { label: 'Company Payroll', to: { name: 'team-payroll', params: teamParams() } }
+            {
+              label: 'Company Payroll',
+              active: name === 'team-payroll',
+              to: { name: 'team-payroll', params: teamParams() }
+            }
           ]
         },
         {
           label: 'Community Credit',
           icon: 'heroicons:hand-raised',
-          active: String(route.name ?? '').startsWith('community-credit'),
+          value: 'community-credit',
+          active: inCommunity,
           disabled,
           to: { name: 'community-credit', params: teamParams() },
-          defaultOpen: false,
+          defaultOpen: hasCompany.value && inCommunity,
           children: [
-            { label: 'Rounds', to: { name: 'community-credit', params: teamParams() } },
+            {
+              label: 'Rounds',
+              active: name === 'community-credit',
+              to: { name: 'community-credit', params: teamParams() }
+            },
             {
               label: 'New credit call',
+              active: name === 'community-credit-new',
               to: { name: 'community-credit-new', params: teamParams() }
             }
           ]
         },
         {
           label: 'Accounting',
-          // Stable accordion value so its open state can be tracked/persisted
-          // independently of its position in the list.
           value: 'accounting',
           icon: 'heroicons:book-open',
+          active: inAccounting,
           disabled,
           to: { name: 'accounting', params: teamParams() },
-          // Closed by default; the persisted "open" is only honoured inside a
-          // company, so on the companies list it collapses like the others.
-          defaultOpen: hasCompany.value && accountingExpanded.value,
+          defaultOpen: hasCompany.value && inAccounting,
           children: [
-            { label: 'Summary', to: { name: 'accounting-summary', params: teamParams() } },
-            { label: 'Income Statement', to: { name: 'accounting-income', params: teamParams() } },
-            { label: 'Balance Sheet', to: { name: 'accounting-balance', params: teamParams() } },
-            { label: 'Trial Balance', to: { name: 'accounting-trial', params: teamParams() } },
-            { label: 'General Ledger', to: { name: 'accounting-ledger', params: teamParams() } }
+            {
+              label: 'Summary',
+              active: name === 'accounting-summary',
+              to: { name: 'accounting-summary', params: teamParams() }
+            },
+            {
+              label: 'Income Statement',
+              active: name === 'accounting-income',
+              to: { name: 'accounting-income', params: teamParams() }
+            },
+            {
+              label: 'Balance Sheet',
+              active: name === 'accounting-balance',
+              to: { name: 'accounting-balance', params: teamParams() }
+            },
+            {
+              label: 'Trial Balance',
+              active: name === 'accounting-trial',
+              to: { name: 'accounting-trial', params: teamParams() }
+            },
+            {
+              label: 'General Ledger',
+              active: name === 'accounting-ledger',
+              to: { name: 'accounting-ledger', params: teamParams() }
+            }
           ]
         },
         {
           label: 'Contract Management',
           icon: 'heroicons:wrench',
+          active: route.name === 'contract-management',
           disabled,
           to: { name: 'contract-management', params: teamParams() }
         },
         {
           label: 'SHER Token',
           icon: 'heroicons:chart-pie',
+          active: route.name === 'sher-token',
           disabled,
           to: { name: 'sher-token', params: teamParams() }
         },
         {
           label: 'Administration',
           icon: 'heroicons:chart-bar',
-          active: String(route.name ?? '').startsWith('bod-'),
+          value: 'administration',
+          active: inAdministration,
           disabled,
           to: { name: 'bod-elections', params: teamParams() },
+          defaultOpen: hasCompany.value && inAdministration,
           children: [
             {
               label: 'Board Election',
-              active: route.name === 'bod-elections' || route.name === 'bod-elections-details',
+              active: name === 'bod-elections' || name === 'bod-elections-details',
               to: { name: 'bod-elections', params: teamParams() }
             },
-            { label: 'Proposals', to: { name: 'bod-proposals', params: teamParams() } }
+            {
+              label: 'Proposals',
+              active: name === 'bod-proposals' || name === 'proposal-detail',
+              to: { name: 'bod-proposals', params: teamParams() }
+            }
           ]
         },
         {
           label: 'Vesting',
           icon: 'heroicons:lock-closed',
+          active: route.name === 'vesting',
           disabled,
           to: { name: 'vesting', params: teamParams() }
         }

--- a/app/src/composables/useSidebarNavItems.ts
+++ b/app/src/composables/useSidebarNavItems.ts
@@ -156,10 +156,15 @@ export function useSidebarNavItems(): ComputedRef<NavigationMenuItem[][]> {
         {
           label: 'Administration',
           icon: 'heroicons:chart-bar',
+          active: String(route.name ?? '').startsWith('bod-'),
           disabled,
           to: { name: 'bod-elections', params: teamParams() },
           children: [
-            { label: 'Board Election', to: { name: 'bod-elections', params: teamParams() } },
+            {
+              label: 'Board Election',
+              active: route.name === 'bod-elections' || route.name === 'bod-elections-details',
+              to: { name: 'bod-elections', params: teamParams() }
+            },
             { label: 'Proposals', to: { name: 'bod-proposals', params: teamParams() } }
           ]
         },

--- a/app/src/views/team/[id]/ProposalsView.vue
+++ b/app/src/views/team/[id]/ProposalsView.vue
@@ -53,26 +53,31 @@ import { ref } from 'vue'
 const createProposalModal = ref({ mount: false, show: false })
 const proposalsListRef = ref<InstanceType<typeof ProposalsList> | null>(null)
 
+// reka-ui (Nuxt UI's Select engine) throws when a SelectItem value is an empty
+// string, which corrupts the component tree and crashes on unmount. Use a
+// non-empty "all" sentinel for the catch-all options instead.
+const ALL = 'all'
+
 const types = [
-  { label: 'All Types', value: '' },
+  { label: 'All Types', value: ALL },
   { label: 'Financial', value: 'Financial' },
   { label: 'Technical', value: 'Technical' },
   { label: 'Operational', value: 'Operational' }
 ]
 
-const creators = [{ label: 'All Creators', value: '' }]
+const creators = [{ label: 'All Creators', value: ALL }]
 
 const statuses = [
-  { label: 'All Status', value: '' },
+  { label: 'All Status', value: ALL },
   { label: 'Active', value: 0 },
   { label: 'Approved', value: 1 },
   { label: 'Rejected', value: 2 },
   { label: 'Tied', value: 3 }
 ]
 
-const selectedType = ref<string>('')
-const selectedCreator = ref<string>('')
-const selectedStatus = ref<string | number>('')
+const selectedType = ref<string>(ALL)
+const selectedCreator = ref<string>(ALL)
+const selectedStatus = ref<string | number>(ALL)
 
 const handleProposalCreated = () => {
   // Close the modal

--- a/app/src/views/team/[id]/ShowIndex.vue
+++ b/app/src/views/team/[id]/ShowIndex.vue
@@ -27,7 +27,9 @@
       <TeamMeta />
       <CompanyOverview />
     </div>
-    <RouterView v-if="teamStore.currentTeamId" :key="teamOutletKey" />
+    <RouterView v-if="teamStore.currentTeamId" v-slot="{ Component }">
+      <component :is="Component" :key="teamOutletKey" />
+    </RouterView>
   </div>
 </template>
 <script setup lang="ts">


### PR DESCRIPTION
# Description

Fixes #2425 — display fixes on the election and administration pages.

## Summary

This PR cleans up four display problems around the election and administration sections:

- **Election progress bar.** An election with no votes yet was showing an animated "loading" bar on each candidate. The bar now stays empty at 0 votes and only fills as votes are cast.
- **Side-menu highlight when voting.** Opening an election's details page kept the "Board Election" entry highlighted in the left menu, so you always know which section you're in.
- **Proposals blank / stuck page.** The Proposals filters were built in a way that crashed the page when you navigated away, leaving the old content on screen or a blank white page. The filters were fixed so navigation away from Proposals always shows the destination page — no refresh needed.
- **Consistent side-menu open/close.** Every parent menu now follows the same rule: the section of the page you're on opens automatically, the others close, and the active page is highlighted. This replaces the previous mix (some always open, one remembering its state, some never highlighting).

Sidebar behavior unit tests were added/updated and pass; `lint` and `format` are clean on the changed files.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)