### PR TITLE
fix: 🐛 restore expense spend form and spendable balance

### DIFF
--- a/app/src/components/forms/TransferForm.vue
+++ b/app/src/components/forms/TransferForm.vue
@@ -206,7 +206,10 @@ const validationSchema = computed(() =>
         const amount = parseFloat(value)
         const bps = props.feeBps ?? 0
         const fee = bps > 0 ? (amount * bps) / (10000 - bps) : 0
-        return amount + fee <= (model.value.token.balance ?? 0)
+        // Same number `TokenAmount` shows as available: for an expense that is
+        // the remaining approved budget, which is lower than the raw holdings.
+        const available = model.value.token.spendableBalance ?? model.value.token.balance ?? 0
+        return amount + fee <= available
       }, 'Amount + fees exceed available balance')
   })
 )

--- a/app/src/components/sections/ExpenseAccountView/TransferAction.vue
+++ b/app/src/components/sections/ExpenseAccountView/TransferAction.vue
@@ -16,11 +16,7 @@
       v-model:open="showModal.show"
       data-test="transfer-modal"
       title="Transfer from Expenses Contract"
-      :description="
-        expenseBalance
-          ? `Spendable balance: ${tokens[0]?.spendableBalance ?? tokens[0]?.balance ?? 0} ${transferData.token.symbol}`
-          : undefined
-      "
+      :description="spendableBalanceLabel"
       :close="{
         onClick: () => {
           showModal = { mount: false, show: false }
@@ -36,8 +32,33 @@
           :description="errorMessage"
           class="mb-4"
         />
+        <div
+          v-if="bodyState === 'loading'"
+          class="flex items-center justify-center gap-2 py-6 text-sm text-gray-500"
+          data-test="balance-loading"
+        >
+          <UIcon name="i-lucide-loader-circle" class="animate-spin" />
+          <span>Loading contract balance…</span>
+        </div>
+
+        <UAlert
+          v-else-if="bodyState === 'error'"
+          color="error"
+          variant="soft"
+          description="Failed to read the Expenses Contract balance. Close this dialog and try again."
+          data-test="balance-error"
+        />
+
+        <UAlert
+          v-else-if="bodyState === 'unsupported'"
+          color="warning"
+          variant="soft"
+          description="This expense is denominated in a token that is not supported."
+          data-test="balance-unsupported"
+        />
+
         <TransferForm
-          v-if="showModal.mount && tokens.length > 0"
+          v-else
           v-model="transferData"
           :tokens="tokens"
           :loading="transferMutation.isPending.value || approveMutation.isPending.value"
@@ -100,9 +121,19 @@ const teamStore = useTeamStore()
 const userDataStore = useUserDataStore()
 const toast = useToast()
 const chainId = useChainId()
-const { data: balance } = useContractBalance(
-  ref(teamStore.getContractAddressByType('ExpenseAccountEIP712'))
+
+// A getter, not `ref(teamStore.getContractAddressByType(...))`: the address comes
+// from the team query, and this row can mount before that query resolves. A ref
+// would snapshot `undefined` and leave the balance query disabled forever.
+const expenseAccountEip712Address = computed(() =>
+  teamStore.getContractAddressByType('ExpenseAccountEIP712')
 )
+
+const {
+  data: balance,
+  isLoading: isBalanceLoading,
+  error: balanceError
+} = useContractBalance(expenseAccountEip712Address)
 const balances = computed(() => balance.value?.balances ?? [])
 const queryClient = useQueryClient()
 
@@ -123,19 +154,29 @@ const createDefaultTransferData = (): TransferData => ({
 })
 
 const transferData = ref(createDefaultTransferData())
-const expenseBalance = computed(() => {
-  const maxAmountData = props.row.data.amount
-  const amountTransferred = props.row.balances[1]
-  return maxAmountData && amountTransferred
-    ? Number(maxAmountData) - Number(amountTransferred)
-    : null
-})
-
-const expenseAccountEip712Address = computed(() =>
-  teamStore.getContractAddressByType('ExpenseAccountEIP712')
-)
 
 const tokens = computed(() => getTokens([props.row], props.row.signature, balances.value))
+const spendableToken = computed(() => tokens.value[0])
+
+/**
+ * What the modal body shows. `getTokens` yields nothing until the contract
+ * balance has been read, so an empty `tokens` is ambiguous on its own: the
+ * balance may still be in flight, the read may have failed, or the expense may
+ * be denominated in a token we do not support. Rendering the form only, with no
+ * `v-else`, turned all three into a blank modal.
+ */
+const bodyState = computed(() => {
+  if (spendableToken.value) return 'ready'
+  if (!expenseAccountEip712Address.value || isBalanceLoading.value) return 'loading'
+  if (balanceError.value) return 'error'
+  return 'unsupported'
+})
+
+const spendableBalanceLabel = computed(() => {
+  const token = spendableToken.value
+  if (!token) return undefined
+  return `Spendable balance: ${token.spendableBalance ?? token.balance} ${token.symbol}`
+})
 
 const transferMutation = useExpenseAccountTransfer()
 const approveMutation = useERC20Approve(computed(() => USDC_ADDRESS as Address))

--- a/app/src/components/sections/ExpenseAccountView/TransferAction.vue
+++ b/app/src/components/sections/ExpenseAccountView/TransferAction.vue
@@ -94,7 +94,7 @@ import { USDC_ADDRESS, type TokenId } from '@/constant'
 import type { BudgetLimit } from '@/types'
 import { useContractBalance } from '@/composables'
 import { useTeamStore, useUserDataStore } from '@/stores'
-import { classifyError, getTokens, log } from '@/utils'
+import { budgetLimitTypes, buildContractBudgetLimit, classifyError, getTokens, log } from '@/utils'
 import {
   encodeFunctionData,
   erc20Abi,
@@ -194,31 +194,6 @@ const transferFromExpenseAccount = async (to: string, amount: string) => {
     await transferErc20Token(to, amount, budgetLimit)
   }
 }
-
-const budgetLimitTypes = {
-  BudgetLimit: [
-    { name: 'amount', type: 'uint256' },
-    { name: 'frequencyType', type: 'uint8' },
-    { name: 'customFrequency', type: 'uint256' },
-    { name: 'startDate', type: 'uint256' },
-    { name: 'endDate', type: 'uint256' },
-    { name: 'tokenAddress', type: 'address' },
-    { name: 'approvedAddress', type: 'address' }
-  ]
-} as const
-
-const buildContractBudgetLimit = (budgetLimit: BudgetLimit) => ({
-  amount:
-    budgetLimit.tokenAddress === zeroAddress
-      ? parseEther(`${budgetLimit.amount}`)
-      : BigInt(Number(budgetLimit.amount) * 1e6),
-  frequencyType: Number(budgetLimit.frequencyType),
-  customFrequency: BigInt(Number(budgetLimit.customFrequency)),
-  startDate: BigInt(Number(budgetLimit.startDate)),
-  endDate: BigInt(Number(budgetLimit.endDate)),
-  tokenAddress: budgetLimit.tokenAddress,
-  approvedAddress: budgetLimit.approvedAddress
-})
 
 const verifyApprovalSignature = async (budgetLimit: BudgetLimit) => {
   const currentContract = expenseAccountEip712Address.value

--- a/app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts
@@ -34,7 +34,7 @@ const contractBalanceState = {
   isLoading: ref(false),
   error: ref<Error | null>(null)
 }
-const useContractBalanceSpy = vi.fn((_address: unknown) => contractBalanceState)
+const useContractBalanceSpy = vi.fn(() => contractBalanceState)
 
 vi.mock('@/composables', () => ({
   useContractBalance: (address: unknown) => useContractBalanceSpy(address)

--- a/app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts
@@ -1,22 +1,43 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
-import { ref } from 'vue'
+import { nextTick, ref, toValue } from 'vue'
 import { readContract, estimateGas } from '@wagmi/core'
 import { recoverTypedDataAddress } from 'viem'
 import TransferAction from '../TransferAction.vue'
-import { mockExpenseAccountWrites, mockERC20Writes } from '@/tests/mocks'
+import { mockExpenseAccountWrites, mockERC20Writes, mockTeamStore } from '@/tests/mocks'
+
+// Hoisted so the module factory below can read it, and mutable so a test can
+// model the window where the contract balance has not been read yet and
+// `getTokens` therefore yields nothing.
+const { mockTokens } = vi.hoisted(() => ({
+  mockTokens: { value: [] as unknown[] }
+}))
+const DEFAULT_TOKENS = [{ symbol: 'USDC', balance: 100, spendableBalance: 100 }]
 
 // `classifyError` is left un-mocked so these tests assert the message the user
 // actually sees, rather than a stand-in string.
 vi.mock('@/utils', async (importOriginal) => ({
   ...(await importOriginal<object>()),
   log: { error: vi.fn() },
-  getTokens: vi.fn(() => [{ symbol: 'USDC', balance: 100, spendableBalance: 100 }])
+  getTokens: vi.fn(() => mockTokens.value)
 }))
 
+// Kept as a spy so a test can assert *what* the balance query was keyed on:
+// the address arrives with the team query, so the argument has to stay a live
+// source rather than a value read once during setup.
+const contractBalanceState = {
+  data: ref<{ balances: unknown[]; total: undefined } | undefined>({
+    balances: [],
+    total: undefined
+  }),
+  isLoading: ref(false),
+  error: ref<Error | null>(null)
+}
+const useContractBalanceSpy = vi.fn((_address: unknown) => contractBalanceState)
+
 vi.mock('@/composables', () => ({
-  useContractBalance: () => ({ data: ref({ balances: [], total: undefined }) })
+  useContractBalance: (address: unknown) => useContractBalanceSpy(address)
 }))
 
 vi.mock('@wagmi/core', () => ({
@@ -88,8 +109,80 @@ describe('TransferAction.vue', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    mockTokens.value = DEFAULT_TOKENS
+    contractBalanceState.isLoading.value = false
+    contractBalanceState.error.value = null
     vi.mocked(estimateGas).mockResolvedValue(21000n)
     vi.mocked(recoverTypedDataAddress).mockResolvedValue(OWNER_ADDRESS)
+  })
+
+  describe('contract balance', () => {
+    const openModal = async (wrapper: VueWrapper) => {
+      await wrapper.find('[data-test="transfer-button"]').trigger('click')
+      await flushPromises()
+    }
+
+    it('keys the balance query on a live address, not one read at setup', async () => {
+      // The address comes from the team query, which routinely resolves after
+      // this row has mounted. Passing `ref(store.getContractAddressByType(...))`
+      // froze `undefined` in place, leaving the query disabled forever: no
+      // balance, a spendable balance of 0, and no transfer form. The ref here
+      // stands in for the query data the real store reads.
+      const teamAddress = ref<string | undefined>(undefined)
+      mockTeamStore.getContractAddressByType = vi.fn(() => teamAddress.value)
+      createComponent()
+
+      const [addressSource] = useContractBalanceSpy.mock.calls[0]!
+      expect(toValue(addressSource)).toBeUndefined()
+
+      teamAddress.value = CURRENT_EXPENSE_ACCOUNT
+      await nextTick()
+
+      expect(toValue(addressSource)).toBe(CURRENT_EXPENSE_ACCOUNT)
+    })
+
+    it('explains itself while the balance is still loading', async () => {
+      mockTokens.value = []
+      contractBalanceState.isLoading.value = true
+
+      const wrapper = createComponent()
+      await openModal(wrapper)
+
+      expect(wrapper.find('[data-test="balance-loading"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="transfer-form"]').exists()).toBe(false)
+    })
+
+    it('reports a failed balance read instead of an empty dialog', async () => {
+      mockTokens.value = []
+      contractBalanceState.error.value = new Error('rpc down')
+
+      const wrapper = createComponent()
+      await openModal(wrapper)
+
+      expect(wrapper.find('[data-test="balance-error"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="transfer-form"]').exists()).toBe(false)
+    })
+
+    it('labels the spendable balance with the expense token symbol', async () => {
+      // The symbol used to come from the empty form model, so the dialog opened
+      // on a bare, unitless number.
+      const wrapper = createComponent()
+      await openModal(wrapper)
+
+      expect(wrapper.findComponent({ name: 'UModal' }).props('description')).toBe(
+        'Spendable balance: 100 USDC'
+      )
+    })
+
+    it('omits the balance label entirely when there is no token to describe', async () => {
+      mockTokens.value = []
+      contractBalanceState.isLoading.value = true
+
+      const wrapper = createComponent()
+      await openModal(wrapper)
+
+      expect(wrapper.findComponent({ name: 'UModal' }).props('description')).toBeUndefined()
+    })
   })
 
   it('invokes transfer when ERC20 allowance is sufficient', async () => {

--- a/app/src/utils/__tests__/expenseUtil.spec.ts
+++ b/app/src/utils/__tests__/expenseUtil.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { getTokens } from '../expenseUtil'
+import { SUPPORTED_TOKENS, USDC_ADDRESS } from '@/constant'
+import type { TokenBalance } from '@/types'
+import type { TableRow } from '@/types/table'
+
+const usdcConfig = SUPPORTED_TOKENS.find((token) => token.id === 'usdc')!
+
+const money = (value: number) => ({ value, formatted: `${value}` })
+const pair = (value: number) => ({ usd: money(value), local: money(value) })
+
+/** Contract holdings as `useContractBalance` exposes them. */
+const heldUsdc = (amount: number): TokenBalance => ({
+  token: usdcConfig,
+  raw: BigInt(Math.round(amount * 1e6)),
+  amount,
+  price: pair(1),
+  value: pair(amount)
+})
+
+/**
+ * An expense row as the backend serialises it: `balances[1]` is the amount
+ * already transferred in the current period, `data.amount` the approved budget.
+ */
+const expenseRow = (overrides: Partial<TableRow> = {}): TableRow => ({
+  signature: '0xSignature',
+  status: 'enabled',
+  data: { amount: 2, tokenAddress: USDC_ADDRESS },
+  balances: { 0: '1700000000', 1: '0' },
+  ...overrides
+})
+
+describe('getTokens', () => {
+  const spendableOf = (row: TableRow, balances: TokenBalance[]) =>
+    getTokens([row], row.signature, balances)[0]?.spendableBalance
+
+  it('treats a never-spent expense as fully spendable', () => {
+    // Regression: 0 transferred is the normal state of a fresh approval. Read
+    // as falsy it collapsed the whole budget to 0 and left nothing to spend.
+    expect(spendableOf(expenseRow(), [heldUsdc(10)])).toBe(2)
+  })
+
+  it('treats a numeric 0 transferred the same as the string the API returns', () => {
+    expect(spendableOf(expenseRow({ balances: { 0: '0', 1: 0 } }), [heldUsdc(10)])).toBe(2)
+  })
+
+  it('subtracts what has already been spent this period', () => {
+    expect(spendableOf(expenseRow({ balances: { 0: '0', 1: '1.5' } }), [heldUsdc(10)])).toBe(0.5)
+  })
+
+  it('caps the spendable amount at what the contract actually holds', () => {
+    // An ERC-20 transfer pays out of the contract's own balance, so an approved
+    // budget the contract cannot cover is not spendable.
+    expect(spendableOf(expenseRow(), [heldUsdc(0.5)])).toBe(0.5)
+  })
+
+  it('never reports a negative balance once the budget is exhausted', () => {
+    expect(spendableOf(expenseRow({ balances: { 0: '0', 1: '3' } }), [heldUsdc(10)])).toBe(0)
+  })
+
+  it('survives a row the backend returned without balances', () => {
+    // `syncExpenseStatus` short-circuits expired rows and passes through
+    // `data.balances`, which `updateExpense` never persists.
+    expect(spendableOf(expenseRow({ balances: undefined }), [heldUsdc(10)])).toBe(2)
+  })
+
+  it('reports no token until the contract balance has been read', () => {
+    // The empty result is what `TransferAction` reads as "still loading" — it
+    // must stay distinguishable from a real zero balance.
+    expect(getTokens([expenseRow()], '0xSignature', [])).toEqual([])
+  })
+
+  it('exposes the balance and symbol alongside the spendable amount', () => {
+    const [token] = getTokens([expenseRow()], '0xSignature', [heldUsdc(10)])
+
+    expect(token).toMatchObject({ symbol: 'USDC', balance: 10, spendableBalance: 2 })
+  })
+})

--- a/app/src/utils/expenseUtil.ts
+++ b/app/src/utils/expenseUtil.ts
@@ -67,18 +67,27 @@ const findToken = (tokenId: TokenId, balances: TokenBalance[]) => {
 }
 
 /**
- * Calculate remaining spendable balance for an expense
+ * Calculate remaining spendable balance for an expense.
+ *
+ * The cap is whichever runs out first: the budget the owner approved, or what
+ * the contract actually holds — an ERC-20 transfer pays from the contract's own
+ * balance, so a funded budget on an empty contract is not spendable.
+ *
  * @param expense The expense row data
- * @returns The remaining balance that can be spent, or null if no budget data found
+ * @param contractBalance Contract holdings of the expense's token
+ * @returns The remaining balance that can be spent, never negative
  */
 const getRemainingExpenseBalance = (expense: TableRow, contractBalance: number): number => {
-  const maxAmountData = expense.data.amount // budgetData.find((item) => item.budgetType === 1)?.value
-  const amountTransferred = expense.balances[1]
+  // Both are 0 on a never-used expense, and `balances` is absent on rows the
+  // backend short-circuits. Truthiness checks here read those as "no budget"
+  // and collapse the whole approval to 0 — coerce instead.
+  const maxAmount = Number(expense.data?.amount ?? 0)
+  const amountTransferred = Number(expense.balances?.[1] ?? 0)
 
-  // Calculate remaining spendable amount
   const remainingBudget =
-    maxAmountData && amountTransferred ? Number(maxAmountData) - Number(amountTransferred) : 0
+    Number.isFinite(maxAmount) && Number.isFinite(amountTransferred)
+      ? Math.max(maxAmount - amountTransferred, 0)
+      : 0
 
-  // Return the minimum between contract balance and remaining budget
   return Math.min(contractBalance, remainingBudget)
 }

--- a/app/src/utils/expenseUtil.ts
+++ b/app/src/utils/expenseUtil.ts
@@ -1,8 +1,39 @@
-import type { ExpenseResponse, TokenBalance, TokenOption } from '@/types'
+import type { BudgetLimit, ExpenseResponse, TokenBalance, TokenOption } from '@/types'
 import { tokenSymbol } from './constantUtil'
-import { zeroAddress } from 'viem'
+import { parseEther, zeroAddress } from 'viem'
 import type { TokenId } from '@/constant'
 import type { TableRow } from '@/types/table'
+
+/**
+ * EIP-712 struct definition of a budget limit. Must stay byte-for-byte in step
+ * with `BudgetLimit` in `ExpenseAccountEIP712.sol` — the field order is part of
+ * the type hash, so reordering here silently breaks signature recovery.
+ */
+export const budgetLimitTypes = {
+  BudgetLimit: [
+    { name: 'amount', type: 'uint256' },
+    { name: 'frequencyType', type: 'uint8' },
+    { name: 'customFrequency', type: 'uint256' },
+    { name: 'startDate', type: 'uint256' },
+    { name: 'endDate', type: 'uint256' },
+    { name: 'tokenAddress', type: 'address' },
+    { name: 'approvedAddress', type: 'address' }
+  ]
+} as const
+
+/** A budget limit in the units the contract expects: wei for native, 6-decimal for ERC-20. */
+export const buildContractBudgetLimit = (budgetLimit: BudgetLimit) => ({
+  amount:
+    budgetLimit.tokenAddress === zeroAddress
+      ? parseEther(`${budgetLimit.amount}`)
+      : BigInt(Number(budgetLimit.amount) * 1e6),
+  frequencyType: Number(budgetLimit.frequencyType),
+  customFrequency: BigInt(Number(budgetLimit.customFrequency)),
+  startDate: BigInt(Number(budgetLimit.startDate)),
+  endDate: BigInt(Number(budgetLimit.endDate)),
+  tokenAddress: budgetLimit.tokenAddress,
+  approvedAddress: budgetLimit.approvedAddress
+})
 
 // Frequency types mapping
 export const frequencyTypes = [


### PR DESCRIPTION
# Description

## Intial Issue Description

Fixes #2435

Opening **Spend** on an approved expense sometimes showed `Spendable balance: 0` — with no unit — over an entirely empty dialog: no recipient field, no amount field, no submit button, so the expense could not be spent. It was intermittent, and a reload could flip it either way on the same expense.

## Issues introduced and fixed (Optional)

Both symptoms had one cause. `TransferAction.vue` keyed its contract-balance query on `ref(teamStore.getContractAddressByType('ExpenseAccountEIP712'))`. `ref(...)` snapshots the value during setup, but that address arrives with the team query. `MyApprovedExpenseSection` renders unguarded — unlike its siblings on the same page, which all sit behind `v-if="expenseContractAddress"` — so any row mounting before the team query resolved froze `undefined` and left the balance query disabled for good (`enabled: !!contractAddress`).

With no balance, `getTokens` returned an empty list, and that single fact drove both symptoms: the dialog description fell back to `?? 0` and took its unit from the still-empty form model, while the form itself sat behind `v-if="tokens.length > 0"` with no `v-else`.

Three further defects surfaced along the way and are fixed here:

- `getRemainingExpenseBalance` gated the budget behind a truthiness check on the transferred amount, so a numeric `0` — the normal state of an approval nobody has spent — collapsed the whole budget to 0. It survives today only because the API happens to serialise it as the string `'0'`.
- The same function indexed `balances` unconditionally, which throws on rows `syncExpenseStatus` short-circuits: `updateExpense` accepts a status of `expired` and writes it without persisting the balances the pass-through then reads.
- `TransferForm` validated the amount against the raw token balance while `TokenAmount` displayed `spendableBalance` as what was available — so a member could submit more than the approved budget and only find out when the contract reverted.

Two adjacent problems were deliberately left out of scope and are tracked separately: the ERC-20 approval in `transferErc20Token` is never used by the contract (it pays from its own balance via `IERC20.transfer`), and the two expense tables still index `row.balances[1]` unguarded.

## PR Summary Or Solution description

- Key the balance query on a getter so it enables when the address lands, and re-keys on a team switch.
- Give the dialog body the states it never had: loading, failed balance read, and unsupported token, each previously rendering as a blank modal.
- Label the spendable balance with the expense's own token symbol instead of the empty form model's.
- Coerce both operands in `getRemainingExpenseBalance`, clamp the result at 0, and read `balances` defensively.
- Validate transfer amounts against the spendable balance. Other `TransferForm` callers leave `spendableBalance` unset and keep falling back to the balance, so their behaviour is unchanged.
- Move `budgetLimitTypes` and `buildContractBudgetLimit` into `expenseUtil` — pure translations with no tie to the component, which had also grown past the 300-line lint cap.

Each fix is pinned by a test verified to fail against the previous code: the `ref()` regression (1 test) and the balance-math cases (3 tests). `getTokens` had no coverage at all before; it now has its own spec.

## Contribution

Reviewer notes, per file:

- `app/src/components/sections/ExpenseAccountView/TransferAction.vue` — root-cause fix plus the three empty-state branches. Worth checking that `bodyState` reads the way you'd expect: `!address || isLoading` covers the disabled-query window, since a disabled TanStack query reports `isLoading === false`.
- `app/src/utils/expenseUtil.ts` — hardened balance math, and the EIP-712 helpers moved in. `budgetLimitTypes` field order is part of the type hash; it must stay in step with `ExpenseAccountEIP712.sol`.
- `app/src/components/forms/TransferForm.vue` — one-line validation change, shared by the Safe and Bank transfer flows.
- `app/src/utils/__tests__/expenseUtil.spec.ts` — new.
- `app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts` — `useContractBalance` is now a spy so a test can assert *what* the query was keyed on, and the token list is mutable so a test can model the not-yet-loaded window.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Contribution checklist

`app/` gate run green: `build` · `test:unit` (2790 passed) · `type-check` · `lint` · `format`. No other subproject touched.
