### PR TITLE
fix: 🐛 use SafeERC20 for production token transfers

### DIFF
--- a/.github/workflows/contract-code-quality.yml
+++ b/.github/workflows/contract-code-quality.yml
@@ -47,6 +47,19 @@ jobs:
           fi
         working-directory: ./contract
 
+      - name: 🚫 Guard against raw ERC20 transfers in production contracts
+        run: |
+          matches=$(grep -rnE '\.(transfer|transferFrom)\(' contracts \
+            --include="*.sol" \
+            --exclude-dir=mocks \
+            --exclude-dir=test || true)
+          if [ -n "$matches" ]; then
+            echo "::error::Use SafeERC20 safeTransfer or safeTransferFrom in production contracts"
+            echo "$matches"
+            exit 1
+          fi
+        working-directory: ./contract
+
       - name: </> Run Solidity Linter
         run: npm run lint:sol
         working-directory: ./contract

--- a/app/src/artifacts/abi/generated.ts
+++ b/app/src/artifacts/abi/generated.ts
@@ -1247,11 +1247,6 @@ export const cashRemunerationEip712Abi = [
   },
   {
     type: 'error',
-    inputs: [{ name: 'token', internalType: 'address', type: 'address' }],
-    name: 'CashRemunerationEIP712__TokenTransferFailed'
-  },
-  {
-    type: 'error',
     inputs: [
       { name: 'expected', internalType: 'address', type: 'address' },
       { name: 'received', internalType: 'address', type: 'address' }
@@ -1299,6 +1294,11 @@ export const cashRemunerationEip712Abi = [
     name: 'OwnableUnauthorizedAccount'
   },
   { type: 'error', inputs: [], name: 'ReentrancyGuardReentrantCall' },
+  {
+    type: 'error',
+    inputs: [{ name: 'token', internalType: 'address', type: 'address' }],
+    name: 'SafeERC20FailedOperation'
+  },
   {
     type: 'error',
     inputs: [{ name: 'token', internalType: 'address', type: 'address' }],
@@ -2235,11 +2235,6 @@ export const expenseAccountEip712Abi = [
   },
   {
     type: 'error',
-    inputs: [{ name: 'token', internalType: 'address', type: 'address' }],
-    name: 'ExpenseAccountEIP712__TokenTransferFailed'
-  },
-  {
-    type: 'error',
     inputs: [],
     name: 'ExpenseAccountEIP712__TransferNotAllowed'
   },
@@ -2275,6 +2270,11 @@ export const expenseAccountEip712Abi = [
     name: 'OwnableUnauthorizedAccount'
   },
   { type: 'error', inputs: [], name: 'ReentrancyGuardReentrantCall' },
+  {
+    type: 'error',
+    inputs: [{ name: 'token', internalType: 'address', type: 'address' }],
+    name: 'SafeERC20FailedOperation'
+  },
   {
     type: 'error',
     inputs: [{ name: 'token', internalType: 'address', type: 'address' }],

--- a/contract/CHANGELOG.md
+++ b/contract/CHANGELOG.md
@@ -43,6 +43,7 @@ Each entry should answer:
 ## CashRemunerationEIP712
 
 ### CashRemunerationEIP712 2.0.1 — unreleased
+
 - What: use SafeERC20 for salary payouts and treasury token withdrawals.
 - Storage: none.
 - Shipped via: pending upgrade in place.
@@ -53,6 +54,7 @@ Each entry should answer:
 ## ExpenseAccountEIP712
 
 ### ExpenseAccountEIP712 2.0.1 — unreleased
+
 - What: use SafeERC20 for expense payouts, deposits, and treasury token withdrawals.
 - Storage: none.
 - Shipped via: pending upgrade in place.

--- a/contract/CHANGELOG.md
+++ b/contract/CHANGELOG.md
@@ -42,9 +42,21 @@ Each entry should answer:
 
 ## CashRemunerationEIP712
 
+### CashRemunerationEIP712 2.0.1 — unreleased
+- What: use SafeERC20 for salary payouts and treasury token withdrawals.
+- Storage: none.
+- Shipped via: pending upgrade in place.
+- Networks: not deployed.
+
 <!-- Add entries above this line, newest first -->
 
 ## ExpenseAccountEIP712
+
+### ExpenseAccountEIP712 2.0.1 — unreleased
+- What: use SafeERC20 for expense payouts, deposits, and treasury token withdrawals.
+- Storage: none.
+- Shipped via: pending upgrade in place.
+- Networks: not deployed.
 
 <!-- Add entries above this line, newest first -->
 

--- a/contract/contracts/CashRemunerationEIP712.sol
+++ b/contract/contracts/CashRemunerationEIP712.sol
@@ -5,6 +5,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
@@ -28,6 +29,7 @@ contract CashRemunerationEIP712 is
   using Address for address payable;
   using ECDSA for bytes32;
   using DateTime for uint256;
+  using SafeERC20 for IERC20;
 
   /**
    * @dev Represents a wage in a specific token.
@@ -185,10 +187,6 @@ contract CashRemunerationEIP712 is
   /// @dev The Bank contract could not be located via the Officer.
   error CashRemunerationEIP712__BankContractNotFound();
 
-  /// @dev A raw ERC20 transfer returned false.
-  /// @param token The token whose `transfer` returned false.
-  error CashRemunerationEIP712__TokenTransferFailed(address token);
-
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor() {
     _disableInitializers();
@@ -321,7 +319,7 @@ contract CashRemunerationEIP712 is
             );
 
           // Transfer tokens from contract to employee
-          IERC20(wage.tokenAddress).transfer(employee, amountToPay);
+          IERC20(wage.tokenAddress).safeTransfer(employee, amountToPay);
 
           // Emit event for token withdrawal (transfer)
           emit WithdrawToken(employee, wage.tokenAddress, amountToPay);
@@ -403,8 +401,7 @@ contract CashRemunerationEIP712 is
     for (uint256 i = 0; i < length; ++i) {
       uint256 tokenBalance = IERC20(tokens[i]).balanceOf(address(this));
       if (tokenBalance > 0) {
-        if (!IERC20(tokens[i]).transfer(bankAddress, tokenBalance))
-          revert CashRemunerationEIP712__TokenTransferFailed(tokens[i]);
+        IERC20(tokens[i]).safeTransfer(bankAddress, tokenBalance);
         emit OwnerTreasuryWithdrawToken(ownerAddress, tokens[i], tokenBalance);
       }
     }
@@ -466,7 +463,7 @@ contract CashRemunerationEIP712 is
 
   /// @notice Current contract version, per semver.
   function version() public pure returns (string memory) {
-    return "2.0.0";
+    return "2.0.1";
   }
 
   /**

--- a/contract/contracts/expense-account/ExpenseAccountEIP712.sol
+++ b/contract/contracts/expense-account/ExpenseAccountEIP712.sol
@@ -5,6 +5,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
@@ -28,6 +29,7 @@ contract ExpenseAccountEIP712 is
   using Address for address payable;
   using ECDSA for bytes32;
   using DateTime for uint256;
+  using SafeERC20 for IERC20;
 
   /// @dev Frequency type controlling how the budget limit is applied.
   enum FrequencyType {
@@ -221,9 +223,6 @@ contract ExpenseAccountEIP712 is
     uint256 required,
     uint256 available
   );
-  /// @dev A raw ERC20 transfer returned false.
-  /// @param token The token whose transfer returned false.
-  error ExpenseAccountEIP712__TokenTransferFailed(address token);
   /// @dev The transfer amount exceeds the single-withdrawal budget limit.
   error ExpenseAccountEIP712__AmountExceedsBudgetLimit();
   /// @dev A one-time budget has already been used.
@@ -303,8 +302,7 @@ contract ExpenseAccountEIP712 is
           amount,
           tokenBal
         );
-      if (!IERC20(budgetLimit.tokenAddress).transfer(to, amount))
-        revert ExpenseAccountEIP712__TokenTransferFailed(budgetLimit.tokenAddress);
+      IERC20(budgetLimit.tokenAddress).safeTransfer(to, amount);
       emit TokenTransfer(budgetLimit.approvedAddress, to, budgetLimit.tokenAddress, amount);
     }
   }
@@ -370,8 +368,7 @@ contract ExpenseAccountEIP712 is
     for (uint256 i = 0; i < length; ++i) {
       uint256 tokenBalance = IERC20(tokens[i]).balanceOf(address(this));
       if (tokenBalance > 0) {
-        if (!IERC20(tokens[i]).transfer(bankAddress, tokenBalance))
-          revert ExpenseAccountEIP712__TokenTransferFailed(tokens[i]);
+        IERC20(tokens[i]).safeTransfer(bankAddress, tokenBalance);
         emit OwnerTreasuryWithdrawToken(ownerAddress, tokens[i], tokenBalance);
       }
     }
@@ -393,8 +390,7 @@ contract ExpenseAccountEIP712 is
       revert ExpenseAccountEIP712__TokenNotSupported(token);
     if (amount == 0) revert ExpenseAccountEIP712__ZeroAmount();
 
-    if (!IERC20(token).transferFrom(msg.sender, address(this), amount))
-      revert ExpenseAccountEIP712__TokenTransferFailed(token);
+    IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
     emit TokenDeposited(msg.sender, token, amount);
   }
 
@@ -577,7 +573,7 @@ contract ExpenseAccountEIP712 is
 
   /// @notice Current contract version, per semver.
   function version() public pure returns (string memory) {
-    return "2.0.0";
+    return "2.0.1";
   }
 
   /**

--- a/contract/contracts/test/MockNoReturnERC20.sol
+++ b/contract/contracts/test/MockNoReturnERC20.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract MockNoReturnERC20 {
+  mapping(address account => uint256 balance) private s_balances;
+  mapping(address owner => mapping(address spender => uint256 allowance)) private s_allowances;
+
+  function mint(address account, uint256 amount) external {
+    s_balances[account] += amount;
+  }
+
+  function balanceOf(address account) external view returns (uint256) {
+    return s_balances[account];
+  }
+
+  function approve(address spender, uint256 amount) external returns (bool) {
+    s_allowances[msg.sender][spender] = amount;
+    return true;
+  }
+
+  function transfer(address to, uint256 amount) external {
+    _transfer(msg.sender, to, amount);
+  }
+
+  function transferFrom(address from, address to, uint256 amount) external {
+    uint256 allowance = s_allowances[from][msg.sender];
+    require(allowance >= amount, "insufficient allowance");
+    s_allowances[from][msg.sender] = allowance - amount;
+    _transfer(from, to, amount);
+  }
+
+  function _transfer(address from, address to, uint256 amount) private {
+    uint256 balance = s_balances[from];
+    require(balance >= amount, "insufficient balance");
+    s_balances[from] = balance - amount;
+    s_balances[to] += amount;
+  }
+}

--- a/contract/test/CashRemunerationEIP712.spec.ts
+++ b/contract/test/CashRemunerationEIP712.spec.ts
@@ -183,6 +183,28 @@ describe('CashRemuneration*** (EIP712)', () => {
         expect(paidWageClaim).to.be.equal(true)
       })
 
+      it('Then I can pay a token that does not return a boolean', async () => {
+        const NoReturnToken = await ethers.getContractFactory('MockNoReturnERC20')
+        const noReturnToken = await NoReturnToken.deploy()
+        const tokenAddress = await noReturnToken.getAddress()
+        const amount = 20n
+
+        await cashRemunerationProxy.addTokenSupport(tokenAddress)
+        await noReturnToken.mint(await cashRemunerationProxy.getAddress(), amount)
+
+        const wageClaim = {
+          employeeAddress: employee.address,
+          minutesWorked: 60,
+          wages: [{ hourlyRate: amount, tokenAddress }],
+          date: Math.floor(Date.now() / 1000)
+        }
+        const signature = await employer.signTypedData(domain, types, wageClaim)
+
+        await cashRemunerationProxy.connect(employee).withdraw(wageClaim, signature)
+
+        expect(await noReturnToken.balanceOf(employee.address)).to.equal(amount)
+      })
+
       describe("Then a user can't transfer if;", () => {
         it('the signer is not the contract employer', async () => {
           const wageClaim = {

--- a/contract/test/ExpenseAccountEIP712.spec.ts
+++ b/contract/test/ExpenseAccountEIP712.spec.ts
@@ -194,6 +194,21 @@ describe('ExpenseAccount (EIP712) - Administrative Tests', () => {
       expect(await expenseAccount.getTokenBalance(await mockUSDT.getAddress())).to.equal(amount)
     })
 
+    it('Should allow deposits from tokens that do not return a boolean', async () => {
+      const NoReturnToken = await ethers.getContractFactory('MockNoReturnERC20')
+      const noReturnToken = await NoReturnToken.deploy()
+      const tokenAddress = await noReturnToken.getAddress()
+      const amount = ethers.parseEther('100')
+
+      await expenseAccount.addTokenSupport(tokenAddress)
+      await noReturnToken.mint(owner.address, amount)
+      await noReturnToken.connect(owner).approve(await expenseAccount.getAddress(), amount)
+
+      await expenseAccount.connect(owner).depositToken(tokenAddress, amount)
+
+      expect(await noReturnToken.balanceOf(await expenseAccount.getAddress())).to.equal(amount)
+    })
+
     it('Should allow owner to add and remove token support', async () => {
       const MockToken = await ethers.getContractFactory('MockERC20')
       const newToken = await MockToken.deploy('NEW', 'NEW')

--- a/contract/test/ExpenseAccountEIP712V2.spec.ts
+++ b/contract/test/ExpenseAccountEIP712V2.spec.ts
@@ -319,6 +319,32 @@ describe('ExpenseAccountEIP712V2', function () {
           .transfer(recipient.address, ethers.parseEther('150'), budgetLimit, signature)
       ).to.emit(expenseAccount, 'TokenTransfer')
     })
+
+    it('Should transfer tokens that do not return a boolean', async function () {
+      const { expenseAccount, owner, approvedAddress, recipient } = await loadFixture(
+        deployExpenseAccountFixture
+      )
+      const NoReturnToken = await ethers.getContractFactory('MockNoReturnERC20')
+      const noReturnToken = await NoReturnToken.deploy()
+      const tokenAddress = await noReturnToken.getAddress()
+      const amount = ethers.parseEther('100')
+
+      await expenseAccount.addTokenSupport(tokenAddress)
+      await noReturnToken.mint(await expenseAccount.getAddress(), amount)
+
+      const budgetLimit = createBudgetLimit({
+        amount,
+        tokenAddress,
+        approvedAddress: approvedAddress.address
+      })
+      const signature = await createSignature(owner, budgetLimit, expenseAccount)
+
+      await expenseAccount
+        .connect(approvedAddress)
+        .transfer(recipient.address, amount, budgetLimit, signature)
+
+      expect(await noReturnToken.balanceOf(recipient.address)).to.equal(amount)
+    })
   })
 
   describe('Validation', function () {


### PR DESCRIPTION
## Summary

- Replace raw ERC20 transfers with `SafeERC20` operations in remuneration and expense contracts.
- Add CI protection against raw production ERC20 transfers.
- Add coverage for tokens that omit boolean return values.
- Bump both contract versions to `2.0.1` and regenerate ABIs.

## Testing

- Added contract tests covering safe payouts, deposits, and transfers with no-return ERC20 tokens.
- CI now rejects raw `transfer` and `transferFrom` calls in production contracts.