### PR TITLE
feat: ✨ improve company navigation links (#2423)

### DIFF
--- a/app/src/components/TeamSelectMenu.vue
+++ b/app/src/components/TeamSelectMenu.vue
@@ -155,6 +155,7 @@
 import { useUserDataStore, useTeamStore } from '@/stores'
 import { useGetTeamsQuery } from '@/queries/team.queries'
 import type { Team } from '@/types/team'
+import { routeForSelectedTeam } from '@/utils/teamNavigation'
 import { computed, ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 
@@ -230,7 +231,7 @@ const closeMenu = () => {
 
 const selectTeam = (team: Team) => {
   teamStore.setCurrentTeamId(team.id)
-  router.push(`/teams/${team.id}`)
+  router.push(routeForSelectedTeam(route, team.id))
   closeMenu()
 }
 

--- a/app/src/components/__tests__/TeamCard.spec.ts
+++ b/app/src/components/__tests__/TeamCard.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, RouterLinkStub } from '@vue/test-utils'
 import TeamCard from '@/components/sections/TeamView/TeamCard.vue'
 import { useCurrencyStore } from '@/stores/currencyStore'
 import { makeCurrencyStoreMock, mockUseContractBalance, mockUserStore } from '@/tests/mocks'
@@ -51,10 +51,22 @@ const makeTeam = (overrides: Partial<Team> = {}): Team =>
     ...overrides
   }) as Team
 
