### PR TITLE
fix: 🐛 drop unused ERC20 approval from expense account spend

### DIFF
--- a/app/src/components/sections/ExpenseAccountView/TransferAction.vue
+++ b/app/src/components/sections/ExpenseAccountView/TransferAction.vue
@@ -40,7 +40,7 @@
           v-if="showModal.mount && tokens.length > 0"
           v-model="transferData"
           :tokens="tokens"
-          :loading="transferMutation.isPending.value || approveMutation.isPending.value"
+          :loading="transferMutation.isPending.value"
           @transfer="
             async (data) => {
               await transferFromExpenseAccount(data.address.address, data.amount)
@@ -69,14 +69,13 @@
 import { ref, computed } from 'vue'
 import TeamArchivedTooltip from '@/components/TeamArchivedTooltip.vue'
 import TransferForm from '@/components/forms/TransferForm.vue'
-import { USDC_ADDRESS, type TokenId } from '@/constant'
+import { type TokenId } from '@/constant'
 import type { BudgetLimit } from '@/types'
 import { useContractBalance } from '@/composables'
-import { useTeamStore, useUserDataStore } from '@/stores'
+import { useTeamStore } from '@/stores'
 import { classifyError, getTokens, log } from '@/utils'
 import {
   encodeFunctionData,
-  erc20Abi,
   parseEther,
   recoverTypedDataAddress,
   zeroAddress,
@@ -87,7 +86,6 @@ import { expenseAccountEip712Abi } from '@/artifacts/abi/generated'
 import { estimateGas, readContract } from '@wagmi/core'
 import { useChainId } from '@wagmi/vue'
 import { config } from '@/wagmi.config'
-import { useERC20Approve } from '@/composables/erc20/writes'
 import { useExpenseAccountTransfer } from '@/composables/expenseAccount/writes'
 import type { WriteFunctionArgs } from '@/composables/contracts/useContractWritesV3'
 import { expenseKeys } from '@/queries'
@@ -97,7 +95,6 @@ import type { TransferData } from '@/types'
 const props = defineProps<{ row: TableRow }>()
 
 const teamStore = useTeamStore()
-const userDataStore = useUserDataStore()
 const toast = useToast()
 const chainId = useChainId()
 const { data: balance } = useContractBalance(
@@ -138,7 +135,6 @@ const expenseAccountEip712Address = computed(() =>
 const tokens = computed(() => getTokens([props.row], props.row.signature, balances.value))
 
 const transferMutation = useExpenseAccountTransfer()
-const approveMutation = useERC20Approve(computed(() => USDC_ADDRESS as Address))
 
 const transferFromExpenseAccount = async (to: string, amount: string) => {
   errorMessage.value = ''
@@ -150,7 +146,7 @@ const transferFromExpenseAccount = async (to: string, amount: string) => {
   if (budgetLimit.tokenAddress === zeroAddress) {
     await transferNativeToken(to, amount, budgetLimit)
   } else {
-    await transferErc20Token(to, amount, budgetLimit)
+    transferErc20Token(to, amount, budgetLimit)
   }
 }
 
@@ -275,46 +271,16 @@ const transferNativeToken = async (to: string, amount: string, budgetLimit: Budg
   submitExpenseAccountTransfer(args)
 }
 
-const transferErc20Token = async (to: string, amount: string, budgetLimit: BudgetLimit) => {
+// `transfer` pays out of the expense contract's own token balance — it never
+// calls `transferFrom` on the caller — so no ERC20 allowance is needed here.
+const transferErc20Token = (to: string, amount: string, budgetLimit: BudgetLimit) => {
   if (!expenseAccountEip712Address.value) return
 
-  const _amount = BigInt(Number(amount) * 1e6)
-  const tokenAddress = USDC_ADDRESS as Address
-
-  let allowance: bigint
-  try {
-    allowance = (await readContract(config, {
-      address: tokenAddress,
-      abi: erc20Abi,
-      functionName: 'allowance',
-      args: [userDataStore.address as Address, expenseAccountEip712Address.value]
-    })) as bigint
-  } catch (error) {
-    log.error('Error reading allowance:', error)
-    errorMessage.value = 'Failed to read allowance'
-    return
-  }
-
-  const buildArgs = () =>
-    [to, _amount, buildContractBudgetLimit(budgetLimit), props.row.signature] as const
-
-  if (allowance < _amount) {
-    approveMutation.mutate(
-      { args: [expenseAccountEip712Address.value, _amount] },
-      {
-        onSuccess: () => {
-          toast.add({ title: 'Approval granted successfully', color: 'success' })
-          submitExpenseAccountTransfer(buildArgs())
-        },
-        onError: (err) => {
-          log.error('Token approval failed:', err)
-          errorMessage.value = 'Failed to approve token spending'
-        }
-      }
-    )
-    return
-  }
-
-  submitExpenseAccountTransfer(buildArgs())
+  submitExpenseAccountTransfer([
+    to,
+    BigInt(Number(amount) * 1e6),
+    buildContractBudgetLimit(budgetLimit),
+    props.row.signature
+  ] as const)
 }
 </script>

--- a/app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts
@@ -92,48 +92,25 @@ describe('TransferAction.vue', () => {
     vi.mocked(recoverTypedDataAddress).mockResolvedValue(OWNER_ADDRESS)
   })
 
-  it('invokes transfer when ERC20 allowance is sufficient', async () => {
-    vi.mocked(readContract)
-      .mockResolvedValueOnce(OWNER_ADDRESS)
-      .mockResolvedValueOnce(BigInt(200 * 1e6))
+  // `ExpenseAccountEIP712.transfer` spends the contract's own token balance, so
+  // the member's allowance is irrelevant: no allowance read, no approval.
+  it('transfers ERC20 without reading an allowance or requesting an approval', async () => {
+    vi.mocked(readContract).mockResolvedValueOnce(OWNER_ADDRESS)
 
     const wrapper = createComponent()
-    await submitTransfer(wrapper)
+    await submitTransfer(wrapper, { to: '0xRecipient', amount: '1' })
 
     expect(approve.mutate).not.toHaveBeenCalled()
-    expect(transfer.mutate).toHaveBeenCalled()
-  })
-
-  it('approves then transfers when allowance is insufficient', async () => {
-    vi.mocked(readContract).mockResolvedValueOnce(OWNER_ADDRESS).mockResolvedValueOnce(0n)
-    approve.mutate.mockImplementationOnce((_v: unknown, opts?: MutationOpts) => {
-      opts?.onSuccess?.()
-    })
-
-    const wrapper = createComponent()
-    await submitTransfer(wrapper)
-
-    expect(approve.mutate).toHaveBeenCalled()
-    expect(transfer.mutate).toHaveBeenCalled()
-  })
-
-  it('shows approve error in the alert and skips the transfer', async () => {
-    vi.mocked(readContract).mockResolvedValueOnce(OWNER_ADDRESS).mockResolvedValueOnce(0n)
-    approve.mutate.mockImplementationOnce((_v: unknown, opts?: MutationOpts) => {
-      opts?.onError?.(new Error('approve failed'))
-    })
-
-    const wrapper = createComponent()
-    await submitTransfer(wrapper)
-
-    expect(transfer.mutate).not.toHaveBeenCalled()
-    expect(wrapper.text()).toContain('Failed to approve token spending')
+    // The only on-chain read is the owner lookup used to verify the signature.
+    expect(readContract).toHaveBeenCalledTimes(1)
+    expect(transfer.mutate).toHaveBeenCalledWith(
+      { args: ['0xRecipient', BigInt(1e6), expect.anything(), '0xSignature'] },
+      expect.anything()
+    )
   })
 
   it('shows transfer error in the alert', async () => {
-    vi.mocked(readContract)
-      .mockResolvedValueOnce(OWNER_ADDRESS)
-      .mockResolvedValueOnce(BigInt(200 * 1e6))
+    vi.mocked(readContract).mockResolvedValueOnce(OWNER_ADDRESS)
     transfer.mutate.mockImplementationOnce((_v: unknown, opts?: MutationOpts) => {
       opts?.onError?.(new Error('transfer failed'))
     })
@@ -154,9 +131,7 @@ describe('TransferAction.vue', () => {
   })
 
   it('closes the modal when the transfer mutation resolves', async () => {
-    vi.mocked(readContract)
-      .mockResolvedValueOnce(OWNER_ADDRESS)
-      .mockResolvedValueOnce(BigInt(200 * 1e6))
+    vi.mocked(readContract).mockResolvedValueOnce(OWNER_ADDRESS)
     transfer.mutate.mockImplementationOnce((_v: unknown, opts?: MutationOpts) =>
       opts?.onSuccess?.()
     )
@@ -177,16 +152,14 @@ describe('TransferAction.vue', () => {
     expect(wrapper.text()).toContain('insufficient funds')
   })
 
-  it('surfaces "Failed to read allowance" when readContract rejects', async () => {
-    vi.mocked(readContract)
-      .mockResolvedValueOnce(OWNER_ADDRESS)
-      .mockRejectedValueOnce(new Error('rpc error'))
+  it('surfaces a verification failure when the owner lookup rejects', async () => {
+    vi.mocked(readContract).mockRejectedValueOnce(new Error('rpc error'))
     const wrapper = createComponent()
     await submitTransfer(wrapper)
 
     expect(transfer.mutate).not.toHaveBeenCalled()
     expect(approve.mutate).not.toHaveBeenCalled()
-    expect(wrapper.text()).toContain('Failed to read allowance')
+    expect(wrapper.text()).toContain('Failed to verify expense approval signature')
   })
 
   it('blocks transfers when the approval was signed for another expense account', async () => {


### PR DESCRIPTION
# Description

## Intial Issue Description

Fixes #2436

Spending an ERC-20 expense asked the member for an ERC-20 approval that the contract never uses.

`transferErc20Token` read the member's allowance toward the ExpenseAccountEIP712 contract and, when it was below the transfer amount, fired `useERC20Approve` before calling `transfer`. That approval has no bearing on whether the transfer succeeds: `ExpenseAccountEIP712.transfer` pays out of the **contract's own** token balance — the ERC-20 branch checks `IERC20(token).balanceOf(address(this))` and calls `IERC20(token).transfer(to, amount)`. There is no `transferFrom(msg.sender, ...)` in that path, so the caller's allowance is irrelevant. The only `transferFrom` in the contract is in `depositToken`, a separate flow that genuinely needs one.

Cost to members: an extra wallet signature and gas on the first spend of each expense, plus a standing allowance granted to the expense contract over their *own* USDC — an approval they never needed to give.

## PR Summary Or Solution description

Frontend-only. The contract is correct as written and is untouched.

**`app/src/components/sections/ExpenseAccountView/TransferAction.vue`**

- `transferErc20Token` now goes straight to `submitExpenseAccountTransfer`. With the allowance read gone it has no `await` left, so it became a plain function and the call site dropped its `await`.
- Removed `approveMutation`, including out of the `TransferForm` `:loading` binding — `transferMutation.isPending` alone now drives it.
- Removed the imports that only served the allowance path: `useERC20Approve`, `erc20Abi`, `USDC_ADDRESS`, and `useUserDataStore`/`userDataStore` (its only use was supplying the owner argument to the allowance read).
- `useERC20Approve` itself stays. Four other components use it — `CreditLendModal`, `SafeDepositRouterForm`, `DepositSafeForm`, `DepositBankForm` — all deposit flows that do route through `transferFrom` and legitimately need an allowance.

**`app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts`**

- The two allowance-conditional tests collapsed into one. Sufficient vs. insufficient allowance is no longer a distinction the component can observe, so a single case asserts `approve.mutate` is never called, that `readContract` fires exactly **once** (the owner lookup for signature verification — a direct guard against an allowance read creeping back), and pins the exact args forwarded to `transfer`.
- `shows approve error in the alert and skips the transfer` is gone along with the branch it covered.
- One judgment call worth a reviewer's eye: `surfaces "Failed to read allowance" when readContract rejects` asserted a message that no longer exists, but it was also the only coverage of `readContract` rejecting. Rather than delete the case, I repointed it at the surviving rejection path — the owner lookup — asserting `Failed to verify expense approval signature`.

Net: 29 insertions, 90 deletions.

## Issues introduced and fixed (Optional)

None introduced. One thing explicitly **out of scope**: members who already spent an ERC-20 expense under the old flow have a leftover allowance sitting on the expense contract. This PR stops new ones being granted but does not revoke existing ones — that needs its own decision and change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features) — no doc surface describes this flow

## Verification

Run from `app/`:

- `CI=1 npx vitest run src/components/sections/ExpenseAccountView` — 6 files, 40 tests passing
- `CI=1 npx vitest run` (full suite) — 325 files, 2775 passed, 1 skipped (pre-existing)
- `CI=1 npm run build-only && npm run type-check` — both clean
- `npm run lint` — 0 errors (1 pre-existing warning in an untouched artifacts spec)
- `npm run format-check` — clean
