### PR TITLE
docs: 📝 clarify global CNC fee accounting

### DIFF
--- a/docs/features/accounting/README.md
+++ b/docs/features/accounting/README.md
@@ -4,15 +4,15 @@ Treat the CNC as a **company** and keep its books: general ledger, income statem
 
 This folder catalogues **every way money moves** across the CNC contracts, maps each one to a journal entry, and runs a **full worked example** end to end so the numbers can be trusted.
 
-| Document | What's inside |
-|----------|---------------|
+| Document                                             | What's inside                                                                                                                                                                                                                                      |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [money-flow-catalogue.md](./money-flow-catalogue.md) | Glossary · the CNC entity · contracts that move money · every monetary interaction · use-case → journal-entry mapping · chart of accounts · a full worked example (general ledger → T-accounts → trial balance → income statement → balance sheet) |
-| [cnc-accounting-spec.md](./cnc-accounting-spec.md) | Phase 1 scope & spec · reusing the Sprint 15 pipeline · inventory of the on-chain + portal data we already have · source → statement-line mapping · how fees and expenses (Ponder/payroll/debt) are booked · the gaps to close in phase 2 |
+| [cnc-accounting-spec.md](./cnc-accounting-spec.md)   | Phase 1 scope & spec · reusing the Sprint 15 pipeline · inventory of the on-chain + portal data we already have · source → statement-line mapping · how fees and expenses (Ponder/payroll/debt) are booked · the gaps to close in phase 2          |
 
 **Tracking:** [#1887](https://github.com/globe-and-citizen/cnc-portal/issues/1887) (goal) · [#2078](https://github.com/globe-and-citizen/cnc-portal/issues/2078) (sprint plan) · [#2126](https://github.com/globe-and-citizen/cnc-portal/issues/2126) (catalogue) · [#1890](https://github.com/globe-and-citizen/cnc-portal/issues/1890) (this spec).
 
 ### At a glance
 
 - **Contracts in scope:** Bank, FeeCollector, CashRemunerationEIP712, ExpenseAccountEIP712, InvestorV1, SafeDepositRouter — the contracts the CNC actually uses.
-- **Key rules:** payroll is **accrual** (via a `Wage Payable` liability); expenses are **cash basis**; investing returns **SHER shares** booked to `Investor Equity`; a direct mint with nothing behind it is **memo only** (tracked in shares, not value); fees between Bank and FeeCollector are **internal** moves.
+- **Key rules:** payroll is **accrual** (via a `Wage Payable` liability); expenses are **cash basis**; investing returns **SHER shares** booked to `Investor Equity`; a direct mint with nothing behind it is **memo only** (tracked in shares, not value); each team books CNC usage fees as an expense, while the global FeeCollector books the same payments as protocol-fee revenue.
 - **The books balance at every level:** journal, trial balance, and `Assets = Liabilities + Equity`.

--- a/docs/features/accounting/cnc-accounting-spec.md
+++ b/docs/features/accounting/cnc-accounting-spec.md
@@ -3,7 +3,8 @@
 This document defines the **scope** and **spec** for CNC accounting: treating the CNC as a
 company and producing its financial statements (general ledger → income statement →
 balance sheet) from data **already available** on-chain and in the portal, reusing the
-Sprint 15 pipeline.
+Sprint 15 pipeline. The shared `FeeCollector` is the CNC protocol's global treasury:
+each team pays a usage fee into it when using CNC services.
 
 It builds on the [money-flow catalogue](./money-flow-catalogue.md), which establishes the
 chart of accounts and the use-case → journal-entry mapping. This spec answers the next
@@ -25,27 +26,25 @@ result.
 ### Explicitly out of scope (deferred)
 
 - **Polymarket / GC:Trader activity.** A CNC team effectively has a GC:Trader account, so
-the CNC's *total* accounting should eventually fold in the GC:Trader (Polymarket) books.
-This is **deferred** — both because of effort and because the surface for Polymarket
-accounting (a GC:Trader project vs. a dedicated app) is itself undecided
-([#2078](https://github.com/globe-and-citizen/cnc-portal/issues/2078)). In the worked
-example the `Trading account` / `Trading Gain` / `Trading Loss` lines stand in for an
-external trader at cost; the live Polymarket position feed is **not** consolidated here.
+  the CNC's _total_ accounting should eventually fold in the GC:Trader (Polymarket) books.
+  This is **deferred** — both because of effort and because the surface for Polymarket
+  accounting (a GC:Trader project vs. a dedicated app) is itself undecided
+  ([#2078](https://github.com/globe-and-citizen/cnc-portal/issues/2078)). In the worked
+  example the `Trading account` / `Trading Gain` / `Trading Loss` lines stand in for an
+  external trader at cost; the live Polymarket position feed is **not** consolidated here.
 - **Governance / wiring contracts** that move no money: `BoardOfDirectors`, `Proposals`,
-`Elections`, `Officer`, `Voting`, proxies/beacons. `Officer` is read-only (fee lookup).
+  `Elections`, `Officer`, `Voting`, proxies/beacons. `Officer` is read-only (fee lookup).
 - **Deployed-but-unused contracts.** Only contracts the CNC actually uses are catalogued.
 
 ### Reporting boundary
 
-
-| Question            | Phase 1 answer                                                                                      |
-| ------------------- | --------------------------------------------------------------------------------------------------- |
-| Entity              | The CNC protocol entity (treasury + equity contracts), one consolidated ledger.                     |
-| Per-team vs. global | **Per team** — each team's contract set is its own books. Cross-team consolidation is out of scope. |
+| Question            | Phase 1 answer                                                                                                                                                                                                                                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Entity              | The CNC protocol entity (global fee treasury + equity contracts), with a separate operational ledger for each team's contract set.                                                                                                                                                                                             |
+| Per-team vs. global | **Both layers** — team activity is attributed per team, while the shared `FeeCollector` is global. A team-to-CNC usage fee is a cross-entity charge, not an internal move within the team.                                                                                                                                     |
 | Currency            | USD reporting currency. **POL** at its current live price (CoinGecko); **SHER** at the router multiplier — a withdrawal frozen at its own date, a pending accrual floating at the current rate; **USDC/USDT** pegged $1. See [catalogue → Currency & valuation](./money-flow-catalogue.md#currency--valuation-rate-of-record). |
-| Period              | A reporting period (the worked example uses 1–28 March 2026).                                       |
-| Basis               | Payroll = **accrual** (`Wage Payable` / `Shares to be issued`); everything else = **cash basis**.   |
-
+| Period              | A reporting period (the worked example uses 1–28 March 2026).                                                                                                                                                                                                                                                                  |
+| Basis               | Payroll = **accrual** (`Wage Payable` / `Shares to be issued`); everything else = **cash basis**.                                                                                                                                                                                                                              |
 
 ---
 
@@ -55,26 +54,20 @@ Sprint 15 ([#1862](https://github.com/globe-and-citizen/cnc-portal/issues/1862))
 pipeline that reconstructs accounting for a Polymarket wallet from raw feeds. The shape is
 reusable; only the **feeds** and the **categorisation** change.
 
-```
-            Sprint 15 (Polymarket)                         Phase 1 (CNC)
-  ─────────────────────────────────────       ─────────────────────────────────────
-  feeds:                                       feeds:
-    • Data API /activity                         • on-chain contract events (the 6 used
-    • Data API /positions                          contracts — see §3.1)
-    • Etherscan /tokentx (USDC)                    • Etherscan/Polygonscan native + ERC-20
-                                                     transfers (already proxied — §3.1)
-                                                   • portal DB: Wage / Claim / WeeklyClaim /
-                                                     Expense / TeamContract (§3.2)
-                  │                                            │
-                  ▼                                            ▼
-       buildLedger(input)  ──────────────►  buildLedger(input)  (same shape)
-         categorize each row                  categorize each row into the CNC
-         → LedgerEntry { category,            chart-of-accounts use cases (UC-BANK-*,
-           amount, cashFlow, … }              UC-CASH-*, UC-EXP-*, UC-INV-*, …)
-                  │                                            │
-                  ▼                                            ▼
-       summary + statements                  general ledger → trial balance →
-       (IS / BS / trial balance)             income statement → balance sheet
+```mermaid
+flowchart LR
+  subgraph sprint15["Sprint 15 — Polymarket"]
+    polyFeeds["Data API activity + positions<br/>Etherscan token transfers"] --> polyLedger["buildLedger(input)<br/>categorize rows"]
+    polyLedger --> polyStatements["Summary + statements<br/>IS · BS · trial balance"]
+  end
+
+  subgraph phase1["Phase 1 — CNC"]
+    cncFeeds["Contract events<br/>Native + ERC-20 transfers<br/>Portal DB rows"] --> cncLedger["buildLedger(input)<br/>categorize CNC use cases"]
+    cncLedger --> cncStatements["General ledger → trial balance<br/>→ income statement → balance sheet"]
+    cncLedger --> feeSplit["Split fee accounting:<br/>team expense ↔ CNC revenue"]
+  end
+
+  polyLedger -.->|"same ledger shape"| cncLedger
 ```
 
 Concretely, the existing `buildLedger` / `LedgerEntry` / `AccountingSummary` model in
@@ -85,12 +78,12 @@ statement components in
 `AccountingBalanceSheet`) are the target rendering layer. Phase 1 work is to:
 
 1. Add **CNC feeds** (contract events + the portal DB rows) alongside the existing
-  transfer proxy.
+   transfer proxy.
 2. Replace the Polymarket `LedgerCategory` set with the CNC **use-case categories** from
-  the money-flow catalogue (`UC-BANK-01…`, `UC-CASH-02/03`, `UC-EXP-01`, `UC-INV-01`,
-   `UC-SDR-01`, fee/funding internal moves).
+   the money-flow catalogue (`UC-BANK-01…`, `UC-CASH-02/03`, `UC-EXP-01`, `UC-INV-01`,
+   `UC-SDR-01`, team funding moves, and cross-entity fee payments).
 3. Map each entry to its **debit/credit accounts** per [catalogue §5](./money-flow-catalogue.md)
-  and let the existing trial-balance / IS / BS components roll them up.
+   and let the existing trial-balance / IS / BS components roll them up.
 
 ---
 
@@ -107,28 +100,25 @@ already proxies transfer history via
 (Etherscan API V2, native + ERC-20). Contract addresses come from
 `app/src/artifacts/deployed_addresses/` and the `TeamContract` table.
 
-
-| Contract                   | Key events available                                                                                   | What it tells the ledger                                                                  |
-| -------------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| **Bank**                   | `Deposited`, `TokenDeposited`, `Transfer`, `TokenTransfer`, `FeePaid`, `DividendDistributionTriggered` | Deposits in, transfers out (+ fee), dividend funding, internal funding of payroll/expense |
-| **FeeCollector**           | `FeePaid`, `Withdrawn`, `TokenWithdrawn`                                                               | Fees collected (internal move from Bank), fee-treasury withdrawals                        |
-| **CashRemunerationEIP712** | `Deposited`, `Withdraw`, `WithdrawToken`, `OwnerTreasuryWithdraw`*                                     | Payroll funding, wage withdrawals (cash / token / SHER mint)                              |
-| **ExpenseAccountEIP712**   | `Deposited`, `TokenDeposited`, `Transfer`, `TokenTransfer`, `OwnerTreasuryWithdraw`*                   | Expense-budget funding and approved payouts                                               |
-| **InvestorV1**             | `Minted`, `DividendDistributed`, `DividendPaid`                                                        | SHER mints (3 paths), pro-rata dividend distribution                                      |
-| **SafeDepositRouter**      | `Deposited`                                                                                            | Invest → SHER mint (cash lands in Safe)                                                   |
-
+| Contract                   | Key events available                                                                        | What it tells the ledger                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| **Bank**                   | `Deposited`, `TokenDeposited`, `Transfer`, `TokenTransfer`, `DividendDistributionTriggered` | Deposits in, transfers out (+ fee), dividend funding, internal funding of payroll/expense |
+| **FeeCollector**           | `FeePaid`, `Withdrawn`, `TokenWithdrawn`                                                    | Fees paid by team contracts into the global CNC treasury, and fee-treasury withdrawals    |
+| **CashRemunerationEIP712** | `Deposited`, `Withdraw`, `WithdrawToken`, `OwnerTreasuryWithdraw`\*                         | Payroll funding, wage withdrawals (cash / token / SHER mint)                              |
+| **ExpenseAccountEIP712**   | `Deposited`, `TokenDeposited`, `Transfer`, `TokenTransfer`, `OwnerTreasuryWithdraw`\*       | Expense-budget funding and approved payouts                                               |
+| **InvestorV1**             | `Minted`, `DividendDistributed`, `DividendPaid`                                             | SHER mints (3 paths), pro-rata dividend distribution                                      |
+| **SafeDepositRouter**      | `Deposited`                                                                                 | Invest → SHER mint (cash lands in Safe)                                                   |
 
 > The `**Minted` event** alone is ambiguous (capital raise vs. wage-in-shares vs. direct
 > mint) — it must be correlated with `Deposited` (SafeDepositRouter) or `WithdrawToken`
 > (CashRemuneration) to pick the right journal entry, per
 > [catalogue §5.4](./money-flow-catalogue.md). A `Minted` with neither is **Default D** —
-> a direct mint booked **Dr Shares to be issued · Cr Investor Equity** at the SHER rate.
+> a direct mint booked **Dr Shares to be issued · Cr Investor Equity\*\* at the SHER rate.
 
 ### 3.2 Portal database (accrual + classification context)
 
-The chain records *when money moved*; the portal records *what it was for* and the accrual
+The chain records _when money moved_; the portal records _what it was for_ and the accrual
 side payroll needs. From `[backend/prisma/schema.prisma](../../../backend/prisma/schema.prisma)`:
-
 
 | Model            | Feeds                                                            | Notes                                                                                                               |
 | ---------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
@@ -138,9 +128,8 @@ side payroll needs. From `[backend/prisma/schema.prisma](../../../backend/prisma
 | **Expense**      | `data` (JSON), `status`, signature, `userAddress`                | The approved budget / category context behind an ExpenseAccount payout (UC-EXP-01)                                  |
 | **TeamContract** | contract `address`, `type`, `teamId`                             | Resolves which on-chain addresses belong to which team's books                                                      |
 
-
-> The **accrual gap** matters: a wage is *earned* when the weekly claim is signed (portal,
-> UC-CASH-02) but *paid* when the employee withdraws (chain, UC-CASH-03). Booking both
+> The **accrual gap** matters: a wage is _earned_ when the weekly claim is signed (portal,
+> UC-CASH-02) but _paid_ when the employee withdraws (chain, UC-CASH-03). Booking both
 > requires joining the portal `WeeklyClaim`/`Claim` rows to the on-chain `Withdraw` /
 > `WithdrawToken` events.
 
@@ -151,20 +140,18 @@ side payroll needs. From `[backend/prisma/schema.prisma](../../../backend/prisma
 Each available source maps to a journal entry (catalogue §5) and thus to a statement line.
 **IS** = income statement, **BS** = balance sheet.
 
-
-| Source (event / record)                                              | Use case          | Journal entry                                                                     | Statement line(s)                                |
-| -------------------------------------------------------------------- | ----------------- | --------------------------------------------------------------------------------- | ------------------------------------------------ |
-| Bank `Deposited` / `TokenDeposited` from a founder (no shares)       | UC-BANK-01        | Dr Cash — Bank · Cr Owner Capital                                                 | BS: Cash ↑, Owner Capital ↑                      |
-| Bank `Deposited` / `TokenDeposited` from a client                    | UC-BANK-02        | Dr Cash — Bank · Cr Service Revenue                                               | IS: Service Revenue; BS: Cash ↑                  |
-| SafeDepositRouter `Deposited` + InvestorV1 `Minted`                  | UC-SDR-01         | Dr Cash — Safe · Cr Investor Equity                                               | BS: Cash ↑, Investor Equity ↑                    |
-| Bank `Transfer` / `TokenTransfer` + `FeePaid` (fund payroll/expense) | UC-BANK-03        | Dr Cash — Payroll/Expense · Dr Cash — FeeCollector (fee) · Cr Cash — Bank         | BS: internal cash move (no IS impact)            |
-| WeeklyClaim signed (portal)                                          | UC-CASH-02        | Dr Payroll Expense · Cr Wage Payable · Cr Shares to be issued                     | IS: Payroll Expense; BS: liabilities ↑           |
-| CashRemuneration `Withdraw` / `WithdrawToken` (+ `Minted`)           | UC-CASH-03        | Dr Wage Payable · Cr Cash — Payroll · Dr Shares to be issued · Cr Investor Equity | BS: liability settled, Cash ↓, Investor Equity ↑ |
-| ExpenseAccount `Transfer` / `TokenTransfer` (+ Expense record)       | UC-EXP-01         | Dr Operating Expense · Cr Cash — Expense                                          | IS: Operating Expense; BS: Cash ↓                |
-| Bank `DividendDistributionTriggered` / InvestorV1 `DividendPaid`     | UC-INV-01         | Dr Dividend Expense · Cr Cash — Bank                                              | IS: Dividend Expense; BS: Cash ↓                 |
-| InvestorV1 `Minted` alone (direct mint)                              | Default D         | Dr Shares to be issued · Cr Investor Equity (at the SHER rate, frozen at mint date) | BS: Investor Equity ↑ (unbacked mint drives Shares to be issued contra) |
-| FeeCollector `FeePaid` (from Bank transfers)                         | fee internal move | Dr Cash — FeeCollector · Cr Cash — Bank                                           | BS: internal cash move (no IS impact)            |
-
+| Source (event / record)                                          | Use case   | Journal entry                                                                                          | Statement line(s)                                                       |
+| ---------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| Bank `Deposited` / `TokenDeposited` from a founder (no shares)   | UC-BANK-01 | Dr Cash — Bank · Cr Owner Capital                                                                      | BS: Cash ↑, Owner Capital ↑                                             |
+| Bank `Deposited` / `TokenDeposited` from a client                | UC-BANK-02 | Dr Cash — Bank · Cr Service Revenue                                                                    | IS: Service Revenue; BS: Cash ↑                                         |
+| SafeDepositRouter `Deposited` + InvestorV1 `Minted`              | UC-SDR-01  | Dr Cash — Safe · Cr Investor Equity                                                                    | BS: Cash ↑, Investor Equity ↑                                           |
+| Bank `Transfer` / `TokenTransfer` (fund payroll/expense)         | UC-BANK-03 | Dr Cash — Payroll/Expense · Cr Cash — Bank                                                             | BS: internal team cash move (no IS impact)                              |
+| WeeklyClaim signed (portal)                                      | UC-CASH-02 | Dr Payroll Expense · Cr Wage Payable · Cr Shares to be issued                                          | IS: Payroll Expense; BS: liabilities ↑                                  |
+| CashRemuneration `Withdraw` / `WithdrawToken` (+ `Minted`)       | UC-CASH-03 | Dr Wage Payable · Cr Cash — Payroll · Dr Shares to be issued · Cr Investor Equity                      | BS: liability settled, Cash ↓, Investor Equity ↑                        |
+| ExpenseAccount `Transfer` / `TokenTransfer` (+ Expense record)   | UC-EXP-01  | Dr Operating Expense · Cr Cash — Expense                                                               | IS: Operating Expense; BS: Cash ↓                                       |
+| Bank `DividendDistributionTriggered` / InvestorV1 `DividendPaid` | UC-INV-01  | Dr Dividend Expense · Cr Cash — Bank                                                                   | IS: Dividend Expense; BS: Cash ↓                                        |
+| InvestorV1 `Minted` alone (direct mint)                          | Default D  | Dr Shares to be issued · Cr Investor Equity (at the SHER rate, frozen at mint date)                    | BS: Investor Equity ↑ (unbacked mint drives Shares to be issued contra) |
+| Bank transfer + FeeCollector `FeePaid` (team usage fee)          | UC-FEE-01  | Team: Dr CNC Usage Fee Expense · Cr Cash — Bank; CNC: Dr Cash — FeeCollector · Cr Protocol Fee Revenue | Team IS: expense; CNC IS: protocol-fee revenue; both BS: cash movement  |
 
 > **Trading lines** (`Trading account`, `Trading Gain`, `Trading Loss`, UC-TRD-) are in the
 > chart of accounts and the worked example, but their live feed is the deferred
@@ -177,18 +164,23 @@ Each available source maps to a journal entry (catalogue §5) and thus to a stat
 
 ### 5.1 Fees
 
-A fee on a Bank transfer moves cash **from Bank to FeeCollector** — both are CNC pockets, so
-it is an **internal move**, not revenue (catalogue §4). It nets out of the income statement
-and balance-sheet totals; it only redistributes cash between pockets.
+A fee on a Bank transfer is paid by the team's `Bank` to the shared global `FeeCollector`.
+It is therefore a **cross-entity charge**, not an internal move within the team. The team
+books a CNC usage expense; the CNC protocol books protocol-fee revenue.
 
 ```
-Dr Cash — FeeCollector   (fee)
-   Cr Cash — Bank        (fee)
+TEAM BOOKS
+Dr CNC Usage Fee Expense   (fee)
+   Cr Cash — Bank          (fee)
+
+CNC BOOKS
+Dr Cash — FeeCollector     (fee)
+   Cr Protocol Fee Revenue (fee)
 ```
 
-> If the CNC ever bills an **external** team through FeeCollector, that inflow *is* revenue
-> and should be recognised as **Protocol Fee Revenue** at FeeCollector instead of an
-> internal move. Phase 1 has no external billing, so all fees stay internal.
+The `FeePaid` event identifies the contract type and payer. The payer's `TeamContract`
+association supplies the team attribution for the team-side expense, while the
+`FeeCollector` event supplies the CNC-side revenue and cash entry.
 
 ### 5.2 Expense categories
 
@@ -196,14 +188,12 @@ Expenses are recognised **cash basis** (when paid), Dr `Operating Expense` · Cr
 pocket. The goal issue calls out explicit categories so the income statement breaks expenses
 down rather than lumping them into one line:
 
-
-| Category                       | What it covers                          | Source today                                               | Phase                         |
-| ------------------------------ | --------------------------------------- | ---------------------------------------------------------- | ----------------------------- |
-| **Payroll**                    | Wages earned by members (accrual)       | `Wage` / `WeeklyClaim` / `Claim` + CashRemuneration events | Phase 1 (`Payroll Expense`)   |
-| **Operating (ExpenseAccount)** | Approved member expense payouts         | `Expense` record + ExpenseAccount `Transfer`               | Phase 1 (`Operating Expense`) |
-| **Ponder (infra)**             | Indexer / hosting / infrastructure cost | **not captured on-chain** — paid off-platform              | Phase 2                       |
-| **Debt (interest)**            | Cost of borrowing from the members      | FixedReturn (Community Credit) events + `getLendingOffer` terms            | Phase 1 (`Interest Expense`, recognised at funding) |
-
+| Category                       | What it covers                          | Source today                                                    | Phase                                               |
+| ------------------------------ | --------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------- |
+| **Payroll**                    | Wages earned by members (accrual)       | `Wage` / `WeeklyClaim` / `Claim` + CashRemuneration events      | Phase 1 (`Payroll Expense`)                         |
+| **Operating (ExpenseAccount)** | Approved member expense payouts         | `Expense` record + ExpenseAccount `Transfer`                    | Phase 1 (`Operating Expense`)                       |
+| **Ponder (infra)**             | Indexer / hosting / infrastructure cost | **not captured on-chain** — paid off-platform                   | Phase 2                                             |
+| **Debt (interest)**            | Cost of borrowing from the members      | FixedReturn (Community Credit) events + `getLendingOffer` terms | Phase 1 (`Interest Expense`, recognised at funding) |
 
 Phase 1 books **payroll**, **operating** and **debt (interest)** expenses from existing data.
 **Ponder (infra)** is named here for the chart of accounts but has no data feed yet — it is a
@@ -215,18 +205,16 @@ gap (§6). Until then it requires manual journal entries if reported at all.
 
 What complete company accounting needs that we **don't yet capture**:
 
-
-| Gap                                               | Why it matters                                                                                                         | Proposed Phase 2 capture                                                                                                                  |
-| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| **Infra / Ponder cost**                           | A real expense paid off-platform (indexer, hosting) never hits a CNC contract, so it's invisible to an on-chain ledger | Manual expense entry or an off-chain bill record feeding `Operating Expense — Infra`                                                      |
-| **Debt & interest** *(resolved)*                  | Borrowed money must raise a liability, and the cost of borrowing must land in the period that earned it, not the one that paid it | **Done:** Community Credit (`FixedReturn.sol`) is the borrowing feature, wired through the `mappers/fixedReturn` source mapper. The credit contract is treated as **external** to the books: a lender's deposit is not the team's money while the offer is still filling, so it is not posted. The loan is recognised only when the round **funds** and the principal actually lands in the Bank — `Dr Cash — Bank · Cr Loan Payable` (`UC-CREDIT-01`), one leg per lender so the journal still reads who is owed — and `Loan Payable` is debited as principal is repaid (`UC-CREDIT-03`). This keeps one posting where the old model wrote two (a deposit into a `Cash — Credit` pocket, then an internal sweep of that same money out to Bank). A round that never funds and is refunded to its lenders produces **no posting at all** — the deposits were never the team's money. The fixed return is recognised **in full the moment the round funds** (`UC-CREDIT-05`, `Dr Interest Expense · Cr Interest Payable`, one posting per lender — see `mappers/creditTimeline`), because `repayLenders` fixes the obligation at `totalFunded × (1 + rate)` and never prorates it: settling early still costs the whole flat fee, so spreading it across the term would understate the debt every day until maturity. A repayment then clears `Interest Payable`; only a fee that was never recognised falls through to `Interest Expense` at payment. The rate does not reach the mapper through the event feed, so it is read from `getLendingOffer`; without that read the mapper falls back to expensing the fixed return at payment. Wording: a "borrowing round," not "debt issuance" — members lend to their own team, nothing is issued to a market. |
-| **Fee revenue (external billing)**                | Today all fees are internal moves; cross-team billing would be real revenue                                            | Recognise `Protocol Fee Revenue` at FeeCollector when the payer is external                                                               |
-| **FX / price-of-record** *(resolved)*             | POL→USD and SHER valuation need a defined rate source                                                                  | **Done:** POL at the current live price (CoinGecko), SHER at the router multiplier (withdrawal frozen at its date, pending accrual floats). Remaining: both refresh on the query lifecycle, not auto-watched on-chain — a live-refresh (block / `MultiplierUpdated`) is still open. |
-| **Cost classification of expenses**               | `Expense.data` JSON has category context but it isn't normalised into accounting categories                            | Map `Expense.data` categories → chart-of-accounts expense lines                                                                           |
-| **Polymarket / GC:Trader consolidation**          | The CNC's *total* result should fold in trading P&L                                                                    | Deferred — surface (GC:Trader project vs. dedicated app) undecided ([#2078](https://github.com/globe-and-citizen/cnc-portal/issues/2078)) |
-| **Period close / retained earnings roll-forward** | Multi-period reporting needs net income to close into retained earnings                                                | Define period boundaries and a close step in the pipeline                                                                                 |
-| **Real-money dogfood validation**                 | Statements are validated against a worked example, not live data                                                       | Deposit + invest in ETH as a team (per goal issue) to generate real data and validate end to end                                          |
-
+| Gap                                               | Why it matters                                                                                                                    | Proposed Phase 2 capture                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Infra / Ponder cost**                           | A real expense paid off-platform (indexer, hosting) never hits a CNC contract, so it's invisible to an on-chain ledger            | Manual expense entry or an off-chain bill record feeding `Operating Expense — Infra`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| **Debt & interest** _(resolved)_                  | Borrowed money must raise a liability, and the cost of borrowing must land in the period that earned it, not the one that paid it | **Done:** Community Credit (`FixedReturn.sol`) is the borrowing feature, wired through the `mappers/fixedReturn` source mapper. The credit contract is treated as **external** to the books: a lender's deposit is not the team's money while the offer is still filling, so it is not posted. The loan is recognised only when the round **funds** and the principal actually lands in the Bank — `Dr Cash — Bank · Cr Loan Payable` (`UC-CREDIT-01`), one leg per lender so the journal still reads who is owed — and `Loan Payable` is debited as principal is repaid (`UC-CREDIT-03`). This keeps one posting where the old model wrote two (a deposit into a `Cash — Credit` pocket, then an internal sweep of that same money out to Bank). A round that never funds and is refunded to its lenders produces **no posting at all** — the deposits were never the team's money. The fixed return is recognised **in full the moment the round funds** (`UC-CREDIT-05`, `Dr Interest Expense · Cr Interest Payable`, one posting per lender — see `mappers/creditTimeline`), because `repayLenders` fixes the obligation at `totalFunded × (1 + rate)` and never prorates it: settling early still costs the whole flat fee, so spreading it across the term would understate the debt every day until maturity. A repayment then clears `Interest Payable`; only a fee that was never recognised falls through to `Interest Expense` at payment. The rate does not reach the mapper through the event feed, so it is read from `getLendingOffer`; without that read the mapper falls back to expensing the fixed return at payment. Wording: a "borrowing round," not "debt issuance" — members lend to their own team, nothing is issued to a market. |
+| **Team/CNC fee attribution** _(resolved)_         | Team usage fees must be split between the paying team's expense and the CNC protocol's revenue                                    | **Done:** `FeePaid.payer` is joined to `TeamContract`; the team books `CNC Usage Fee Expense`, and the global `FeeCollector` books `Protocol Fee Revenue`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **FX / price-of-record** _(resolved)_             | POL→USD and SHER valuation need a defined rate source                                                                             | **Done:** POL at the current live price (CoinGecko), SHER at the router multiplier (withdrawal frozen at its date, pending accrual floats). Remaining: both refresh on the query lifecycle, not auto-watched on-chain — a live-refresh (block / `MultiplierUpdated`) is still open.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| **Cost classification of expenses**               | `Expense.data` JSON has category context but it isn't normalised into accounting categories                                       | Map `Expense.data` categories → chart-of-accounts expense lines                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **Polymarket / GC:Trader consolidation**          | The CNC's _total_ result should fold in trading P&L                                                                               | Deferred — surface (GC:Trader project vs. dedicated app) undecided ([#2078](https://github.com/globe-and-citizen/cnc-portal/issues/2078))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **Period close / retained earnings roll-forward** | Multi-period reporting needs net income to close into retained earnings                                                           | Define period boundaries and a close step in the pipeline                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **Real-money dogfood validation**                 | Statements are validated against a worked example, not live data                                                                  | Deposit + invest in ETH as a team (per goal issue) to generate real data and validate end to end                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 
 ---
 
@@ -241,7 +229,7 @@ What complete company accounting needs that we **don't yet capture**:
   ```
   and statement line (§4).
   ```
-- [x] **Fees & expenses booking** — fees as internal moves; expense categories incl. Ponder
+- [x] **Fees & expenses booking** — team CNC usage fees as cross-entity charges; expense categories incl. Ponder
   ```
   (infra), payroll, debt (interest) (§5).
   ```

--- a/docs/features/accounting/money-flow-catalogue.md
+++ b/docs/features/accounting/money-flow-catalogue.md
@@ -25,16 +25,19 @@ Plain-English meaning of the terms used throughout, so anyone on the team can fo
 
 ## 1. The CNC entity
 
-The CNC "company" is the **protocol entity**: its treasury contracts plus its equity contract. We keep **one consolidated set of books** for it; cash is tracked per on-chain account ("pocket"), but they all roll up into total Cash.
+The CNC "company" is the **protocol entity**: its global fee treasury plus its equity
+contract. Each team also has its own operational contract set and books. The shared
+`FeeCollector` is not a team's pocket: every team pays its CNC usage fees into that global
+treasury, and the CNC recognises the corresponding protocol-fee revenue.
 
-| Inside the CNC books  | On-chain home            |
-| --------------------- | ------------------------ |
-| Operating treasury    | `Bank`                   |
-| Protocol fee treasury | `FeeCollector`           |
-| Payroll               | `CashRemunerationEIP712` |
-| Expense budget        | `ExpenseAccountEIP712`   |
-| Equity / dividends    | `InvestorV1` (SHER)      |
-| Capital raises → Safe | `SafeDepositRouter`      |
+| Inside the CNC books         | On-chain home            |
+| ---------------------------- | ------------------------ |
+| Operating treasury           | `Bank`                   |
+| Global protocol fee treasury | `FeeCollector`           |
+| Payroll                      | `CashRemunerationEIP712` |
+| Expense budget               | `ExpenseAccountEIP712`   |
+| Equity / dividends           | `InvestorV1` (SHER)      |
+| Capital raises → Safe        | `SafeDepositRouter`      |
 
 ---
 
@@ -57,7 +60,7 @@ Deployed contracts that **do not move money** (governance / wiring, out of scope
 
 ## 3. Monetary interactions per contract (Step 2)
 
-Direction: **IN** (money in), **OUT** (money out), **INT** (internal transfer between CNC accounts), **MINT** (creates new shares).
+Direction: **IN** (money in), **OUT** (money out), **INT** (internal transfer within one team's accounts), **FEE** (team-to-CNC protocol payment), **MINT** (creates new shares).
 
 ### 3.1 Bank — treasury
 
@@ -72,10 +75,10 @@ Direction: **IN** (money in), **OUT** (money out), **INT** (internal transfer be
 
 ### 3.2 FeeCollector — protocol fees
 
-| Function                     | Asset           | Direction         | Caller           | Event                         |
-| ---------------------------- | --------------- | ----------------- | ---------------- | ----------------------------- |
-| `payFee()` / `payFeeToken()` | native / ERC-20 | IN                | billing contract | `FeePaid`                     |
-| `withdraw()`                 | native + ERC-20 | OUT → beneficiary | owner            | `Withdrawn`, `TokenWithdrawn` |
+| Function                     | Asset           | Direction         | Caller                      | Event                         |
+| ---------------------------- | --------------- | ----------------- | --------------------------- | ----------------------------- |
+| `payFee()` / `payFeeToken()` | native / ERC-20 | IN                | team contract (e.g. `Bank`) | `FeePaid`                     |
+| `withdraw()`                 | native + ERC-20 | OUT → beneficiary | owner                       | `Withdrawn`, `TokenWithdrawn` |
 
 ### 3.3 CashRemunerationEIP712 — payroll
 
@@ -112,42 +115,47 @@ Direction: **IN** (money in), **OUT** (money out), **INT** (internal transfer be
 
 The accounts used across the use cases and the worked example.
 
-| Account                                                   | Type      | Normal balance | Notes                                                       |
-| --------------------------------------------------------- | --------- | -------------- | ----------------------------------------------------------- |
-| **Cash — Bank / Safe / Payroll / Expense / FeeCollector** | Asset     | Debit          | One pocket per on-chain account; rolls up into total Cash   |
-| **Trading account**                                       | Asset     | Debit          | Capital deployed to an external trader, carried at cost     |
-| **Wage Payable**                                          | Liability | Credit         | Payroll earned but not yet paid (accrual)                   |
+| Account                                                   | Type      | Normal balance | Notes                                                                                                                                    |
+| --------------------------------------------------------- | --------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Cash — Bank / Safe / Payroll / Expense / FeeCollector** | Asset     | Debit          | Team pockets plus the global FeeCollector treasury; report them separately before any consolidation                                      |
+| **Trading account**                                       | Asset     | Debit          | Capital deployed to an external trader, carried at cost                                                                                  |
+| **Wage Payable**                                          | Liability | Credit         | Payroll earned but not yet paid (accrual)                                                                                                |
 | **Shares to be issued**                                   | Liability | Credit         | SHER earned but not yet taken; floats at the current multiplier while pending, then clears into equity frozen at the withdraw-date value |
-| **Owner Capital**                                         | Equity    | Credit         | Founder deposits with no shares in return                   |
-| **Investor Equity**                                       | Equity    | Credit         | SHER share capital — capital raises, wages paid in shares, and direct mints |
-| **Retained Earnings**                                     | Equity    | Credit         | Cumulative net income                                       |
-| **Service Revenue**                                       | Income    | Credit         | Payment from a client for a service                         |
-| **Trading Gain**                                          | Income    | Credit         | Profit returned by the trader                               |
-| **Payroll Expense**                                       | Expense   | Debit          | Wages earned                                                |
-| **Operating Expense**                                     | Expense   | Debit          | Approved expense payouts                                    |
-| **Trading Loss**                                          | Expense   | Debit          | Loss on capital deployed to the trader                      |
-| **Dividend Expense**                                      | Expense   | Debit          | Dividend distributed to shareholders                        |
+| **Owner Capital**                                         | Equity    | Credit         | Founder deposits with no shares in return                                                                                                |
+| **Investor Equity**                                       | Equity    | Credit         | SHER share capital — capital raises, wages paid in shares, and direct mints                                                              |
+| **Retained Earnings**                                     | Equity    | Credit         | Cumulative net income                                                                                                                    |
+| **Service Revenue**                                       | Income    | Credit         | Payment from a client for a service                                                                                                      |
+| **Protocol Fee Revenue**                                  | Income    | Credit         | CNC usage fees paid by teams into the global FeeCollector                                                                                |
+| **Trading Gain**                                          | Income    | Credit         | Profit returned by the trader                                                                                                            |
+| **Payroll Expense**                                       | Expense   | Debit          | Wages earned                                                                                                                             |
+| **Operating Expense**                                     | Expense   | Debit          | Approved expense payouts                                                                                                                 |
+| **CNC Usage Fee Expense**                                 | Expense   | Debit          | Fees paid by a team for using CNC services                                                                                               |
+| **Trading Loss**                                          | Expense   | Debit          | Loss on capital deployed to the trader                                                                                                   |
+| **Dividend Expense**                                      | Expense   | Debit          | Dividend distributed to shareholders                                                                                                     |
 
-> **Fees.** A fee on a Bank transfer moves cash from Bank to `Cash — FeeCollector` — both are CNC pockets, so it is an **internal move**, not revenue. (If you ever bill an external team, recognise it as `Protocol Fee Revenue` at FeeCollector instead.)
+> **Fees.** A fee on a team's Bank transfer is paid to the shared global `FeeCollector`.
+> In the team's books it is `CNC Usage Fee Expense`; in the CNC protocol's books it is
+> `Protocol Fee Revenue` and an increase in `Cash — FeeCollector`. It is not an internal
+> move within the paying team.
 
 ### Currency & valuation (rate of record)
 
 Every entry is reported in **USD**. The **quantity** of each currency is what actually moved on-chain and never changes; only its USD equivalence does. How each currency is converted:
 
-| Currency          | Rate of record                                     | Behaviour when the rate moves                                                                                                                                                                                          |
-| ----------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **USDC / USDT**   | pegged **$1.00**                                    | never moves                                                                                                                                                                                                            |
-| **POL (native)**  | the **current live price** (CoinGecko)             | The POL quantity is fixed; only its USD value moves. **Every** POL posting — past and present — is shown at **today's** price, so the whole POL book re-values together and stays balanced (no per-date historical rate). |
-| **SHER**          | the router **compensation multiplier** (1 SHER = `1 / multiplier` USD) | **Realization model** — a *taken* leg freezes, a *pending* leg floats (see below).                                                                                                     |
+| Currency         | Rate of record                                                         | Behaviour when the rate moves                                                                                                                                                                                             |
+| ---------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **USDC / USDT**  | pegged **$1.00**                                                       | never moves                                                                                                                                                                                                               |
+| **POL (native)** | the **current live price** (CoinGecko)                                 | The POL quantity is fixed; only its USD value moves. **Every** POL posting — past and present — is shown at **today's** price, so the whole POL book re-values together and stays balanced (no per-date historical rate). |
+| **SHER**         | the router **compensation multiplier** (1 SHER = `1 / multiplier` USD) | **Realization model** — a _taken_ leg freezes, a _pending_ leg floats (see below).                                                                                                                                        |
 
 **SHER — freeze at withdrawal, float while pending.** A wage is a **fixed quantity of SHER** (e.g. 10 h × 5 SHER/h = 50 SHER, whatever the multiplier is); the multiplier only changes its USD value, never the number of SHER minted. So:
 
-- a **withdrawal / mint** (UC-CASH-03 / Default D) is **frozen at the multiplier of its own date** — the value at which the shares were *taken* — and never moves again;
+- a **withdrawal / mint** (UC-CASH-03 / Default D) is **frozen at the multiplier of its own date** — the value at which the shares were _taken_ — and never moves again;
 - a **pending accrual** (SHER earned but not yet withdrawn, held in `Shares to be issued`, UC-CASH-02) **floats at the current multiplier** — re-valued every time the multiplier moves, until it is withdrawn.
 
 When a withdrawal settles an accrual, both legs carry the **withdrawal-date** value, so `Shares to be issued` nets to zero with no revaluation account. A partly-withdrawn accrual is quantity-weighted: the withdrawn part frozen, the rest still floating.
 
-> **Why POL and SHER differ.** Pending SHER is a *promise* the company still owes (a liability), so marking it to the current rate just restates what is owed; once withdrawn it is *realized* equity and locks. POL is cash the company *holds* — its dollar-equivalence is simply recomputed at the current price, and because both sides of every POL entry move together the books never fall out of balance.
+> **Why POL and SHER differ.** Pending SHER is a _promise_ the company still owes (a liability), so marking it to the current rate just restates what is owed; once withdrawn it is _realized_ equity and locks. POL is cash the company _holds_ — its dollar-equivalence is simply recomputed at the current price, and because both sides of every POL entry move together the books never fall out of balance.
 
 ---
 
@@ -195,7 +203,7 @@ flowchart LR
   bank[("Cash — Bank")]:::asset
   payCash[("Cash — Payroll")]:::asset
   expCash[("Cash — Expense")]:::asset
-  feeCash[("Cash — FeeCollector")]:::asset
+  feeCash[("Cash — FeeCollector<br/>(global CNC treasury)")]:::asset
   trading[Trading account]:::asset
   invEq[Investor Equity]:::equity
   wagePay[Wage Payable]:::liability
@@ -216,7 +224,10 @@ flowchart LR
   trading -->|"UC-TRD-03 · trader loses capital"| tradeLoss
 
   bank -.->|"UC-BANK-03 · fund payroll / expense"| payCash
-  bank -.->|"fee on transfer"| feeCash
+  feeExpense["CNC Usage Fee Expense<br/>(team books)"]:::expense
+  protocolFee["Protocol Fee Revenue<br/>(CNC books)"]:::income
+  bank -.->|"UC-FEE-01 · team usage fee"| feeExpense
+  protocolFee -->|"FeePaid · global revenue"| feeCash
 
   classDef asset fill:#dbeafe,stroke:#3b82f6,color:#1e3a8a;
   classDef equity fill:#ede9fe,stroke:#8b5cf6,color:#4c1d95;
@@ -224,15 +235,16 @@ flowchart LR
   classDef liability fill:#fef3c7,stroke:#f59e0b,color:#78350f;
 ```
 
-| UC             | Interaction                            | Journal entry                                                                                   |
-| -------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| **UC-CASH-02** | wage earned (accrual, at claim)        | Dr Payroll Expense · Cr Wage Payable (cash part) · Cr Shares to be issued (SHER part)           |
-| **UC-CASH-03** | wage paid (at withdraw)                | Dr Wage Payable · Cr Cash — Payroll · Dr Shares to be issued · Cr Investor Equity (SHER minted) |
-| **UC-EXP-01**  | approved expense paid (cash basis)     | Dr Operating Expense · Cr Cash — Expense                                                        |
-| **UC-INV-01**  | dividend paid pro-rata                 | Dr Dividend Expense · Cr Cash — Bank                                                            |
-| **UC-BANK-03** | fund payroll/expense from Bank (+ fee) | Dr Cash — Payroll/Expense · Dr Cash — FeeCollector (fee) · Cr Cash — Bank                       |
-| **UC-TRD-01**  | deploy capital to trader               | Dr Trading account · Cr Cash — Bank                                                             |
-| **UC-TRD-03**  | trader loses part of the capital       | Dr Cash (returned) · Dr Trading Loss · Cr Trading account                                       |
+| UC             | Interaction                        | Journal entry                                                                                          |
+| -------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **UC-CASH-02** | wage earned (accrual, at claim)    | Dr Payroll Expense · Cr Wage Payable (cash part) · Cr Shares to be issued (SHER part)                  |
+| **UC-CASH-03** | wage paid (at withdraw)            | Dr Wage Payable · Cr Cash — Payroll · Dr Shares to be issued · Cr Investor Equity (SHER minted)        |
+| **UC-EXP-01**  | approved expense paid (cash basis) | Dr Operating Expense · Cr Cash — Expense                                                               |
+| **UC-INV-01**  | dividend paid pro-rata             | Dr Dividend Expense · Cr Cash — Bank                                                                   |
+| **UC-BANK-03** | fund payroll/expense from Bank     | Dr Cash — Payroll/Expense · Cr Cash — Bank                                                             |
+| **UC-FEE-01**  | team pays CNC usage fee            | Team: Dr CNC Usage Fee Expense · Cr Cash — Bank; CNC: Dr Cash — FeeCollector · Cr Protocol Fee Revenue |
+| **UC-TRD-01**  | deploy capital to trader           | Dr Trading account · Cr Cash — Bank                                                                    |
+| **UC-TRD-03**  | trader loses part of the capital   | Dr Cash (returned) · Dr Trading Loss · Cr Trading account                                              |
 
 ### 5.3 Payroll is accrual; expense is cash basis
 
@@ -270,7 +282,8 @@ flowchart TD
 
 ## 6. Worked example — a full period
 
-This is the scenario in the companion spreadsheet, booked end to end. Amounts in USD — POL at its current price, SHER at the router multiplier (see [Currency & valuation](#currency--valuation-rate-of-record)). This period has **no rate change**, so every SHER is valued at $1 and every POL amount is stable; the realization/float rules only bite once a rate moves. It balances at every level.
+This is the scenario in the companion spreadsheet, booked end to end for **one team**.
+Amounts in USD — POL at its current price, SHER at the router multiplier (see [Currency & valuation](#currency--valuation-rate-of-record)). This period has **no rate change**, so every SHER is valued at $1 and every POL amount is stable; the realization/float rules only bite once a rate moves. Team usage fees are expenses in this ledger; the corresponding CNC revenue entry is shown in §6.7.
 
 ### 6.1 The events
 
@@ -317,10 +330,10 @@ The period runs **1 – 28 March 2026**. Each transaction is dated below, and th
 | 2026-03-11 | Transfer Safe → Bank (fund operations) | Cash — Bank                      |      71.75 |            |
 |            |                                        | Cash — Safe                      |            |      71.75 |
 | 2026-03-12 | Ravi funds payroll $50.02              | Cash — Payroll                   |         50 |            |
-|            |                                        | Cash — FeeCollector              |       0.02 |            |
+|            |                                        | CNC Usage Fee Expense            |       0.02 |            |
 |            |                                        | Cash — Bank                      |            |      50.02 |
 | 2026-03-12 | Ravi funds payroll 22 POL              | Cash — Payroll                   |       1.72 |            |
-|            |                                        | Cash — FeeCollector              |       0.01 |            |
+|            |                                        | CNC Usage Fee Expense            |       0.01 |            |
 |            |                                        | Cash — Bank                      |            |       1.73 |
 | 2026-03-13 | Geor claims $40 + 10 POL + 10 SHER     | Payroll Expense                  |       50.8 |            |
 |            |                                        | Wage Payable                     |            |       40.8 |
@@ -330,7 +343,7 @@ The period runs **1 – 28 March 2026**. Each transaction is dated below, and th
 |            |                                        | Shares to be issued              |         10 |            |
 |            |                                        | Investor Equity (10 SHER minted) |            |         10 |
 | 2026-03-16 | Ravi funds expense $50                 | Cash — Expense                   |       49.8 |            |
-|            |                                        | Cash — FeeCollector              |        0.2 |            |
+|            |                                        | CNC Usage Fee Expense            |        0.2 |            |
 |            |                                        | Cash — Bank                      |            |         50 |
 | 2026-03-17 | Geor withdraws $20 expense             | Operating Expense                |         20 |            |
 |            |                                        | Cash — Expense                   |            |         20 |
@@ -381,7 +394,7 @@ Dr                       | Cr
 #8  from Bank POL   1.72 |
 Solde              10.92 |
 
-Cash — FeeCollector (Asset)
+CNC Usage Fee Expense (Expense)
 Dr                       | Cr
 #7  fee payroll     0.02 |
 #8  fee POL         0.01 |
@@ -434,26 +447,28 @@ Payroll Expense   (Dr) 50.8  — #9
 Operating Expense (Dr) 20    — #12
 Trading Loss      (Dr) 20    — #14
 Dividend Expense  (Dr) 20    — #18
+CNC Usage Fee Expense (Dr) 0.23 — #7, #8, #11
 Owner Capital          0     (empty — everyone got shares or it was revenue)
 ```
 
 ### 6.4 Trial balance
 
-| Account             | Type      |      Debit |     Credit |
-| ------------------- | --------- | ---------: | ---------: |
-| Cash                | Asset     |     142.20 |            |
-| Trading account     | Asset     |          0 |            |
-| Owner Capital       | Equity    |            |          0 |
-| Investor Equity     | Equity    |            |        168 |
-| Service Revenue     | Income    |            |        100 |
-| Trading Gain        | Income    |            |         15 |
-| Wage Payable        | Liability |          0 |          0 |
-| Shares to be issued | Liability |      30.00 |            |
-| Payroll Expense     | Expense   |      50.80 |            |
-| Operating Expense   | Expense   |         20 |            |
-| Trading Loss        | Expense   |         20 |            |
-| Dividend Expense    | Expense   |         20 |            |
-| **TOTAL**           |           | **283.00** | **283.00** |
+| Account               | Type      |      Debit |     Credit |
+| --------------------- | --------- | ---------: | ---------: |
+| Cash                  | Asset     |     141.97 |            |
+| Trading account       | Asset     |          0 |            |
+| Owner Capital         | Equity    |            |          0 |
+| Investor Equity       | Equity    |            |        168 |
+| Service Revenue       | Income    |            |        100 |
+| Trading Gain          | Income    |            |         15 |
+| Wage Payable          | Liability |          0 |          0 |
+| Shares to be issued   | Liability |      30.00 |            |
+| Payroll Expense       | Expense   |      50.80 |            |
+| Operating Expense     | Expense   |         20 |            |
+| CNC Usage Fee Expense | Expense   |       0.23 |            |
+| Trading Loss          | Expense   |         20 |            |
+| Dividend Expense      | Expense   |         20 |            |
+| **TOTAL**             |           | **283.00** | **283.00** |
 
 ### 6.5 Income statement
 
@@ -464,37 +479,53 @@ Owner Capital          0     (empty — everyone got shares or it was revenue)
 | **Total revenue**       | **+115.00** |
 | Payroll Expense         |      −50.80 |
 | Operating Expense       |      −20.00 |
+| CNC Usage Fee Expense   |       −0.23 |
 | Trading Loss            |      −20.00 |
 | Dividend Expense        |      −20.00 |
-| **Total expenses**      | **−110.80** |
-| **Net income (profit)** |   **+4.20** |
+| **Total expenses**      | **−111.03** |
+| **Net income (profit)** |   **+3.97** |
 
 ### 6.6 Balance sheet
 
-|                                                   |                      $ |
-| ------------------------------------------------- | ---------------------: |
-| **ASSETS**                                        |                        |
-| Cash (USDC + POL)                                 |                 142.20 |
-| Trading account (at cost)                         |                   0.00 |
-| **Total assets**                                  |             **142.20** |
-| **LIABILITIES**                                   |                        |
-| Wage Payable (settled)                            |                   0.00 |
-| Shares to be issued (unbacked direct mint, contra) |                −30.00 |
-| **Total liabilities**                             |              **−30.00** |
-| **EQUITY**                                        |                        |
-| Owner capital                                     |                   0.00 |
-| Investor equity (SHER)                            |                 168.00 |
-| Retained earnings (net profit)                    |                   4.20 |
-| **Total equity**                                  |             **172.20** |
-| **Assets = Liabilities + Equity**                 | **142.20 = −30.00 + 172.20** ✅ |
+|                                                    |                               $ |
+| -------------------------------------------------- | ------------------------------: |
+| **ASSETS**                                         |                                 |
+| Cash (USDC + POL)                                  |                          141.97 |
+| Trading account (at cost)                          |                            0.00 |
+| **Total assets**                                   |                      **141.97** |
+| **LIABILITIES**                                    |                                 |
+| Wage Payable (settled)                             |                            0.00 |
+| Shares to be issued (unbacked direct mint, contra) |                          −30.00 |
+| **Total liabilities**                              |                      **−30.00** |
+| **EQUITY**                                         |                                 |
+| Owner capital                                      |                            0.00 |
+| Investor equity (SHER)                             |                          168.00 |
+| Retained earnings (net profit)                     |                            3.97 |
+| **Total equity**                                   |                      **171.97** |
+| **Assets = Liabilities + Equity**                  | **141.97 = −30.00 + 171.97** ✅ |
+
+### 6.7 Global CNC fee ledger
+
+The team ledger above records the $0.23 of usage fees as `CNC Usage Fee Expense` and
+reduces the team's cash accordingly. The shared CNC `FeeCollector` records the other side
+in the protocol ledger:
+
+```
+Dr Cash — FeeCollector       0.23
+   Cr Protocol Fee Revenue   0.23
+```
+
+The `FeePaid` event links this CNC revenue to the paying team through its `payer` address
+and the `TeamContract` mapping. The two entries belong to different reporting layers;
+the fee is not an internal transfer within the team.
 
 ---
 
 ## 7. Reconciliation & notes
 
-- **It balances at every level:** journal 708.10 = 708.10 · trial balance 283 = 283 · assets 142.20 = liabilities −30 + equity 172.20.
+- **It balances at every level:** journal 708.10 = 708.10 · trial balance 283 = 283 · assets 141.97 = liabilities −30 + equity 171.97.
 - **Internal transfers don't touch the statements.** Funding payroll/expense from Bank, and the Safe → Bank transfer, only move cash between pockets — no effect on the income statement, balance-sheet totals, or net trial balance. The Safe → Bank transfer of 71.75 exists only because operating payments (payroll, expense, dividend, trader) leave from Bank while the funding (investments) lands in Safe.
-- **Fees stay inside Cash.** The $0.23 of fees moved from Bank to FeeCollector — both CNC pockets — so no revenue is recognised here.
+- **Fees are cross-entity charges.** The team books $0.23 of `CNC Usage Fee Expense`, reducing team cash to $141.97 and team net income to $3.97. The CNC protocol separately books $0.23 of `Protocol Fee Revenue` and `Cash — FeeCollector` in §6.7.
 - **Shares vs value.** `Investor Equity` ($168) counts capital raises ($100 + $10 + $10 + $8), the SHER paid as a wage ($10) and Ravi's direct mint ($30). Ravi's mint (**Default D**) issues 30 SHER straight to equity; because he never accrued them, the offsetting `Dr Shares to be issued` has nothing to cancel and leaves that liability at **−30** (contra) — the known unbacked-direct-mint edge. Still reconcile shares (`Σ Minted` = on-chain supply) against the value in `Investor Equity`.
 - **SHER wages are recognised at withdraw, not at claim.** From the claim until the withdrawal, the SHER part of a wage sits in the `Shares to be issued` liability — **floating at the current multiplier** while it is pending. Only at `withdraw()` does `individualMint` fire and the value move into `Investor Equity`, **frozen at the withdraw-date multiplier**. This matches the on-chain `WithdrawToken` / `Minted` events. The withdraw nets the liability to $0, so it never appears on the balance sheet at period end — but in a period where a claim is open without a matching withdrawal, `Shares to be issued` carries the promised SHER, re-valued at the current multiplier.
 - **Owner Capital is $0** in this period: everyone who put money in either received shares (Investor Equity) or it was a client payment (Service Revenue) — nobody made a pure founder deposit.


### PR DESCRIPTION
## Summary
- document the shared global FeeCollector and team-to-CNC usage-fee boundary
- distinguish team-side CNC usage expense from CNC-side protocol-fee revenue
- replace the Sprint 15 pipeline ASCII diagram with Mermaid
- update the worked example and reconciled totals

## Why
The accounting documentation still described fees as internal transfers within a team, while the implementation routes usage fees from each team into the global CNC FeeCollector.

## Validation
- `git diff --check`
- documentation consistency review

Closes #2449