-const mountCard = (team: Team = makeTeam()) => mount(TeamCard, { props: { team } })
+const mountCard = (team: Team = makeTeam()) =>
+  mount(TeamCard, {
+    props: { team, to: { name: 'show-team', params: { id: team.id } } },
+    global: { stubs: { RouterLink: RouterLinkStub } }
+  })
 
 describe('TeamCard', () => {
   describe('Identity', () => {
+    it('exposes the whole company card as an accessible router link', () => {
+      const wrapper = mountCard()
+      const link = wrapper.findComponent(RouterLinkStub)
+
+      expect(link.props('to')).toEqual({ name: 'show-team', params: { id: '1' } })
+      expect(link.attributes('aria-label')).toBe('Open Team A')
+    })
+
     it('renders the team name and description', () => {
       const wrapper = mountCard()
 
@@ -287,21 +299,14 @@ describe('TeamCard', () => {
       expect(disabledOf(makeTeam())).toBe(false)
     })
 
-    // The whole card is the navigation target, so a click meant for the menu
-    // must not also open the team.
-    it('keeps menu clicks from reaching the card underneath', async () => {
-      const onCardClick = vi.fn()
-      const wrapper = mount(TeamCard, {
-        props: { team: makeTeam() },
-        attrs: { onClick: onCardClick }
-      })
+    // The menu is a sibling of the overlay link, avoiding invalid nested
+    // interactive controls and keeping card actions independent from navigation.
+    it('keeps the action menu outside the company link', () => {
+      const wrapper = mountCard()
+      const link = wrapper.find('[data-test="team-link"]')
+      const menu = wrapper.find('[data-test="team-menu"]')
 
-      await wrapper.find('[data-test="u-dropdown"]').trigger('click')
-      expect(onCardClick).not.toHaveBeenCalled()
-
-      // …while a click anywhere else on the card still navigates.
-      await wrapper.trigger('click')
-      expect(onCardClick).toHaveBeenCalledTimes(1)
+      expect(link.element.contains(menu.element)).toBe(false)
     })
 
     it('emits the chosen action instead of mutating the team itself', () => {

--- a/app/src/components/__tests__/TeamSelectMenu.spec.ts
+++ b/app/src/components/__tests__/TeamSelectMenu.spec.ts
@@ -60,11 +60,35 @@ describe('TeamSelectMenu', () => {
   })
 
   describe('actions', () => {
-    it('selects a team: sets the current team and navigates to it', async () => {
+    it('selects a team and preserves the current team-scoped route', async () => {
+      setMockRoute({
+        name: 'proposal-detail',
+        params: { id: '1', proposalId: '9' },
+        query: { tab: 'votes' },
+        hash: '#result',
+        path: '/teams/1/administration/bod-proposals/9'
+      })
       const wrapper = mountMenu()
       await wrapper.find('[data-test="team-option-1"]').trigger('click')
       expect(mockTeamStore.setCurrentTeamId).toHaveBeenCalledWith('1')
-      expect(mockRouterPush).toHaveBeenCalledWith('/teams/1')
+      expect(mockRouterPush).toHaveBeenCalledWith({
+        name: 'proposal-detail',
+        params: { id: '1', proposalId: '9' },
+        query: { tab: 'votes' },
+        hash: '#result'
+      })
+    })
+
+    it('falls back to the company overview from the companies list', async () => {
+      setMockRoute({ name: 'teams', params: {}, query: {}, path: '/teams' })
+
+      const wrapper = mountMenu()
+      await wrapper.find('[data-test="team-option-1"]').trigger('click')
+
+      expect(mockRouterPush).toHaveBeenCalledWith({
+        name: 'show-team',
+        params: { id: '1' }
+      })
     })
 
     it('navigates to the companies list from "All companies"', async () => {

--- a/app/src/components/sections/TeamView/TeamCard.vue
+++ b/app/src/components/sections/TeamView/TeamCard.vue
@@ -1,11 +1,18 @@
 <template>
   <UCard
     :ui="{
-      root: 'flex flex-col overflow-visible border-t-3',
+      root: 'relative flex flex-col overflow-visible border-t-3',
       body: 'flex flex-1 flex-col gap-3.5 p-5'
     }"
     :class="isOwner ? 'border-t-primary' : 'border-t-secondary'"
   >
+    <RouterLink
+      :to="to"
+      :aria-label="`Open ${team.name}`"
+      class="focus-visible:ring-primary absolute inset-0 z-10 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+      data-test="team-link"
+    />
+
     <!-- Identity -->
     <div class="flex items-start justify-between gap-2.5">
       <div class="min-w-0">
@@ -14,7 +21,7 @@
           {{ team.description }}
         </p>
       </div>
-      <div class="flex shrink-0 items-center gap-1.5">
+      <div class="relative z-20 flex shrink-0 items-center gap-1.5">
         <UBadge v-if="isOwner" size="sm" color="primary" variant="solid">Owner</UBadge>
         <UBadge v-else size="sm" color="secondary" variant="solid">Employee</UBadge>
         <UDropdownMenu :items="menuItems" @click.stop>
@@ -129,6 +136,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { DropdownMenuItem } from '@nuxt/ui'
+import { RouterLink, type RouteLocationRaw } from 'vue-router'
 import { useUserDataStore, useCurrencyStore } from '@/stores'
 import { useContractBalance } from '@/composables/useContractBalance'
 import { EMPTY_VALUE, formatCurrency, formatPercent } from '@/utils/format'
@@ -138,6 +146,7 @@ import type { ContractType } from '@/types/teamContract'
 
 interface Props {
   team: Team
+  to: RouteLocationRaw
 }
 
 const props = defineProps<Props>()

--- a/app/src/tests/mocks/router.mock.ts
+++ b/app/src/tests/mocks/router.mock.ts
@@ -6,6 +6,7 @@ export interface MockRoute {
   query: Record<string, string>
   path: string
   fullPath: string
+  hash: string
   name: string | undefined
   meta: Record<string, unknown>
 }
@@ -15,6 +16,7 @@ const defaultRoute = (): MockRoute => ({
   query: {},
   path: '/teams/1',
   fullPath: '/teams/1',
+  hash: '',
   name: undefined,
   meta: { name: 'Team View' }
 })

--- a/app/src/utils/__tests__/teamNavigation.spec.ts
+++ b/app/src/utils/__tests__/teamNavigation.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { routeForSelectedTeam } from '@/utils/teamNavigation'
+import type { RouteLocationNormalizedLoaded } from 'vue-router'
+
+const routeContext = (
+  overrides: Partial<RouteLocationNormalizedLoaded>
+): RouteLocationNormalizedLoaded =>
+  ({
+    name: 'show-team',
+    params: { id: '1' },
+    query: {},
+    hash: '',
+    ...overrides
+  }) as RouteLocationNormalizedLoaded
+
+describe('routeForSelectedTeam', () => {
+  it('changes only the company on a team-scoped route', () => {
+    const route = routeContext({
+      name: 'proposal-detail',
+      params: { id: '1', proposalId: '9' },
+      query: { tab: 'votes', filter: ['open', 'owned'] },
+      hash: '#result'
+    })
+
+    expect(routeForSelectedTeam(route, '42')).toEqual({
+      name: 'proposal-detail',
+      params: { id: '42', proposalId: '9' },
+      query: { tab: 'votes', filter: ['open', 'owned'] },
+      hash: '#result'
+    })
+  })
+
+  it('keeps the overview route when switching from an overview', () => {
+    const route = routeContext({ name: 'show-team', params: { id: '1' } })
+
+    expect(routeForSelectedTeam(route, 7)).toEqual({
+      name: 'show-team',
+      params: { id: '7' },
+      query: {},
+      hash: ''
+    })
+  })
+
+  it('falls back to the selected company overview outside a team route', () => {
+    const route = routeContext({ name: 'teams', params: {}, query: { create: '1' } })
+
+    expect(routeForSelectedTeam(route, '12')).toEqual({
+      name: 'show-team',
+      params: { id: '12' }
+    })
+  })
+})

--- a/app/src/utils/teamNavigation.ts
+++ b/app/src/utils/teamNavigation.ts
@@ -1,0 +1,26 @@
+import type { RouteLocationNormalizedLoaded, RouteLocationRaw } from 'vue-router'
+
+type TeamRouteContext = Pick<RouteLocationNormalizedLoaded, 'name' | 'params' | 'query' | 'hash'>
+
+/**
+ * Keep the current team-scoped destination while changing only its company.
+ * Routes outside a company workspace have no page to preserve, so they open
+ * the selected company's overview instead.
+ */
+export function routeForSelectedTeam(
+  route: TeamRouteContext,
+  teamId: string | number
+): RouteLocationRaw {
+  const id = String(teamId)
+
+  if (!route.name || route.params.id == null) {
+    return { name: 'show-team', params: { id } }
+  }
+
+  return {
+    name: route.name,
+    params: { ...route.params, id },
+    query: route.query,
+    hash: route.hash
+  }
+}

--- a/app/src/views/team/ListIndex.vue
+++ b/app/src/views/team/ListIndex.vue
@@ -99,9 +99,9 @@
         v-for="team in teams"
         :key="team.id"
         :team="team"
+        :to="{ name: 'show-team', params: { id: team.id } }"
         :data-test="`team-card-${team.id}`"
         class="cursor-pointer transition duration-300 hover:-translate-y-0.5 hover:shadow-md"
-        @click="navigateToTeam(team.id)"
         @update="openAction(team, 'update')"
         @archive="openAction(team, 'archive')"
         @hide="openAction(team, 'hide')"
@@ -212,10 +212,6 @@ watch(
   },
   { immediate: true }
 )
-
-const navigateToTeam = (id: number | string) => {
-  router.push(`/teams/${id}`)
-}
 
 // --- Card actions ---------------------------------------------------------
 // The cards only announce what was chosen; the list owns the modals so they

--- a/app/src/views/team/__tests__/ListIndex.actions.spec.ts
+++ b/app/src/views/team/__tests__/ListIndex.actions.spec.ts
@@ -3,7 +3,7 @@ import ListIndex from '@/views/team/ListIndex.vue'
 import { mount } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
 import { createMockQueryResponse } from '@/tests/mocks/query.mock'
-import { mockTeamData, mockRouterPush } from '@/tests/mocks'
+import { mockTeamData } from '@/tests/mocks'
 import type { Team } from '@/types'
 import { useRoute } from 'vue-router'
 
@@ -46,7 +46,7 @@ describe('ListIndex - card actions', () => {
           AddTeamForm: true,
           TeamCard: {
             name: 'TeamCard',
-            props: ['team'],
+            props: ['team', 'to'],
             template: '<div :data-test="`team-card-${team.id}`" />'
           },
           ...Object.fromEntries(Object.values(MODAL_FOR).map((name) => [name, modalStub(name)]))
@@ -113,14 +113,5 @@ describe('ListIndex - card actions', () => {
     await wrapper.vm.$nextTick()
 
     expect(modal.props('open')).toBe(false)
-  })
-
-  // Opening a card's menu must never also open the team behind it.
-  it('does not navigate when a card raises an action', async () => {
-    const wrapper = mountWithActions([TEAM])
-    cardFor(wrapper, '42').vm.$emit('update')
-    await wrapper.vm.$nextTick()
-
-    expect(mockRouterPush).not.toHaveBeenCalled()
   })
 })

--- a/app/src/views/team/__tests__/ListIndex.spec.ts
+++ b/app/src/views/team/__tests__/ListIndex.spec.ts
@@ -3,7 +3,7 @@ import ListIndex from '@/views/team/ListIndex.vue'
 import { mount } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
 import { createMockQueryResponse } from '@/tests/mocks/query.mock'
-import { mockTeamsData, mockTeamData, mockRouterPush, mockRouterReplace } from '@/tests/mocks'
+import { mockTeamsData, mockTeamData, mockRouterReplace } from '@/tests/mocks'
 import type { Team } from '@/types'
 import { useRoute } from 'vue-router'
 
@@ -42,9 +42,10 @@ describe('ListIndex - Team List View', () => {
               '<div data-test="add-team-card"><button data-test="add-team">Add Team</button></div>'
           },
           TeamCard: {
+            name: 'TeamCard',
             template:
               '<div :data-test="`team-card-${team.id}`" class="team-card"><strong>{{ team.name }}</strong></div>',
-            props: ['team']
+            props: ['team', 'to']
           }
         }
       }
@@ -222,56 +223,43 @@ describe('ListIndex - Team List View', () => {
     })
   })
 
-  describe('User Interactions', () => {
-    it('should navigate to team when team card is clicked', async () => {
+  describe('Company links', () => {
+    it('should give each team card a route to its company overview', async () => {
       const wrapper = createWrapper(mockTeamsData)
       await wrapper.vm.$nextTick()
 
-      const teamCard = wrapper.find(`[data-test="team-card-${mockTeamData.id}"]`)
-      await teamCard.trigger('click')
+      const teamCard = wrapper
+        .findAllComponents({ name: 'TeamCard' })
+        .find((card) => card.props('team').id === mockTeamData.id)
 
-      expect(mockRouterPush).toHaveBeenCalledWith(`/teams/${mockTeamData.id}`)
+      expect(teamCard?.props('to')).toEqual({
+        name: 'show-team',
+        params: { id: mockTeamData.id }
+      })
     })
 
-    it('should navigate with correct team ID', async () => {
-      const testTeam = { ...mockTeamData, id: '123' }
-      const wrapper = createWrapper([testTeam])
+    it('should create a distinct destination for every company', async () => {
+      const teams = [
+        { ...mockTeamData, id: '1' },
+        { ...mockTeamData, id: '2', name: 'Team 2' },
+        { ...mockTeamData, id: '3', name: 'Team 3' }
+      ]
+      const wrapper = createWrapper(teams)
       await wrapper.vm.$nextTick()
 
-      const teamCard = wrapper.find(`[data-test="team-card-${testTeam.id}"]`)
-      await teamCard.trigger('click')
-
-      expect(mockRouterPush).toHaveBeenCalledWith('/teams/123')
+      expect(
+        wrapper.findAllComponents({ name: 'TeamCard' }).map((card) => card.props('to'))
+      ).toEqual(teams.map((team) => ({ name: 'show-team', params: { id: team.id } })))
     })
+  })
 
+  describe('User Interactions', () => {
     it('should open add team modal when add team button is clicked', async () => {
       const wrapper = createWrapper([], false)
       await wrapper.vm.$nextTick()
 
       const addTeamBtn = wrapper.find('[data-test="add-team"]')
       expect(addTeamBtn.exists()).toBe(true)
-    })
-
-    it('should handle multiple team clicks correctly', async () => {
-      const multipleTeams = [
-        { ...mockTeamData, id: '1' },
-        { ...mockTeamData, id: '2', name: 'Team 2' },
-        { ...mockTeamData, id: '3', name: 'Team 3' }
-      ]
-      const wrapper = createWrapper(multipleTeams)
-      await wrapper.vm.$nextTick()
-
-      const teamCard1 = wrapper.find('[data-test="team-card-1"]')
-      const teamCard2 = wrapper.find('[data-test="team-card-2"]')
-      const teamCard3 = wrapper.find('[data-test="team-card-3"]')
-
-      await teamCard1.trigger('click')
-      await teamCard2.trigger('click')
-      await teamCard3.trigger('click')
-
-      expect(mockRouterPush).toHaveBeenNthCalledWith(1, '/teams/1')
-      expect(mockRouterPush).toHaveBeenNthCalledWith(2, '/teams/2')
-      expect(mockRouterPush).toHaveBeenNthCalledWith(3, '/teams/3')
     })
   })
 


### PR DESCRIPTION
# Description

## Initial issue description

Company cards only supported JavaScript-driven navigation, which prevented native browser actions such as opening a company in a new tab. The navbar team selector also reset users to the selected company's overview instead of keeping them on the equivalent workspace page.

Closes #2423

Parent goal: #2128

## PR summary

- Render each company card as an accessible `RouterLink` while keeping its management menu outside the link interaction layer.
- Preserve the current named team route when switching companies by replacing only the team `id`.
- Retain route-specific params, query parameters, and hashes.
- Fall back to the selected company's overview when switching from a non-team route.
- Add focused component and utility tests for link semantics and route reconstruction.

## User impact

Users can open companies through native browser link behaviors, including Cmd/Ctrl-click and the context menu. They can also switch companies without losing their current workspace location.

## Validation

- `npm run lint` (passes with one pre-existing disabled-test warning)
- `npm run format-check`
- `npm run type-check`
- `npm run test:unit -- --run` — 2,741 passed, 1 skipped

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Contribution checklist

- [x] Commit messages follow the repository guidelines.
- [x] Tests for the changes have been added.
- [x] No documentation update is required.
