### PR TITLE
fix: 🐛 align claim form daily-cap fallback with the server default

### DIFF
--- a/app/src/composables/__tests__/useClaimForm.spec.ts
+++ b/app/src/composables/__tests__/useClaimForm.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { useClaimForm, formatUTC } from '@/composables/useClaimForm'
+import { DEFAULT_MAXIMUM_HOURS_PER_DAY } from '@/utils'
 
 const createOptions = () => {
   const toast = { add: vi.fn() }
@@ -143,17 +144,50 @@ describe('useClaimForm', () => {
     expect(overTotalResult.error?.issues.some((i) => i.message.includes('daily cap'))).toBe(true)
   })
 
-  it('falls back to 24h limit when no daily cap is set', () => {
+  it('falls back to the server default cap when no daily cap is set', () => {
     const options = createOptions()
     const { claimSchema } = useClaimForm(options)
 
     const validResult = claimSchema.value.safeParse({
-      hoursWorked: '23',
-      minutesWorked: '50',
-      memo: 'long day',
+      hoursWorked: String(DEFAULT_MAXIMUM_HOURS_PER_DAY),
+      minutesWorked: '0',
+      memo: 'full day',
       dayWorked: '2024-01-10T00:00:00.000Z'
     })
     expect(validResult.success).toBe(true)
+
+    const overResult = claimSchema.value.safeParse({
+      hoursWorked: String(DEFAULT_MAXIMUM_HOURS_PER_DAY),
+      minutesWorked: '10',
+      memo: 'over the default cap',
+      dayWorked: '2024-01-10T00:00:00.000Z'
+    })
+    expect(overResult.success).toBe(false)
+    expect(
+      overResult.error?.issues.some((i) =>
+        i.message.includes(`daily cap of ${DEFAULT_MAXIMUM_HOURS_PER_DAY} hours`)
+      )
+    ).toBe(true)
+  })
+
+  it('counts already-claimed minutes against the default cap for legacy wages', () => {
+    const options = createOptions()
+    const { claimSchema } = useClaimForm({
+      ...options,
+      existingClaims: ref([{ minutesWorked: 420, dayWorked: '2024-01-10T00:00:00.000Z' }])
+    })
+
+    // 7h already claimed + 2h new = 9h > 8h default cap
+    const overResult = claimSchema.value.safeParse({
+      hoursWorked: '2',
+      minutesWorked: '0',
+      memo: 'over remaining',
+      dayWorked: '2024-01-10T00:00:00.000Z'
+    })
+    expect(overResult.success).toBe(false)
+    const message = overResult.error?.issues.find((i) => i.path.includes('hoursWorked'))?.message
+    expect(message).toContain('Already claimed: 7h')
+    expect(message).toContain('Remaining: 1h')
   })
 
   it('rejects when input plus already-claimed minutes exceed the daily cap', () => {

--- a/app/src/composables/useClaimForm.ts
+++ b/app/src/composables/useClaimForm.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import type { ClaimFormData } from '@/types'
+import { DEFAULT_MAXIMUM_HOURS_PER_DAY } from '@/utils'
 
 dayjs.extend(utc)
 
@@ -88,9 +89,11 @@ const formatMinutes = (minutes: number): string => {
 }
 
 const buildClaimSchema = (dailyCap?: number, existingClaims?: DailyClaimEntry[]) => {
+  // Wages created before the daily-cap column existed carry no value; fall back to the
+  // same default the server applies so both sides accept exactly the same claims.
   const hasCap = typeof dailyCap === 'number' && dailyCap > 0
-  const maxMinutes = hasCap ? dailyCap * 60 : 1440
-  const maxHoursLabel = hasCap ? dailyCap : 24
+  const effectiveCap = hasCap ? dailyCap : DEFAULT_MAXIMUM_HOURS_PER_DAY
+  const maxMinutes = effectiveCap * 60
 
   return z
     .object({
@@ -99,8 +102,8 @@ const buildClaimSchema = (dailyCap?: number, existingClaims?: DailyClaimEntry[])
         .refine((val) => String(val).trim() !== '', { message: 'Hours is required' })
         .refine((val) => !isNaN(Number(val)), { message: 'Must be a valid number' })
         .refine((val) => Number(val) >= 0, { message: 'Hours cannot be negative' })
-        .refine((val) => Number(val) <= maxHoursLabel, {
-          message: `Cannot exceed ${maxHoursLabel} hours`
+        .refine((val) => Number(val) <= effectiveCap, {
+          message: `Cannot exceed ${effectiveCap} hours`
         })
         .refine((val) => Number.isInteger(Number(val)), {
           message: 'Hours must be a whole number'
@@ -120,13 +123,11 @@ const buildClaimSchema = (dailyCap?: number, existingClaims?: DailyClaimEntry[])
       path: ['hoursWorked']
     })
     .refine((data) => Number(data.hoursWorked) * 60 + Number(data.minutesWorked) <= maxMinutes, {
-      message: hasCap
-        ? `Cannot exceed daily cap of ${dailyCap} hours`
-        : 'Total duration cannot exceed 24 hours (1440 minutes)',
+      message: `Cannot exceed daily cap of ${effectiveCap} hours`,
       path: ['hoursWorked']
     })
     .superRefine((data, ctx) => {
-      if (!hasCap || !existingClaims?.length) return
+      if (!existingClaims?.length) return
       const inputMinutes = Number(data.hoursWorked) * 60 + Number(data.minutesWorked)
       const claimed = alreadyClaimedForDay(existingClaims, data.dayWorked)
       if (inputMinutes + claimed <= maxMinutes) return


### PR DESCRIPTION
# Description
Wages created before the daily-cap column existed let the form accept up to 24h while the server refused anything over 8h. The form now falls back to the same DEFAULT_MAXIMUM_HOURS_PER_DAY as the backend, and the already-claimed check runs for those wages too.

Fixes #2472


