### PR TITLE
fix: 🐛 correct address display logic in UserComponent

### DIFF
--- a/app/src/components/UserComponent.vue
+++ b/app/src/components/UserComponent.vue
@@ -84,10 +84,10 @@
       </span>
       <p
         class="mt-1.5 max-w-full text-gray-400"
-        :class="isDetailedView ? 'font-mono text-xs break-all' : 'text-sm'"
+        :class="isDetailedView ? 'font-mono text-sm' : 'text-sm'"
         data-test="formatted-address"
       >
-        {{ isDetailedView ? user.address : formatedUserAddress }}
+        {{ formatedUserAddress }}
       </p>
     </div>
   </div>


### PR DESCRIPTION
# Description

## Initial issue

Show the wallet address in the shortened format (e.g. 0x098C…9DFB) on the detailed user card, matching the candidate cards and the rest of the app.

Closes #2442





## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (visual-only change)
- [ ] Docs have been added / updated