### PR TITLE
fix: 🐛 wage change mid-week splits the week and bypasses hour limits

### DIFF
--- a/app/src/components/RateDotList.vue
+++ b/app/src/components/RateDotList.vue
@@ -17,14 +17,14 @@
           'bg-purple-500': !['native', 'usdc', 'usdt'].includes(rate.type)
         }"
       />
-      {{ rate.type === 'native' ? NETWORK.currencySymbol : rate.type.toUpperCase() }}
+      {{ rateSymbol(rate.type) }}
       {{ formatRateAmount(rate.amount) }}
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { NETWORK } from '@/constant'
+import { rateSymbol } from '@/utils/wageUtil'
 
 interface RateItem {
   type: string

--- a/app/src/components/sections/CashRemunerationView/Form/__tests__/ClaimForm.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/Form/__tests__/ClaimForm.spec.ts
@@ -203,10 +203,11 @@ describe('ClaimForm.vue', () => {
       .findComponent({ name: 'UCalendar' })
       .props('isDateDisabled') as DateDisabledFn
 
-    expect(fn1({ year: 2024, month: 1, day: 8 })).toBe(true)
-    expect(fn2({ year: 2024, month: 1, day: 7 })).toBe(true)
-    expect(fn2({ year: 2024, month: 1, day: 13 })).toBe(true)
-    expect(fn2({ year: 2024, month: 1, day: 8 })).toBe(true)
+    // Now is Fri 12 Jan 2024, so the current ISO week runs Mon 8 -> Sun 14.
+    expect(fn1({ year: 2024, month: 1, day: 8 })).toBe(true) // week already approved
+    expect(fn2({ year: 2024, month: 1, day: 7 })).toBe(true) // previous week
+    expect(fn2({ year: 2024, month: 1, day: 13 })).toBe(true) // in the future
+    expect(fn2({ year: 2024, month: 1, day: 8 })).toBe(false)
     expect(fn3({ year: 2024, month: 1, day: 1 })).toBe(false)
 
     vi.useRealTimers()

--- a/app/src/components/sections/ClaimHistoryView/ClaimHistoryActionAlerts.vue
+++ b/app/src/components/sections/ClaimHistoryView/ClaimHistoryActionAlerts.vue
@@ -1,6 +1,16 @@
 <template>
   <UCard data-test="action-alerts">
     <div class="flex flex-col gap-4">
+      <!-- Upcoming rate change: shown to the member so the switch is not a surprise -->
+      <UAlert
+        v-if="memberAddress === userStore.address && scheduledWageNotice"
+        color="info"
+        variant="subtle"
+        icon="i-heroicons-calendar"
+        data-test="scheduled-wage-alert"
+        :description="`${scheduledWageNotice}. Weeks before that date keep your current rate.`"
+      />
+
       <!-- Submit Claims Alert (for member's own view) -->
       <UAlert
         v-if="memberAddress === userStore.address"
@@ -108,6 +118,8 @@ import isoWeek from 'dayjs/plugin/isoWeek'
 import type { Address } from 'viem'
 import { useTeamStore, useUserDataStore } from '@/stores'
 import { useGetTeamWagesQuery, useGetTeamWeeklyClaimsQuery } from '@/queries'
+import { formatScheduledWageNotice } from '@/utils/wageUtil'
+import { useScheduledWageRefresh } from '@/composables/useScheduledWageRefresh'
 import type { WeeklyClaim } from '@/types'
 import SubmitClaims from '../CashRemunerationView/SubmitClaims.vue'
 import SubmitWeeklyGoals from '../CashRemunerationView/SubmitWeeklyGoals.vue'
@@ -145,6 +157,21 @@ const userWage = computed(() =>
 )
 
 const hasWage = computed(() => !!userWage.value)
+
+const scheduledWage = computed(() => userWage.value?.scheduledWage ?? null)
+
+const scheduledWageNotice = computed(() => {
+  const effectiveFrom = scheduledWage.value?.effectiveFrom
+  if (!effectiveFrom) return null
+  if (!dayjs.utc(props.selectedWeekStart).isBefore(dayjs.utc(effectiveFrom))) return null
+
+  return formatScheduledWageNotice(scheduledWage.value)
+})
+
+useScheduledWageRefresh(
+  scheduledWage,
+  computed(() => teamStore.currentTeamId)
+)
 
 watch(teamWageDataError, (newVal) => {
   if (newVal) {

--- a/app/src/components/sections/ClaimHistoryView/__tests__/ClaimHistoryActionAlerts.scheduledWage.spec.ts
+++ b/app/src/components/sections/ClaimHistoryView/__tests__/ClaimHistoryActionAlerts.scheduledWage.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { mockUserStore, mockWageData } from '@/tests/mocks'
+import { useGetTeamWagesQuery } from '@/queries'
+import {
+  baseAddress,
+  createWeeklyClaim,
+  createWrapper,
+  openModalForDayMock
+} from './claimHistoryActionAlerts.harness'
+
+describe('ClaimHistoryActionAlerts - scheduled wage notice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUserStore.address = baseAddress
+    openModalForDayMock.mockReset()
+  })
+
+  const withScheduledWage = () =>
+    (
+      useGetTeamWagesQuery as unknown as { mockReturnValueOnce: (value: unknown) => void }
+    ).mockReturnValueOnce({
+      data: ref([
+        {
+          ...mockWageData[0],
+          userAddress: baseAddress,
+          scheduledWage: {
+            ...mockWageData[0],
+            userAddress: baseAddress,
+            effectiveFrom: '2026-08-17T00:00:00.000Z',
+            ratePerHour: [{ type: 'sher', amount: 10 }],
+            maximumHoursPerWeek: 15,
+            maximumHoursPerDay: 8
+          }
+        }
+      ]),
+      error: ref(null)
+    })
+
+  const alertFor = (selectedWeekStart: string) => {
+    const wrapper = createWrapper({ weeklyClaim: createWeeklyClaim(), selectedWeekStart })
+    return wrapper.find('[data-test="scheduled-wage-alert"]')
+  }
+
+  it('announces the rate and both hour ceilings on a week that predates the change', () => {
+    withScheduledWage()
+
+    const alert = alertFor('2026-08-10T00:00:00.000Z')
+
+    expect(alert.exists()).toBe(true)
+    expect(alert.text()).toContain('SHER 10')
+    expect(alert.text()).toContain('15h/wk')
+    expect(alert.text()).toContain('8h/d')
+  })
+
+  it.each([
+    ['the week the change takes effect', '2026-08-17T00:00:00.000Z'],
+    ['a week after the change took effect', '2026-08-24T00:00:00.000Z']
+  ])('hides the notice on %s', (_label, selectedWeekStart) => {
+    // Those weeks already run on the new wage, so calling it upcoming — and
+    // saying the week keeps the current rate — would be false.
+    withScheduledWage()
+
+    expect(alertFor(selectedWeekStart).exists()).toBe(false)
+  })
+
+  it('shows no notice when no change is scheduled', () => {
+    expect(alertFor('2026-08-10T00:00:00.000Z').exists()).toBe(false)
+  })
+})

--- a/app/src/components/sections/ClaimHistoryView/__tests__/claimHistoryActionAlerts.harness.ts
+++ b/app/src/components/sections/ClaimHistoryView/__tests__/claimHistoryActionAlerts.harness.ts
@@ -1,0 +1,74 @@
+import { vi } from 'vitest'
+import { defineComponent } from 'vue'
+import ClaimHistoryActionAlerts from '@/components/sections/ClaimHistoryView/ClaimHistoryActionAlerts.vue'
+import { renderWithProviders, mockWeeklyClaimData } from '@/tests/mocks'
+
+/**
+ * Shared mount setup for the ClaimHistoryActionAlerts specs.
+ *
+ * The component pulls in four child components and two query hooks, so every
+ * spec needs the same stub wall. Keeping it here lets the behaviour be split
+ * across focused spec files instead of one file that outgrows the max-lines
+ * budget.
+ */
+
+export const baseAddress = '0x1234567890123456789012345678901234567890'
+
+export const openModalForDayMock = vi.fn()
+
+export const createWeeklyClaim = (overrides: Record<string, unknown> = {}) => ({
+  ...mockWeeklyClaimData[0],
+  weekStart: '2024-01-01T00:00:00.000Z',
+  signature: null,
+  status: 'pending',
+  claims: [{ ...mockWeeklyClaimData[0]?.claims[0], dayWorked: '2024-01-01T00:00:00.000Z' }],
+  wage: {
+    ...mockWeeklyClaimData[0]?.wage,
+    userAddress: baseAddress
+  },
+  ...overrides
+})
+
+export const makeGlobal = () => ({
+  stubs: {
+    SubmitClaims: defineComponent({
+      name: 'SubmitClaims',
+      props: {
+        signedWeekStarts: { type: Array, required: true }
+      },
+      setup(_, { expose }) {
+        expose({ openModalForDay: openModalForDayMock })
+        return {}
+      },
+      template: '<div data-test="submit-claims">{{ signedWeekStarts.length }}</div>'
+    }),
+    SubmitWeeklyGoals: {
+      name: 'SubmitWeeklyGoals',
+      props: ['weeklyClaim', 'selectedWeekStart'],
+      template: '<div data-test="submit-weekly-goals" />'
+    },
+    CRSigne: {
+      name: 'CRSigne',
+      props: ['disabled'],
+      template: '<div data-test="cr-signe">{{ disabled }}</div>'
+    },
+    CRWithdrawClaim: {
+      name: 'CRWithdrawClaim',
+      props: ['disabled'],
+      template: '<div data-test="cr-withdraw">{{ disabled }}</div>'
+    },
+    IconifyIcon: {
+      name: 'IconifyIcon',
+      template: '<span data-test="icon" />'
+    }
+  }
+})
+
+export const createWrapper = (props: Record<string, unknown> = {}) =>
+  renderWithProviders(ClaimHistoryActionAlerts, {
+    props: {
+      memberAddress: baseAddress,
+      ...props
+    },
+    global: makeGlobal()
+  })

--- a/app/src/components/sections/DashboardView/MemberSection.vue
+++ b/app/src/components/sections/DashboardView/MemberSection.vue
@@ -88,6 +88,15 @@
               {{ row.original.currentWage.maximumHoursPerDay + 'h/d' }}
             </span>
           </div>
+          <span
+            v-if="scheduledWageNotice(row.original.scheduledWage)"
+            class="mt-1.5 inline-flex max-w-full items-start gap-1 rounded-md bg-[#E6F1FB] px-2 py-1 text-left text-[11px] leading-tight font-medium text-wrap text-[#0C447C]"
+            title="Wage changes take effect at the start of the next week"
+            data-test="scheduled-wage-badge"
+          >
+            <UIcon name="i-heroicons-calendar" aria-hidden="true" class="mt-0.5 size-3 shrink-0" />
+            {{ scheduledWageNotice(row.original.scheduledWage) }}
+          </span>
         </div>
         <div v-else>—</div>
       </template>
@@ -145,6 +154,7 @@ import SetMemberWageModal from './SetMemberWageModal.vue'
 import RateDotList from '@/components/RateDotList.vue'
 import TeamArchivedTooltip from '@/components/TeamArchivedTooltip.vue'
 import { useTeamWriteGuard } from '@/composables/useTeamWriteGuard'
+import { formatScheduledWageNotice } from '@/utils/wageUtil'
 
 type MemberRow = Member & {
   index: number
@@ -154,6 +164,8 @@ const userDataStore = useUserDataStore()
 const toast = useToast()
 const teamStore = useTeamStore()
 const { isWriteDisabled, archivedTooltip } = useTeamWriteGuard()
+
+const scheduledWageNotice = (wage: Wage | null | undefined) => formatScheduledWageNotice(wage)
 
 const pauseWageTooltip = (wage: Wage | null | undefined) => {
   if (archivedTooltip.value) return archivedTooltip.value

--- a/app/src/components/sections/DashboardView/SetMemberWageModal.vue
+++ b/app/src/components/sections/DashboardView/SetMemberWageModal.vue
@@ -27,6 +27,21 @@
 
       <template #body>
         <div class="mt-1 space-y-4">
+          s
+          <UAlert
+            v-if="props.wage"
+            icon="i-heroicons-information-circle"
+            color="info"
+            variant="soft"
+            data-test="wage-effective-date-notice"
+            :title="`This change takes effect on ${effectiveDateLabel}.`"
+            :description="
+              scheduledWageNotice
+                ? `A change is already scheduled for that date (${scheduledWageNotice}). Saving replaces it without pushing the date back.`
+                : 'The current rate stays in force until then, including for claims backdated to earlier weeks.'
+            "
+          />
+
           <UStepper :items="items" v-model="currentStep" />
 
           <SetMemberWageStandardStep
@@ -62,6 +77,7 @@ import { useSetMemberWageMutation } from '@/queries/wage.queries'
 import type { Member, Wage, WageWithForm } from '@/types'
 import type { AxiosError } from 'axios'
 import { normalizeRatePerHour, buildRatePayload, DEFAULT_MAXIMUM_HOURS_PER_DAY } from '@/utils'
+import { formatScheduledWageNotice, nextEffectiveDateLabel } from '@/utils/wageUtil'
 import { useTeamWriteGuard } from '@/composables/useTeamWriteGuard'
 import { getAxiosErrorMessage } from '@/utils/httpErrorUtil'
 import type { StepperItem } from '@nuxt/ui'
@@ -104,6 +120,9 @@ const initialWage = (): WageWithForm => {
 }
 
 const wageData = ref<WageWithForm>(initialWage())
+
+const effectiveDateLabel = computed(() => nextEffectiveDateLabel())
+const scheduledWageNotice = computed(() => formatScheduledWageNotice(props.wage?.scheduledWage))
 
 const items = computed<StepperItem[]>(() =>
   wageData.value.enableOvertimeRules

--- a/app/src/composables/useClaimForm.ts
+++ b/app/src/composables/useClaimForm.ts
@@ -4,10 +4,12 @@ import type { CalendarDate, DateValue } from '@internationalized/date'
 import { z } from 'zod'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
+import isoWeek from 'dayjs/plugin/isoWeek'
 import type { ClaimFormData } from '@/types'
 import { DEFAULT_MAXIMUM_HOURS_PER_DAY } from '@/utils'
 
 dayjs.extend(utc)
+dayjs.extend(isoWeek)
 
 export interface ClaimFormFileData {
   fileName?: string

--- a/app/src/composables/useScheduledWageRefresh.ts
+++ b/app/src/composables/useScheduledWageRefresh.ts
@@ -1,0 +1,60 @@
+import { onScopeDispose, toValue, watch, type MaybeRefOrGetter } from 'vue'
+import { useQueryClient } from '@tanstack/vue-query'
+import { useDocumentVisibility } from '@vueuse/core'
+import { wageKeys, teamKeys } from '@/queries'
+import { msUntilWageEffective } from '@/utils/wageUtil'
+import type { Wage } from '@/types'
+
+/**
+ * Refresh wage data the moment a scheduled change takes effect.
+ *
+ * Wage changes land on Monday 00:00 UTC. Rather than polling, a single timer is
+ * armed for the exact moment the change becomes operative. Because a tab left
+ * open over the weekend can have its timers throttled or suspended, the queries
+ * are also invalidated when the document becomes visible again and the
+ * effective date has passed in the meantime.
+ */
+export function useScheduledWageRefresh(
+  scheduledWage: MaybeRefOrGetter<Wage | null | undefined>,
+  teamId: MaybeRefOrGetter<string | number | null>
+) {
+  const queryClient = useQueryClient()
+  const visibility = useDocumentVisibility()
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const clearTimer = () => {
+    if (timer) clearTimeout(timer)
+    timer = undefined
+  }
+
+  const invalidate = () => {
+    const id = toValue(teamId)
+    if (!id) return
+    queryClient.invalidateQueries({ queryKey: wageKeys.team(id) })
+    queryClient.invalidateQueries({ queryKey: teamKeys.detail(String(id)) })
+  }
+
+  watch(
+    [() => toValue(scheduledWage), visibility],
+    ([wage, isVisible]) => {
+      clearTimer()
+      if (!wage) return
+
+      const delay = msUntilWageEffective(wage)
+
+      // Already past its effective date: the cached wage is stale, so refresh
+      // as soon as the tab is being looked at.
+      if (delay === null) {
+        if (isVisible === 'visible') invalidate()
+        return
+      }
+
+      // setTimeout caps out at ~24.8 days; scheduled changes are at most a week
+      // away, so a single timer always covers the wait.
+      timer = setTimeout(invalidate, delay)
+    },
+    { immediate: true }
+  )
+
+  onScopeDispose(clearTimer)
+}

--- a/app/src/queries/wage.queries.ts
+++ b/app/src/queries/wage.queries.ts
@@ -96,6 +96,36 @@ export const useSetMemberWageMutation = createMutationHook<void, SetMemberWagePa
 })
 
 // ============================================================================
+// DELETE /wage/scheduled - Cancel a wage change that has not taken effect yet
+// ============================================================================
+
+export interface CancelScheduledWageParams {
+  queryParams: {
+    /** Team ID */
+    teamId: string | number
+    /** User wallet address */
+    userAddress: string
+  }
+}
+
+/**
+ * Cancel a scheduled wage change, leaving the current wage in force
+ *
+ * @endpoint DELETE /wage/scheduled
+ * @pathParams none
+ * @queryParams { teamId: string | number, userAddress: string }
+ * @body none
+ */
+export const useCancelScheduledWageMutation = createMutationHook<void, CancelScheduledWageParams>({
+  method: 'DELETE',
+  endpoint: 'wage/scheduled',
+  invalidateKeys: (params) => [
+    wageKeys.team(params.queryParams.teamId),
+    teamKeys.detail(String(params.queryParams.teamId))
+  ]
+})
+
+// ============================================================================
 // PUT /wage/{wageId} - Toggle wage status (disable / enable)
 // ============================================================================
 

--- a/app/src/types/cash-remuneration.ts
+++ b/app/src/types/cash-remuneration.ts
@@ -27,6 +27,7 @@ export interface Wage {
   maximumHoursPerDay?: number
   disabled: boolean
   nextWageId: number | null
+  effectiveFrom?: string | null // ISO date string
   createdAt: string // ISO date string
   updatedAt: string // ISO date string
   user?: User

--- a/app/src/types/cash-remuneration.ts
+++ b/app/src/types/cash-remuneration.ts
@@ -28,6 +28,7 @@ export interface Wage {
   disabled: boolean
   nextWageId: number | null
   effectiveFrom?: string | null // ISO date string
+  scheduledWage?: Wage | null
   createdAt: string // ISO date string
   updatedAt: string // ISO date string
   user?: User

--- a/app/src/types/member.ts
+++ b/app/src/types/member.ts
@@ -7,4 +7,5 @@ export interface Member {
   teamId: number
   imageUrl?: string
   currentWage?: Wage
+  scheduledWage?: Wage | null // Present when a wage change is scheduled for a future week.
 }

--- a/app/src/utils/__tests__/wageScheduling.spec.ts
+++ b/app/src/utils/__tests__/wageScheduling.spec.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatScheduledWageNotice,
+  msUntilWageEffective,
+  nextEffectiveDateLabel
+} from '@/utils/wageUtil'
+import type { Wage } from '@/types'
+import { NETWORK } from '@/constant'
+
+const wage = (overrides: Partial<Wage>): Wage =>
+  ({
+    id: 2,
+    teamId: 1,
+    userAddress: '0x0000000000000000000000000000000000000001',
+    ratePerHour: [{ type: 'usdc', amount: 25 }],
+    maximumHoursPerWeek: 40,
+    disabled: false,
+    nextWageId: null,
+    createdAt: '2026-08-12T00:00:00.000Z',
+    updatedAt: '2026-08-12T00:00:00.000Z',
+    ...overrides
+  }) as Wage
+
+describe('formatScheduledWageNotice', () => {
+  it('returns null when nothing is scheduled', () => {
+    expect(formatScheduledWageNotice(null)).toBeNull()
+    expect(formatScheduledWageNotice(undefined)).toBeNull()
+    expect(formatScheduledWageNotice(wage({ effectiveFrom: null }))).toBeNull()
+  })
+
+  it('returns null when the effective date is unparseable', () => {
+    expect(formatScheduledWageNotice(wage({ effectiveFrom: 'not-a-date' }))).toBeNull()
+  })
+
+  it('summarises the upcoming rate and its effective day', () => {
+    const notice = formatScheduledWageNotice(wage({ effectiveFrom: '2026-08-17T00:00:00.000Z' }))
+
+    expect(notice).toContain('USDC 25')
+    expect(notice).toContain('17')
+  })
+
+  it('includes the upcoming hour ceilings alongside the rate', () => {
+    // The caps can change with the rate, and showing only the rate hides half of
+    // what the member is about to be held to.
+    const notice = formatScheduledWageNotice(
+      wage({
+        effectiveFrom: '2026-08-17T00:00:00.000Z',
+        maximumHoursPerWeek: 20,
+        maximumHoursPerDay: 8
+      })
+    )
+
+    expect(notice).toContain('20h/wk')
+    expect(notice).toContain('8h/d')
+  })
+
+  it('omits the daily ceiling when the wage does not set one', () => {
+    const notice = formatScheduledWageNotice(
+      wage({
+        effectiveFrom: '2026-08-17T00:00:00.000Z',
+        maximumHoursPerWeek: 35,
+        maximumHoursPerDay: undefined
+      })
+    )
+
+    expect(notice).toContain('35h/wk')
+    expect(notice).not.toContain('h/d')
+  })
+
+  it('joins several token rates and drops the empty ones', () => {
+    const notice = formatScheduledWageNotice(
+      wage({
+        effectiveFrom: '2026-08-17T00:00:00.000Z',
+        ratePerHour: [
+          { type: 'usdc', amount: 25 },
+          { type: 'sher', amount: 10 },
+          { type: 'native', amount: 0 }
+        ]
+      })
+    )
+
+    expect(notice).toContain('USDC 25 + SHER 10')
+    expect(notice).not.toContain('NATIVE')
+  })
+
+  it('shows the chain symbol for the native token, never the raw type', () => {
+    // "NATIVE" is a database value; the table next to this badge renders the
+    // network ticker, and the two must agree.
+    const notice = formatScheduledWageNotice(
+      wage({
+        effectiveFrom: '2026-08-17T00:00:00.000Z',
+        ratePerHour: [{ type: 'native', amount: 10 }]
+      })
+    )
+
+    expect(notice).not.toContain('NATIVE')
+    expect(notice).toContain(`${NETWORK.currencySymbol} 10`)
+  })
+
+  it('words the change as a replacement of the current rate', () => {
+    const notice = formatScheduledWageNotice(wage({ effectiveFrom: '2026-08-17T00:00:00.000Z' }))
+
+    expect(notice).toMatch(/^Changes to /)
+  })
+
+  it('falls back to a generic label when there is nothing to spell out', () => {
+    const notice = formatScheduledWageNotice(
+      wage({
+        effectiveFrom: '2026-08-17T00:00:00.000Z',
+        ratePerHour: [],
+        maximumHoursPerWeek: 0,
+        maximumHoursPerDay: undefined
+      })
+    )
+
+    expect(notice).toMatch(/^Wage changes on /)
+  })
+})
+
+describe('msUntilWageEffective', () => {
+  const now = new Date('2026-08-12T12:00:00.000Z').getTime()
+
+  it('returns null when nothing is scheduled', () => {
+    expect(msUntilWageEffective(null, now)).toBeNull()
+  })
+
+  it('returns the remaining delay for a future change', () => {
+    const delay = msUntilWageEffective(wage({ effectiveFrom: '2026-08-17T00:00:00.000Z' }), now)
+
+    expect(delay).toBe(new Date('2026-08-17T00:00:00.000Z').getTime() - now)
+  })
+
+  it('returns null once the effective date has passed', () => {
+    expect(
+      msUntilWageEffective(wage({ effectiveFrom: '2026-08-10T00:00:00.000Z' }), now)
+    ).toBeNull()
+  })
+})
+
+describe('nextEffectiveDateLabel', () => {
+  it('points at the next Monday when called mid-week', () => {
+    // Wednesday 12 Aug 2026 -> Monday 17 Aug
+    expect(nextEffectiveDateLabel(new Date('2026-08-12T15:00:00.000Z'))).toContain('17')
+  })
+
+  it('points at the following Monday when called on a Monday', () => {
+    // A change made on Monday still lands on the *next* week's Monday, matching
+    // the server so the two never disagree.
+    expect(nextEffectiveDateLabel(new Date('2026-08-17T09:00:00.000Z'))).toContain('24')
+  })
+
+  it('points at the next day when called on a Sunday', () => {
+    expect(nextEffectiveDateLabel(new Date('2026-08-16T09:00:00.000Z'))).toContain('17')
+  })
+})

--- a/app/src/utils/wageUtil.ts
+++ b/app/src/utils/wageUtil.ts
@@ -6,6 +6,14 @@ import type {
   WeeklyClaim
 } from '@/types'
 import { parseEther, parseUnits, type Address } from 'viem'
+import dayjs from 'dayjs'
+import isoWeek from 'dayjs/plugin/isoWeek'
+import utc from 'dayjs/plugin/utc'
+import { formatDate, type DateInput } from '@/utils/format'
+import { NETWORK } from '@/constant'
+
+dayjs.extend(utc)
+dayjs.extend(isoWeek)
 
 const requiredRateTypes: RatePerHour['type'][] = ['native', 'usdc', 'sher']
 
@@ -20,6 +28,77 @@ export const formatMinutesAsDuration = (totalMinutes: number): string => {
   if (m === 0) return `${h}h`
   if (h === 0) return `${m}min`
   return `${h}h ${m}min`
+}
+
+/**
+ * Ticker shown for a rate. The `native` type is stored generically but has to be
+ * displayed as the chain's own symbol — "NATIVE" is a database value, not
+ * something a user recognises.
+ */
+export const rateSymbol = (type: string): string =>
+  type === 'native' ? NETWORK.currencySymbol : type.toUpperCase()
+
+/**
+ * Summarises a pending wage change for display, e.g.
+ * "Changes to SHER 10/h, 20h/wk, 8h/d on Aug 17, 2026".
+ *
+ * Covers the hour ceilings as well as the rate: a scheduled wage carries its own
+ * weekly and daily caps, and showing only the rate hides half of what is about
+ * to change.
+ *
+ * Worded as a replacement — the badge sits next to the wage in force, and
+ * "from <date>" alone reads as something being added rather than the current
+ * terms being superseded. Symbol precedes the amount to match `RateDotList`,
+ * the other place rates are displayed.
+ *
+ * Returns null when nothing is scheduled, so callers can `v-if` on the result.
+ */
+export const formatScheduledWageNotice = (scheduledWage?: Wage | null): string | null => {
+  if (!scheduledWage?.effectiveFrom) return null
+
+  const effectiveDate = dayjs(scheduledWage.effectiveFrom)
+  if (!effectiveDate.isValid()) return null
+
+  const rates = (scheduledWage.ratePerHour ?? [])
+    .filter((rate) => rate.amount > 0)
+    .map((rate) => `${rateSymbol(rate.type)} ${rate.amount}`)
+    .join(' + ')
+
+  const parts = [
+    rates ? `${rates}/h` : null,
+    scheduledWage.maximumHoursPerWeek ? `${scheduledWage.maximumHoursPerWeek}h/wk` : null,
+    scheduledWage.maximumHoursPerDay ? `${scheduledWage.maximumHoursPerDay}h/d` : null
+  ].filter(Boolean)
+
+  const day = formatDate(effectiveDate)
+
+  return parts.length ? `Changes to ${parts.join(', ')} on ${day}` : `Wage changes on ${day}`
+}
+
+/**
+ * The Monday a change made now would take effect on, formatted for display.
+ * Mirrors the server's `nextMondayUtc`, which anchors every wage change to the
+ * start of the next ISO week so a wage boundary never falls mid-week.
+ */
+export const nextEffectiveDateLabel = (now: DateInput = new Date()): string =>
+  formatDate(dayjs(now).utc().add(1, 'week').startOf('isoWeek'))
+
+/**
+ * Milliseconds until a scheduled wage takes effect, or null when there is
+ * nothing to wait for. Used to refresh the UI the moment the change lands
+ * instead of polling.
+ */
+export const msUntilWageEffective = (
+  scheduledWage?: Wage | null,
+  now: number = Date.now()
+): number | null => {
+  if (!scheduledWage?.effectiveFrom) return null
+
+  const effectiveAt = new Date(scheduledWage.effectiveFrom).getTime()
+  if (Number.isNaN(effectiveAt)) return null
+
+  const delay = effectiveAt - now
+  return delay > 0 ? delay : null
 }
 
 export const normalizeRatePerHour = (rates?: RatePerHour[] | null): RatePerHourWithEnabled[] => {

--- a/backend/prisma/migrations/20260812000000_wage_effective_from/migration.sql
+++ b/backend/prisma/migrations/20260812000000_wage_effective_from/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable: add effectiveFrom to Wage.
+-- NULL means the wage is effective immediately (legacy and normal case).
+-- A future timestamp means the wage is scheduled and the predecessor in the
+-- chain remains operative until that date.
+ALTER TABLE "Wage" ADD COLUMN "effectiveFrom" TIMESTAMP(3);

--- a/backend/prisma/migrations/20260812010000_wage_member_chain_index/migration.sql
+++ b/backend/prisma/migrations/20260812010000_wage_member_chain_index/migration.sql
@@ -1,0 +1,5 @@
+-- Resolving the wage that covers a given week reads a member's whole chain
+-- (`WHERE "teamId" = $1 AND "userAddress" = $2`), which now runs on every claim
+-- and every weekly-goals submission. Without this index that is a sequential
+-- scan over every wage of every team.
+CREATE INDEX IF NOT EXISTS "Wage_teamId_userAddress_idx" ON "Wage" ("teamId", "userAddress");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -113,6 +113,7 @@ model Wage {
   // Enforced by a deferrable EXCLUDE constraint (Wage_active_unique) in
   // migration 20260428_wage_active_deferrable. Deferrable so chained
   // create-and-relink can run inside a single transaction.
+  @@index([teamId, userAddress])
 }
 
 model Claim {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -100,6 +100,7 @@ model Wage {
   maximumHoursPerWeek         Int
   maximumHoursPerDay          Int           @default(8)
   disabled                    Boolean       @default(false)
+  effectiveFrom               DateTime?
   nextWageId                  Int?          @unique
   nextWage                    Wage?         @relation("wageRelated", fields: [nextWageId], references: [id], onDelete: SetNull)
   previousWage                Wage?         @relation("wageRelated")

--- a/backend/src/controllers/__tests__/claimController.test.ts
+++ b/backend/src/controllers/__tests__/claimController.test.ts
@@ -58,6 +58,15 @@ vi.mock('../../utils/cashRemunerationUtil', () => ({
   getCashRemunerationOwner: vi.fn(),
 }));
 
+// Mock the wage resolution utility so addClaim's resolveWageForWeek call
+// returns whatever we set up per-test via mockResolveWageForWeek.
+const { mockResolveWageForWeek } = vi.hoisted(() => ({
+  mockResolveWageForWeek: vi.fn(),
+}));
+vi.mock('../../utils/wageResolution', () => ({
+  resolveWageForWeek: mockResolveWageForWeek,
+}));
+
 // Mock the storage service
 const { mockGetPublicFileUrl, mockDeleteFile } = vi.hoisted(() => ({
   mockGetPublicFileUrl: vi.fn((key: string) => `https://storage.railway.app/test-bucket/${key}`),
@@ -241,7 +250,7 @@ describe('Claim Controller', () => {
     });
 
     it("should return 400 if user doesn't have wage", async () => {
-      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(null);
+      mockResolveWageForWeek.mockResolvedValue(null);
       const response = await request(app)
         .post('/')
         .send({ teamId: 1, minutesWorked: 300, memo: 'memo' });
@@ -256,9 +265,7 @@ describe('Claim Controller', () => {
         { id: 1, dayWorked: testDate, hoursWorked: 5, minutesWorked: 300 },
       ];
 
-      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(
-        createMockWage({ maximumHoursPerDay: 6 })
-      );
+      mockResolveWageForWeek.mockResolvedValue(createMockWage({ maximumHoursPerDay: 6 }));
       vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(modifiedWeeklyClaims);
 
       const response = await request(app).post('/').send({
@@ -281,7 +288,7 @@ describe('Claim Controller', () => {
         { id: 1, dayWorked: testDate, hoursWorked: 7, minutesWorked: 420 },
       ];
 
-      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(createMockWage());
+      mockResolveWageForWeek.mockResolvedValue(createMockWage());
       vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(modifiedWeeklyClaims);
 
       const response = await request(app).post('/').send({
@@ -302,9 +309,7 @@ describe('Claim Controller', () => {
         { id: 1, dayWorked: testDate, hoursWorked: 4, minutesWorked: 240 },
       ];
 
-      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(
-        createMockWage({ maximumHoursPerDay: 8 })
-      );
+      mockResolveWageForWeek.mockResolvedValue(createMockWage({ maximumHoursPerDay: 8 }));
       vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(modifiedWeeklyClaims);
       vi.spyOn(prisma.claim, 'create').mockResolvedValue(createMockClaim());
 
@@ -320,7 +325,7 @@ describe('Claim Controller', () => {
 
     it('should return 400 when SUBMIT_RESTRICTION is active and dayWorked is outside the allowed window', async () => {
       vi.mocked(getEffectiveStatus).mockResolvedValueOnce('enabled');
-      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(createMockWage());
+      mockResolveWageForWeek.mockResolvedValue(createMockWage());
 
       const outOfWindow = dayjs.utc().subtract(10, 'day').startOf('day').toISOString();
       const response = await request(app)
@@ -333,7 +338,7 @@ describe('Claim Controller', () => {
 
     it('should allow submission outside the window when SUBMIT_RESTRICTION is disabled', async () => {
       vi.mocked(getEffectiveStatus).mockResolvedValueOnce('disabled');
-      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(createMockWage());
+      mockResolveWageForWeek.mockResolvedValue(createMockWage());
       vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(null);
       vi.spyOn(prisma.weeklyClaim, 'create').mockResolvedValue(createMockWeeklyClaim());
       vi.spyOn(prisma.claim, 'create').mockResolvedValue(createMockClaim());
@@ -351,7 +356,7 @@ describe('Claim Controller', () => {
       const mockWeeklyClaims = createMockWeeklyClaim();
       const mockClaim = createMockClaim();
 
-      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(mockWage);
+      mockResolveWageForWeek.mockResolvedValue(mockWage);
       vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(null);
       vi.spyOn(prisma.weeklyClaim, 'create').mockResolvedValue(mockWeeklyClaims);
       vi.spyOn(prisma.claim, 'create').mockResolvedValue(mockClaim);
@@ -376,7 +381,7 @@ describe('Claim Controller', () => {
       const mockWeeklyClaims = createMockWeeklyClaim();
       const mockClaim = createMockClaim();
 
-      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(mockWage);
+      mockResolveWageForWeek.mockResolvedValue(mockWage);
       vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(mockWeeklyClaims);
       const createSpy = vi.spyOn(prisma.claim, 'create').mockResolvedValue(mockClaim);
 
@@ -398,7 +403,7 @@ describe('Claim Controller', () => {
     it('should return 409 if the claim is already signed', async () => {
       const mockWage = createMockWage();
       const mockWeeklyClaims = createMockWeeklyClaim({ status: 'signed', signature: '0xabc' });
-      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(mockWage);
+      mockResolveWageForWeek.mockResolvedValue(mockWage);
       vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(mockWeeklyClaims);
       const response = await request(app)
         .post('/')
@@ -410,7 +415,7 @@ describe('Claim Controller', () => {
     it('should return 409 if the claim is already disabled', async () => {
       const mockWage = createMockWage();
       const mockWeeklyClaims = createMockWeeklyClaim({ status: 'disabled' });
-      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(mockWage);
+      mockResolveWageForWeek.mockResolvedValue(mockWage);
       vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(mockWeeklyClaims);
       const response = await request(app)
         .post('/')
@@ -422,7 +427,7 @@ describe('Claim Controller', () => {
     it('should return 409 if the claim is already withdrawn', async () => {
       const mockWage = createMockWage();
       const mockWeeklyClaims = createMockWeeklyClaim({ status: 'withdrawn' });
-      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(mockWage);
+      mockResolveWageForWeek.mockResolvedValue(mockWage);
       vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(mockWeeklyClaims);
       const response = await request(app)
         .post('/')
@@ -436,7 +441,7 @@ describe('Claim Controller', () => {
       const mockWeeklyClaims = createMockWeeklyClaim();
       const mockClaim = createMockClaim();
 
-      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(mockWage);
+      mockResolveWageForWeek.mockResolvedValue(mockWage);
       vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(mockWeeklyClaims);
       vi.spyOn(prisma.claim, 'create').mockResolvedValue(mockClaim);
 
@@ -455,7 +460,7 @@ describe('Claim Controller', () => {
     });
 
     it('should return 500 if internal server error occurs', async () => {
-      vi.spyOn(prisma.wage, 'findFirst').mockRejectedValue(new Error('DB error'));
+      mockResolveWageForWeek.mockRejectedValue(new Error('DB error'));
 
       const response = await request(app)
         .post('/')
@@ -481,7 +486,7 @@ describe('Claim Controller', () => {
           ],
         });
 
-        vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(mockWage);
+        mockResolveWageForWeek.mockResolvedValue(mockWage);
         vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(mockWeeklyClaim);
         const createSpy = vi.spyOn(prisma.claim, 'create').mockResolvedValue(mockClaim);
 

--- a/backend/src/controllers/__tests__/wageController.test.ts
+++ b/backend/src/controllers/__tests__/wageController.test.ts
@@ -18,6 +18,7 @@ vi.mock('../../utils', async () => {
       findMany: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
+      delete: vi.fn(),
     },
   };
   prismaMock.$transaction = vi.fn(async (cb: (tx: unknown) => unknown) => cb(prismaMock));
@@ -71,6 +72,9 @@ const mockWage = {
   createdAt: new Date(),
   updatedAt: new Date(),
 } as unknown as Wage;
+
+/** A date comfortably inside the next ISO week, so the wage reads as scheduled. */
+const futureDate = () => new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
 
 describe('Wage Controller', () => {
   describe('PUT: /setWage', () => {
@@ -477,6 +481,124 @@ describe('Wage Controller', () => {
 
       expect(response.status).toBe(201);
     });
+
+    const validBody = {
+      teamId: 1,
+      userAddress: '0x1234567890123456789012345678901234567890',
+      ratePerHour: [{ type: 'cash', amount: 60 }],
+      maximumHoursPerWeek: 40,
+    };
+
+    it('should defer a change to an existing wage to the next Monday', async () => {
+      // A wage boundary must never fall mid-week, otherwise two WeeklyClaims can
+      // cover the same week under different wages (issue #2479).
+      vi.spyOn(prisma.team, 'findFirst').mockResolvedValue(mockTeam);
+      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(mockWage);
+      const createSpy = vi.spyOn(prisma.wage, 'create').mockResolvedValue({
+        ...mockWage,
+        id: 2,
+      } as Wage);
+      vi.spyOn(prisma.wage, 'update').mockResolvedValue(mockWage);
+
+      const response = await request(app).put('/setWage').send(validBody);
+
+      expect(response.status).toBe(201);
+      const effectiveFrom = createSpy.mock.calls[0][0].data.effectiveFrom as Date;
+      expect(effectiveFrom.getUTCDay()).toBe(1);
+      expect(effectiveFrom.getUTCHours()).toBe(0);
+      expect(effectiveFrom.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('should apply the very first wage immediately', async () => {
+      vi.spyOn(prisma.team, 'findFirst').mockResolvedValue(mockTeam);
+      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(null);
+      vi.spyOn(prisma.wage, 'findMany').mockResolvedValue([]);
+      const createSpy = vi.spyOn(prisma.wage, 'create').mockResolvedValue(mockWage);
+
+      const response = await request(app).put('/setWage').send(validBody);
+
+      expect(response.status).toBe(201);
+      expect(createSpy.mock.calls[0][0].data).not.toHaveProperty('effectiveFrom');
+    });
+
+    it('should rewrite a scheduled wage in place without moving its effective date', async () => {
+      // Correcting a typo before Monday must not push the change back a week,
+      // nor leave a dead link in the chain.
+      vi.spyOn(prisma.team, 'findFirst').mockResolvedValue(mockTeam);
+      vi.spyOn(prisma.wage, 'findFirst')
+        .mockResolvedValueOnce({ ...mockWage, id: 2, effectiveFrom: futureDate() } as Wage)
+        .mockResolvedValueOnce({ ...mockWage, id: 1, nextWageId: 2 } as Wage);
+      const updateSpy = vi.spyOn(prisma.wage, 'update').mockResolvedValue(mockWage);
+      const createSpy = vi.spyOn(prisma.wage, 'create');
+
+      const response = await request(app).put('/setWage').send(validBody);
+
+      expect(response.status).toBe(200);
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 2 } }));
+      expect(updateSpy.mock.calls[0][0].data).not.toHaveProperty('effectiveFrom');
+    });
+
+    it('should refuse to rewrite a scheduled wage when the active one is disabled', async () => {
+      vi.spyOn(prisma.team, 'findFirst').mockResolvedValue(mockTeam);
+      vi.spyOn(prisma.wage, 'findFirst')
+        .mockResolvedValueOnce({ ...mockWage, id: 2, effectiveFrom: futureDate() } as Wage)
+        .mockResolvedValueOnce({ ...mockWage, id: 1, nextWageId: 2, disabled: true } as Wage);
+
+      const response = await request(app).put('/setWage').send(validBody);
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe('Cannot set wage: the current wage is disabled');
+    });
+  });
+
+  describe('DELETE: /scheduled', () => {
+    const query = { teamId: 1, userAddress: '0x1234567890123456789012345678901234567890' };
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockAuthorizeUser.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        req.address = '0x1234567890123456789012345678901234567890';
+        next();
+      });
+      vi.spyOn(prisma.team, 'findUnique').mockResolvedValue({ ...mockTeam, isArchived: false });
+    });
+
+    it('should unlink and delete the scheduled wage, leaving the predecessor in force', async () => {
+      const predecessor = { ...mockWage, id: 1, nextWageId: 2 } as Wage;
+      vi.spyOn(prisma.wage, 'findFirst')
+        .mockResolvedValueOnce({ ...mockWage, id: 2, effectiveFrom: futureDate() } as Wage)
+        .mockResolvedValueOnce(predecessor);
+      const updateSpy = vi.spyOn(prisma.wage, 'update').mockResolvedValue(predecessor);
+      const deleteSpy = vi.spyOn(prisma.wage, 'delete').mockResolvedValue(mockWage);
+
+      const response = await request(app).delete('/scheduled').query(query);
+
+      expect(response.status).toBe(200);
+      expect(updateSpy).toHaveBeenCalledWith({ where: { id: 1 }, data: { nextWageId: null } });
+      expect(deleteSpy).toHaveBeenCalledWith({ where: { id: 2 } });
+      expect(response.body).toMatchObject({ id: 1 });
+    });
+
+    it('should return 404 when the leaf wage is already in force', async () => {
+      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue({
+        ...mockWage,
+        effectiveFrom: null,
+      } as Wage);
+
+      const response = await request(app).delete('/scheduled').query(query);
+
+      expect(response.status).toBe(404);
+      expect(response.body.message).toBe('No scheduled wage change to cancel');
+    });
+
+    it('should return 404 when the member has no wage at all', async () => {
+      vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(null);
+
+      const response = await request(app).delete('/scheduled').query(query);
+
+      expect(response.status).toBe(404);
+    });
   });
 
   describe('GET: /', () => {
@@ -538,6 +660,49 @@ describe('Wage Controller', () => {
 
       expect(response.status).toBe(500);
       expect(response.body.message).toContain('Internal server error');
+    });
+
+    it('should surface the active wage, not the scheduled one, when a change is pending', async () => {
+      // The claim form validates against this payload, so it must carry the
+      // rates and caps that apply right now — never the upcoming ones.
+      vi.spyOn(prisma.team, 'findFirst').mockResolvedValue(mockTeam);
+
+      const activeWage = {
+        ...mockWage,
+        id: 1,
+        maximumHoursPerWeek: 40,
+        effectiveFrom: null,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        nextWageId: 2,
+      };
+      const scheduledLeaf = {
+        ...mockWage,
+        id: 2,
+        maximumHoursPerWeek: 45,
+        effectiveFrom: futureDate(),
+      };
+
+      // The endpoint reads the whole chain and splits it in memory.
+      vi.spyOn(prisma.wage, 'findMany').mockResolvedValue([activeWage, scheduledLeaf] as never);
+
+      const response = await request(app).get('/').query({ teamId: 1 });
+
+      expect(response.status).toBe(200);
+      expect(response.body[0]).toMatchObject({ id: 1, maximumHoursPerWeek: 40 });
+      expect(response.body[0].scheduledWage).toMatchObject({ id: 2, maximumHoursPerWeek: 45 });
+    });
+
+    it('should return the leaf with a null scheduledWage when no change is pending', async () => {
+      vi.spyOn(prisma.team, 'findFirst').mockResolvedValue(mockTeam);
+      vi.spyOn(prisma.wage, 'findMany').mockResolvedValue([
+        { ...mockWage, effectiveFrom: null, createdAt: new Date('2026-01-01') } as never,
+      ]);
+
+      const response = await request(app).get('/').query({ teamId: 1 });
+
+      expect(response.status).toBe(200);
+      expect(response.body[0]).toMatchObject({ id: 1 });
+      expect(response.body[0].scheduledWage).toBeNull();
     });
 
     it('should return wages with null maximumOvertimeHoursPerWeek for legacy records', async () => {

--- a/backend/src/controllers/__tests__/weeklyClaimController.test.ts
+++ b/backend/src/controllers/__tests__/weeklyClaimController.test.ts
@@ -72,6 +72,14 @@ vi.mock('../../utils/viem.config', () => ({
   default: { readContract: readContractMock },
 }));
 
+// Mock the wage resolution utility used by submitWeeklyGoals.
+const { mockResolveWageForWeek } = vi.hoisted(() => ({
+  mockResolveWageForWeek: vi.fn(),
+}));
+vi.mock('../../utils/wageResolution', () => ({
+  resolveWageForWeek: mockResolveWageForWeek,
+}));
+
 // Mock viem's recoverTypedDataAddress so tests can drive the recovery result
 // (matching CALLER vs mismatch vs throw) without producing real signatures.
 // vi.mock is hoisted; the inline 0x1234...7890 mirrors the CALLER constant.
@@ -1028,7 +1036,7 @@ describe('Weekly Claim Controller', () => {
     const currentWage = { id: 7, teamId: 1, userAddress: CALLER, nextWageId: null };
 
     it('creates a claim-less weekly claim when none exists yet', async () => {
-      vi.mocked(prisma.wage.findFirst).mockResolvedValue(currentWage as never);
+      mockResolveWageForWeek.mockResolvedValue(currentWage);
       vi.mocked(prisma.weeklyClaim.findFirst).mockResolvedValue(null as never);
       vi.mocked(prisma.weeklyClaim.create).mockResolvedValue(
         weeklyClaimFactory({ id: 42, weeklyGoals: GOALS_BODY.weeklyGoals }) as never
@@ -1052,7 +1060,7 @@ describe('Weekly Claim Controller', () => {
     });
 
     it('updates the memo on an existing pending weekly claim', async () => {
-      vi.mocked(prisma.wage.findFirst).mockResolvedValue(currentWage as never);
+      mockResolveWageForWeek.mockResolvedValue(currentWage);
       vi.mocked(prisma.weeklyClaim.findFirst).mockResolvedValue(
         weeklyClaimFactory({ id: 5, status: 'pending', signature: null }) as never
       );
@@ -1071,7 +1079,7 @@ describe('Weekly Claim Controller', () => {
     });
 
     it('rejects with 409 when the week is already signed', async () => {
-      vi.mocked(prisma.wage.findFirst).mockResolvedValue(currentWage as never);
+      mockResolveWageForWeek.mockResolvedValue(currentWage);
       vi.mocked(prisma.weeklyClaim.findFirst).mockResolvedValue(
         weeklyClaimFactory({ id: 5, status: 'signed', signature: '0xabc' }) as never
       );
@@ -1084,7 +1092,7 @@ describe('Weekly Claim Controller', () => {
     });
 
     it('returns 400 when the caller has no current wage', async () => {
-      vi.mocked(prisma.wage.findFirst).mockResolvedValue(null as never);
+      mockResolveWageForWeek.mockResolvedValue(null);
 
       const response = await request(app).put('/goals').send(GOALS_BODY);
 

--- a/backend/src/controllers/claimController.ts
+++ b/backend/src/controllers/claimController.ts
@@ -23,6 +23,7 @@ import {
   isSubmitRestricted,
   SUBMIT_RESTRICTION_MAX_DAYS_BACK,
 } from '../utils/featureUtils';
+import { resolveWageForWeek } from '../utils/wageResolution';
 
 dayjs.extend(utc);
 dayjs.extend(isoWeek);
@@ -114,10 +115,7 @@ export const addClaim = async (req: Request, res: Response) => {
   const weekStart = dayjs.utc(dayWorked).startOf('isoWeek').toDate(); // Monday 00:00 UTC
 
   try {
-    // Get user current
-    const wage = await prisma.wage.findFirst({
-      where: { userAddress: callerAddress, nextWageId: null, teamId: teamId },
-    });
+    const wage = await resolveWageForWeek(teamId, callerAddress, weekStart);
 
     if (!wage) {
       return errorResponse(400, 'No wage found for the user', res);
@@ -139,14 +137,10 @@ export const addClaim = async (req: Request, res: Response) => {
       );
     }
 
-    // get the member current wage
-
+    // Find the weekly claim for the active wage and current week.
     let weeklyClaim = await prisma.weeklyClaim.findFirst({
       where: {
-        wage: {
-          teamId: teamId,
-          nextWageId: null,
-        },
+        wageId: wage.id,
         weekStart: weekStart,
         memberAddress: callerAddress,
         teamId: teamId,

--- a/backend/src/controllers/teamController.ts
+++ b/backend/src/controllers/teamController.ts
@@ -7,6 +7,7 @@ import { resolveStorageImageUrl } from '../utils/profileImage.util';
 import { generateUniqueSlug } from '../utils/slug.util';
 import { isActiveOfficerVersion } from '../utils/officerVersion';
 import { isAdmin } from '../utils/roleUtils';
+import { splitCurrentAndScheduled } from '../utils/wageResolution';
 import { UserRoles } from '../types/roles';
 
 // A slug is taken when some team already holds it.
@@ -91,13 +92,13 @@ const withCurrentOfficerAndContracts = <
 };
 
 // The team list card shows the viewer's own wage status ("Wage set" vs "No wage
-// set"), not the whole roster's. Fetch just the caller's active wage (the row
-// with no successor) across the listed teams in a single query and index it by
-// team, so the list stays one extra query rather than one per team.
+// set"), not the whole roster's. Fetch the caller's leaf wages across the
+// listed teams in a single query, then resolve to the active wage when a
+// scheduled change exists (effectiveFrom in the future).
 const findCallerWagesByTeamId = async (callerAddress: string, teamIds: number[]) => {
   if (teamIds.length === 0) return new Map<number, Wage>();
 
-  const wages = await prisma.wage.findMany({
+  const leafWages = await prisma.wage.findMany({
     where: {
       userAddress: callerAddress,
       teamId: { in: teamIds },
@@ -105,7 +106,30 @@ const findCallerWagesByTeamId = async (callerAddress: string, teamIds: number[])
     },
   });
 
-  return new Map(wages.map((wage) => [wage.teamId, wage]));
+  const now = new Date();
+  const scheduledLeafIds = leafWages
+    .filter((w) => w.effectiveFrom && w.effectiveFrom > now)
+    .map((w) => w.id);
+
+  // When some leaves are scheduled, batch-fetch their predecessors.
+  let predecessorMap = new Map<number, Wage>();
+  if (scheduledLeafIds.length > 0) {
+    const predecessors = await prisma.wage.findMany({
+      where: {
+        userAddress: callerAddress,
+        nextWageId: { in: scheduledLeafIds },
+      },
+    });
+    predecessorMap = new Map(predecessors.map((p) => [p.nextWageId!, p]));
+  }
+
+  const result = new Map<number, Wage>();
+  for (const leaf of leafWages) {
+    const isScheduled = leaf.effectiveFrom && leaf.effectiveFrom > now;
+    const activeWage = isScheduled ? (predecessorMap.get(leaf.id) ?? leaf) : leaf;
+    result.set(activeWage.teamId, activeWage);
+  }
+  return result;
 };
 
 // Create a new team
@@ -226,10 +250,11 @@ const getTeam = async (req: Request, res: Response) => {
             imageUrl: true,
             Wage: {
               where: {
-                teamId: Number(id), // wage de cette équipe uniquement
-                nextWageId: null, // nextWageId null = wage actuel (pas de successeur)
+                teamId: Number(id),
               },
-              take: 1,
+              orderBy: {
+                id: 'asc',
+              },
             },
           },
         },
@@ -249,13 +274,18 @@ const getTeam = async (req: Request, res: Response) => {
       return errorResponse(403, 'Unauthorized', res);
     }
 
+    const now = new Date();
     const membersWithResolvedImages = await Promise.all(
-      team.members.map(async (member) => ({
-        ...member,
-        imageUrl: await resolveStorageImageUrl(member.imageUrl),
-        currentWage: member.Wage[0] ?? null, // aplatir le tableau
-        Wage: undefined, // retirer le tableau brut
-      }))
+      team.members.map(async (member) => {
+        const { current, scheduled } = splitCurrentAndScheduled(member.Wage, now);
+        return {
+          ...member,
+          imageUrl: await resolveStorageImageUrl(member.imageUrl),
+          currentWage: current,
+          scheduledWage: scheduled,
+          Wage: undefined,
+        };
+      })
     );
 
     const callerMemberData = await prisma.memberTeamsData.findUnique({

--- a/backend/src/controllers/wageController.ts
+++ b/backend/src/controllers/wageController.ts
@@ -3,7 +3,9 @@ import { Request, Response } from 'express';
 import { Prisma } from '@prisma/client';
 import { prisma } from '../utils';
 import { errorResponse } from '../utils/utils';
+import { isScheduledWage, nextMondayUtc, splitCurrentAndScheduled } from '../utils/wageResolution';
 import {
+  cancelScheduledWageQuerySchema,
   getWagesQuerySchema,
   setWageBodySchema,
   toggleWageStatusParamsSchema,
@@ -42,8 +44,8 @@ export const setWage = async (req: Request, res: Response) => {
   try {
     // authz enforced by requireTeamOwner middleware
 
-    // Check if the user has a current wage
-    const currentWage = await prisma.wage.findFirst({
+    // Find the leaf of the wage chain (the most recent wage record).
+    const leafWage = await prisma.wage.findFirst({
       where: {
         teamId,
         userAddress,
@@ -51,18 +53,41 @@ export const setWage = async (req: Request, res: Response) => {
       },
     });
 
-    if (currentWage) {
-      if (currentWage.disabled) {
+    if (leafWage) {
+      if (isScheduledWage(leafWage)) {
+        const activePredecessor = await prisma.wage.findFirst({
+          where: { teamId, userAddress, nextWageId: leafWage.id },
+        });
+
+        if (activePredecessor?.disabled) {
+          return errorResponse(400, 'Cannot set wage: the current wage is disabled', res);
+        }
+
+        const updatedWage = await prisma.wage.update({
+          where: { id: leafWage.id },
+          data: wagePayload,
+        });
+        return res.status(200).json(updatedWage);
+      }
+
+      // The leaf is the currently active wage.
+      const activeWage = leafWage;
+
+      if (activeWage.disabled) {
         return errorResponse(400, 'Cannot set wage: the current wage is disabled', res);
       }
+
+      const effectiveFrom = nextMondayUtc();
 
       // Create wage and chain it to the previous wage. Done in a transaction
       // so the deferrable Wage_active_unique constraint is checked at COMMIT,
       // after the old wage's nextWageId has been set.
       const createdWage = await prisma.$transaction(async (tx) => {
-        const newWage = await tx.wage.create({ data: wagePayload });
+        const newWage = await tx.wage.create({
+          data: { ...wagePayload, effectiveFrom },
+        });
         await tx.wage.update({
-          where: { id: currentWage.id },
+          where: { id: activeWage.id },
           data: { nextWageId: newWage.id },
         });
         return newWage;
@@ -96,21 +121,81 @@ export const getWages = async (req: Request, res: Response) => {
 
   try {
     // authz enforced by requireTeamMember middleware
-    const wages = await prisma.wage.findMany({
-      where: {
-        teamId,
-        nextWageId: null,
-      },
-      include: {
-        previousWage: {
-          select: {
-            id: true,
-          },
-        },
-      },
+    //
+    // Callers use this endpoint to know the rates and caps that apply right now
+    // — the claim form validates against them — so the operative wage is
+    // returned at the top level with any upcoming change attached as
+    // `scheduledWage`.
+    //
+    // The whole chain is fetched in one query and split in memory: resolving
+    // per member would issue a query each, and reading the leaf directly would
+    // let the screen disagree with what the claim engine charges.
+    const allWages = await prisma.wage.findMany({
+      where: { teamId },
+      orderBy: { id: 'asc' },
+    });
+
+    const chainsByMember = new Map<string, typeof allWages>();
+    for (const wage of allWages) {
+      const chain = chainsByMember.get(wage.userAddress);
+      if (chain) chain.push(wage);
+      else chainsByMember.set(wage.userAddress, [wage]);
+    }
+
+    const now = new Date();
+    const wages = Array.from(chainsByMember.values()).flatMap((chain) => {
+      const { current, scheduled } = splitCurrentAndScheduled(chain, now);
+      return current ? [{ ...current, scheduledWage: scheduled }] : [];
     });
 
     return res.status(200).json(wages);
+  } catch (error) {
+    console.log('Error: ', error);
+    return errorResponse(500, 'Internal server error', res);
+  }
+};
+
+/**
+ * Cancel a wage change that was scheduled but has not taken effect yet.
+ *
+ * The scheduled row is deleted and the predecessor becomes the leaf again, so
+ * the chain returns to exactly the state it had before the change was made.
+ * Refused once the change is live — claims may already reference it by then.
+ */
+export const cancelScheduledWage = async (req: Request, res: Response) => {
+  const { teamId, userAddress } = req.query as unknown as z.infer<
+    typeof cancelScheduledWageQuerySchema
+  >;
+
+  try {
+    // authz enforced by requireTeamOwner middleware
+    const leafWage = await prisma.wage.findFirst({
+      where: { teamId, userAddress, nextWageId: null },
+    });
+
+    if (!leafWage || !isScheduledWage(leafWage)) {
+      return errorResponse(404, 'No scheduled wage change to cancel', res);
+    }
+
+    const predecessor = await prisma.wage.findFirst({
+      where: { teamId, userAddress, nextWageId: leafWage.id },
+    });
+
+    if (!predecessor) {
+      return errorResponse(409, 'Cannot cancel: the scheduled wage has no predecessor', res);
+    }
+
+    // Unlink before deleting so the deferrable Wage_active_unique constraint
+    // never sees two active leaves at once.
+    await prisma.$transaction(async (tx) => {
+      await tx.wage.update({
+        where: { id: predecessor.id },
+        data: { nextWageId: null },
+      });
+      await tx.wage.delete({ where: { id: leafWage.id } });
+    });
+
+    return res.status(200).json(predecessor);
   } catch (error) {
     console.log('Error: ', error);
     return errorResponse(500, 'Internal server error', res);
@@ -123,8 +208,22 @@ export const toggleWageStatus = async (req: Request, res: Response) => {
   const { action } = req.query as unknown as z.infer<typeof toggleWageStatusQuerySchema>;
 
   try {
+    // Allow toggling the leaf wage **or** the active predecessor when a
+    // scheduled wage exists (the predecessor's nextWageId points to the
+    // scheduled leaf whose effectiveFrom is in the future).
     const wage = await prisma.wage.findFirst({
-      where: { id: wageId, nextWageId: null },
+      where: {
+        id: wageId,
+        OR: [
+          { nextWageId: null },
+          {
+            nextWage: {
+              nextWageId: null,
+              effectiveFrom: { gt: new Date() },
+            },
+          },
+        ],
+      },
       include: { team: { select: { ownerAddress: true } } },
     });
 

--- a/backend/src/controllers/weeklyClaimController.ts
+++ b/backend/src/controllers/weeklyClaimController.ts
@@ -14,6 +14,7 @@ import publicClient from '../utils/viem.config';
 import { refreshAttachmentUrls } from '../services/attachmentService';
 import { resolveStorageImageUrl } from '../utils/profileImage.util';
 import { signWeeklyClaimBodySchema, z } from '../validation';
+import { resolveWageForWeek } from '../utils/wageResolution';
 
 type SignWeeklyClaimBody = z.infer<typeof signWeeklyClaimBodySchema>;
 
@@ -596,11 +597,10 @@ export const submitWeeklyGoals = async (req: Request, res: Response) => {
   const weekStart = dayjs.utc(weekStartInput).startOf('isoWeek').toDate();
 
   try {
-    // A WeeklyClaim requires a wageId, so the member needs a current wage
-    // before any goals can be recorded (mirrors addClaim).
-    const wage = await prisma.wage.findFirst({
-      where: { userAddress: callerAddress, nextWageId: null, teamId },
-    });
+    // A WeeklyClaim requires a wageId, so the member needs a wage before any
+    // goals can be recorded. Resolved against the target week so goals land on
+    // the same row as that week's claims (mirrors addClaim).
+    const wage = await resolveWageForWeek(teamId, callerAddress, weekStart);
 
     if (!wage) {
       return errorResponse(400, 'No wage found for the user', res);
@@ -608,7 +608,7 @@ export const submitWeeklyGoals = async (req: Request, res: Response) => {
 
     const existing = await prisma.weeklyClaim.findFirst({
       where: {
-        wage: { teamId, nextWageId: null },
+        wageId: wage.id,
         weekStart,
         memberAddress: callerAddress,
         teamId,

--- a/backend/src/routes/wageRoute.ts
+++ b/backend/src/routes/wageRoute.ts
@@ -1,5 +1,10 @@
 import express from 'express';
-import { getWages, setWage, toggleWageStatus } from '../controllers/wageController';
+import {
+  cancelScheduledWage,
+  getWages,
+  setWage,
+  toggleWageStatus,
+} from '../controllers/wageController';
 import {
   rejectIfArchived,
   requireTeamMember,
@@ -11,6 +16,7 @@ import {
   validateParamsAndQuery,
   setWageBodySchema,
   getWagesQuerySchema,
+  cancelScheduledWageQuerySchema,
   toggleWageStatusParamsSchema,
   toggleWageStatusQuerySchema,
 } from '../validation';
@@ -269,6 +275,54 @@ wageRoutes.get(
   validateQuery(getWagesQuerySchema),
   requireTeamMember('query.teamId'),
   getWages
+);
+
+/**
+ * @openapi
+ * /wage/scheduled:
+ *  delete:
+ *   summary: Cancel a scheduled wage change
+ *   tags: [Wages]
+ *   security:
+ *     - bearerAuth: []
+ *   description: Removes a wage change that was scheduled for a future week and has not taken effect yet. The previously active wage becomes current again.
+ *   parameters:
+ *     - in: query
+ *       name: teamId
+ *       required: true
+ *       schema:
+ *         type: integer
+ *         minimum: 1
+ *       description: The ID of the team
+ *     - in: query
+ *       name: userAddress
+ *       required: true
+ *       schema:
+ *         type: string
+ *         pattern: "^0x[a-fA-F0-9]{40}$"
+ *       description: The Ethereum address of the member
+ *   responses:
+ *     200:
+ *       description: Scheduled change cancelled; returns the wage that stays in force
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WageRecord'
+ *     403:
+ *       description: Forbidden - caller is not the owner of the team
+ *     404:
+ *       description: No scheduled wage change to cancel
+ *     409:
+ *       description: The scheduled wage has no predecessor
+ *     500:
+ *       description: Internal server error
+ */
+wageRoutes.delete(
+  '/scheduled',
+  validateQuery(cancelScheduledWageQuerySchema),
+  requireTeamOwner('query.teamId'),
+  rejectIfArchived('query.teamId'),
+  cancelScheduledWage
 );
 
 /**

--- a/backend/src/utils/__tests__/wageResolution.test.ts
+++ b/backend/src/utils/__tests__/wageResolution.test.ts
@@ -1,0 +1,165 @@
+import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+import utc from 'dayjs/plugin/utc';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  resolveWageForWeek,
+  resolveCurrentWage,
+  nextMondayUtc,
+  isScheduledWage,
+  pickWageForWeek,
+  splitCurrentAndScheduled,
+} from '../wageResolution';
+
+dayjs.extend(utc);
+dayjs.extend(isoWeek);
+
+vi.mock('../dependenciesUtil', () => ({
+  prisma: {
+    wage: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from '../dependenciesUtil';
+
+const week = (iso: string) => dayjs.utc(iso).startOf('isoWeek').toDate();
+const at = (iso: string) => new Date(iso);
+
+describe('wageResolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('resolveWageForWeek', () => {
+    it('returns null when the member has no wage at all', async () => {
+      vi.mocked(prisma.wage.findMany).mockResolvedValue([]);
+
+      expect(await resolveWageForWeek(1, '0xabc', week('2026-08-12'))).toBeNull();
+    });
+
+    it('returns the only wage when the chain has a single link', async () => {
+      const v1 = { id: 1, effectiveFrom: null, createdAt: at('2026-01-01T00:00:00Z') };
+      vi.mocked(prisma.wage.findMany).mockResolvedValue([v1] as never);
+
+      expect(await resolveWageForWeek(1, '0xabc', week('2026-08-12'))).toEqual(v1);
+    });
+
+    it('returns the old wage for a week that predates a scheduled change', async () => {
+      // v2 takes effect Mon 17 Aug; the claim targets the week of Mon 10 Aug.
+      const v1 = { id: 1, effectiveFrom: null, createdAt: at('2026-01-01T00:00:00Z') };
+      const v2 = { id: 2, effectiveFrom: at('2026-08-17T00:00:00Z'), createdAt: at('2026-08-12') };
+      vi.mocked(prisma.wage.findMany).mockResolvedValue([v1, v2] as never);
+
+      expect(await resolveWageForWeek(1, '0xabc', week('2026-08-12'))).toEqual(v1);
+    });
+
+    it('returns the new wage once its effective week has started', async () => {
+      const v1 = { id: 1, effectiveFrom: null, createdAt: at('2026-01-01T00:00:00Z') };
+      const v2 = { id: 2, effectiveFrom: at('2026-08-17T00:00:00Z'), createdAt: at('2026-08-12') };
+      vi.mocked(prisma.wage.findMany).mockResolvedValue([v1, v2] as never);
+
+      expect(await resolveWageForWeek(1, '0xabc', week('2026-08-18'))).toEqual(v2);
+    });
+
+    it('picks the right link when several changes have happened', async () => {
+      const v1 = { id: 1, effectiveFrom: null, createdAt: at('2026-01-01T00:00:00Z') };
+      const v2 = { id: 2, effectiveFrom: at('2026-08-10T00:00:00Z'), createdAt: at('2026-08-05') };
+      const v3 = { id: 3, effectiveFrom: at('2026-08-24T00:00:00Z'), createdAt: at('2026-08-19') };
+      vi.mocked(prisma.wage.findMany).mockResolvedValue([v1, v2, v3] as never);
+
+      // Backdating onto the week of Mon 10 Aug must land on v2, not v3.
+      expect(await resolveWageForWeek(1, '0xabc', week('2026-08-12'))).toEqual(v2);
+    });
+
+    it('falls back to the earliest wage for a week before any wage existed', async () => {
+      // Legacy rows carry createdAt only, which is a technical timestamp —
+      // rejecting here would break historical weeks that were legitimately
+      // claimed.
+      const v1 = { id: 1, effectiveFrom: null, createdAt: at('2026-08-10T00:00:00Z') };
+      vi.mocked(prisma.wage.findMany).mockResolvedValue([v1] as never);
+
+      expect(await resolveWageForWeek(1, '0xabc', week('2026-07-01'))).toEqual(v1);
+    });
+  });
+
+  describe('splitCurrentAndScheduled', () => {
+    const now = at('2026-08-12T15:00:00Z'); // a Wednesday; week starts Mon 10 Aug
+
+    it('reports no wage for an empty chain', () => {
+      expect(splitCurrentAndScheduled([], now)).toEqual({ current: null, scheduled: null });
+    });
+
+    it('separates the wage in force from the change queued behind it', () => {
+      const v1 = { id: 1, effectiveFrom: null, createdAt: at('2026-01-01T00:00:00Z') };
+      const v2 = { id: 2, effectiveFrom: at('2026-08-17T00:00:00Z'), createdAt: at('2026-08-12') };
+
+      expect(splitCurrentAndScheduled([v1, v2], now)).toEqual({ current: v1, scheduled: v2 });
+    });
+
+    it('reports nothing scheduled once the change has taken effect', () => {
+      const v1 = { id: 1, effectiveFrom: null, createdAt: at('2026-01-01T00:00:00Z') };
+      const v2 = { id: 2, effectiveFrom: at('2026-08-10T00:00:00Z'), createdAt: at('2026-08-05') };
+
+      expect(splitCurrentAndScheduled([v1, v2], now)).toEqual({ current: v2, scheduled: null });
+    });
+
+    it('agrees with the claim engine on a legacy mid-week change', () => {
+      // Rows predating `effectiveFrom` carry a mid-week `createdAt`. Reading the
+      // chain's leaf would show v2 while claims for this week are still priced
+      // on v1 — the screen and the server must not disagree.
+      const v1 = { id: 1, effectiveFrom: null, createdAt: at('2026-01-01T00:00:00Z') };
+      const v2 = { id: 2, effectiveFrom: null, createdAt: at('2026-08-12T09:00:00Z') };
+
+      const { current } = splitCurrentAndScheduled([v1, v2], now);
+
+      expect(current).toEqual(v1);
+      expect(current).toEqual(pickWageForWeek([v1, v2], week('2026-08-12')));
+    });
+  });
+
+  describe('resolveCurrentWage', () => {
+    it('ignores a wage scheduled for a future week', async () => {
+      const v1 = { id: 1, effectiveFrom: null, createdAt: at('2026-01-01T00:00:00Z') };
+      const v2 = { id: 2, effectiveFrom: at('2026-08-17T00:00:00Z'), createdAt: at('2026-08-12') };
+      vi.mocked(prisma.wage.findMany).mockResolvedValue([v1, v2] as never);
+
+      expect(await resolveCurrentWage(1, '0xabc', at('2026-08-12T15:00:00Z'))).toEqual(v1);
+    });
+  });
+
+  describe('nextMondayUtc', () => {
+    it('returns the next Monday at 00:00 UTC', () => {
+      const result = nextMondayUtc(at('2026-08-12T15:30:00.000Z')); // a Wednesday
+
+      expect(result.toISOString()).toBe('2026-08-17T00:00:00.000Z');
+    });
+
+    it('returns the following Monday even when called on a Monday', () => {
+      const result = nextMondayUtc(at('2026-08-17T10:00:00.000Z'));
+
+      expect(result.toISOString()).toBe('2026-08-24T00:00:00.000Z');
+    });
+  });
+
+  describe('isScheduledWage', () => {
+    const now = at('2026-08-12T12:00:00Z');
+
+    it('is false for a wage with no effectiveFrom', () => {
+      expect(isScheduledWage({ effectiveFrom: null }, now)).toBe(false);
+    });
+
+    it('is false once effectiveFrom has passed', () => {
+      expect(isScheduledWage({ effectiveFrom: at('2026-08-10T00:00:00Z') }, now)).toBe(false);
+    });
+
+    it('is true while effectiveFrom is still ahead', () => {
+      expect(isScheduledWage({ effectiveFrom: at('2026-08-17T00:00:00Z') }, now)).toBe(true);
+    });
+
+    it('is false for a missing wage', () => {
+      expect(isScheduledWage(null, now)).toBe(false);
+    });
+  });
+});

--- a/backend/src/utils/wageResolution.ts
+++ b/backend/src/utils/wageResolution.ts
@@ -1,0 +1,136 @@
+import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+import utc from 'dayjs/plugin/utc';
+import { prisma } from './dependenciesUtil';
+
+dayjs.extend(utc);
+dayjs.extend(isoWeek);
+
+type ChainedWage = { id: number; effectiveFrom: Date | null; createdAt: Date };
+
+/**
+ * The date a wage started (or will start) being operative.
+ *
+ * `effectiveFrom` is set when a change is deferred to a future Monday.  Wages
+ * created before that column existed — and the very first wage of a member —
+ * carry `null` and took effect the moment they were created.
+ */
+function effectiveAt(wage: ChainedWage): Date {
+  return wage.effectiveFrom ?? wage.createdAt;
+}
+
+/**
+ * Resolve the wage that was operative for a member during a given ISO week.
+ *
+ * The week worked determines the rate, never the date the claim is entered.
+ * A member catching up on a forgotten week is therefore paid — and capped — at
+ * the terms that were in force back then, and their claim lands on that week's
+ * existing WeeklyClaim instead of opening a second one under a newer wage
+ * (issue #2479).
+ *
+ * `weekStart` must be a Monday 00:00 UTC, matching how WeeklyClaim rows are
+ * keyed.  Wage changes are always anchored to a Monday, so exactly one wage
+ * covers any given week.
+ *
+ * When the week predates the member's first wage the earliest wage of the
+ * chain is returned rather than nothing: on legacy rows `createdAt` is a
+ * technical timestamp, not a business start date, so rejecting would break
+ * historical weeks that were legitimately claimed.
+ */
+export function pickWageForWeek<T extends ChainedWage>(wages: T[], weekStart: Date): T | null {
+  if (wages.length === 0) return null;
+
+  const operative = wages.filter((wage) => effectiveAt(wage) <= weekStart);
+
+  // Nothing had started yet: fall back to the earliest link rather than
+  // returning nothing (see the note on this function's async counterpart).
+  if (operative.length === 0) {
+    return wages.reduce((earliest, wage) => (wage.id < earliest.id ? wage : earliest));
+  }
+
+  // Ties are broken by id, which increases along the chain, so a wage created
+  // later always wins over one that shares its effective date.
+  return operative.reduce((latest, wage) =>
+    effectiveAt(wage) > effectiveAt(latest) ||
+    (effectiveAt(wage).getTime() === effectiveAt(latest).getTime() && wage.id > latest.id)
+      ? wage
+      : latest
+  );
+}
+
+export async function resolveWageForWeek(teamId: number, userAddress: string, weekStart: Date) {
+  // Chains are a handful of rows at most, and ids increase along the chain
+  // because each link is appended after the previous one.
+  const wages = await prisma.wage.findMany({
+    where: { teamId, userAddress },
+    orderBy: { id: 'asc' },
+  });
+
+  return pickWageForWeek(wages, weekStart);
+}
+
+/**
+ * Start of the ISO week (Monday 00:00 UTC) containing `now` — the week whose
+ * wage is currently operative.
+ */
+export function currentWeekStart(now?: Date): Date {
+  return dayjs
+    .utc(now ?? new Date())
+    .startOf('isoWeek')
+    .toDate();
+}
+
+/**
+ * Split a member's wage chain into the wage in force this week and the change
+ * queued behind it, using the same rule the claim engine applies.
+ *
+ * Deriving both from `pickWageForWeek` is what keeps the screen and the server
+ * in agreement. Reading the chain's leaf directly instead looks equivalent but
+ * is not: rows predating `effectiveFrom` carry a mid-week `createdAt`, so the
+ * leaf can already be displayed as current while claims for this week are still
+ * being priced on its predecessor.
+ */
+export function splitCurrentAndScheduled<T extends ChainedWage>(wages: T[], now?: Date) {
+  const reference = now ?? new Date();
+  const current = pickWageForWeek(wages, currentWeekStart(reference));
+
+  if (!current) return { current: null, scheduled: null };
+
+  const scheduled =
+    wages.find((wage) => wage.id !== current.id && isScheduledWage(wage, reference)) ?? null;
+
+  return { current, scheduled };
+}
+
+/**
+ * Resolve the wage operative right now — the leaf of the chain unless a change
+ * is scheduled, in which case the predecessor is still the one that applies.
+ */
+export async function resolveCurrentWage(teamId: number, userAddress: string, now?: Date) {
+  const reference = now ?? new Date();
+  const currentWeekStart = dayjs.utc(reference).startOf('isoWeek').toDate();
+
+  return resolveWageForWeek(teamId, userAddress, currentWeekStart);
+}
+
+/**
+ * Returns the start of the next ISO week (Monday 00:00 UTC).
+ *
+ * Every wage change lands here, so a wage boundary never falls in the middle of
+ * a week and one week always maps to exactly one wage.
+ */
+export function nextMondayUtc(now?: Date): Date {
+  const reference = now ?? new Date();
+  return dayjs.utc(reference).add(1, 'week').startOf('isoWeek').toDate();
+}
+
+/**
+ * Is this wage scheduled but not yet operative?
+ */
+export function isScheduledWage(
+  wage: { effectiveFrom: Date | null } | null | undefined,
+  now?: Date
+): boolean {
+  if (!wage?.effectiveFrom) return false;
+  return wage.effectiveFrom > (now ?? new Date());
+}

--- a/backend/src/validation/schemas/wage.ts
+++ b/backend/src/validation/schemas/wage.ts
@@ -72,6 +72,12 @@ export const getWagesQuerySchema = z.object({
   teamId: teamIdSchema,
 });
 
+// Cancel a wage change that has been scheduled but has not taken effect yet
+export const cancelScheduledWageQuerySchema = z.object({
+  teamId: teamIdSchema,
+  userAddress: addressSchema,
+});
+
 // Toggle wage status path params and query
 export const toggleWageStatusParamsSchema = z.object({
   wageId: z.coerce.number().int().positive('Wage ID must be a positive integer'),

--- a/docs/features/payroll/Readme.md
+++ b/docs/features/payroll/Readme.md
@@ -83,7 +83,22 @@ every story is ticked, all use cases and edge cases of payroll are covered.
       an amber badge "8h/d" (tooltip "Daily limit: N hours"); the cell shows "—"
       when the member has no wage
 - [ ] Editing a member with an existing wage pre-fills the current values; saving
-      creates a new wage **version** (the old one is superseded, one active wage per member)
+      creates a new wage **version** (one active wage per member)
+- [ ] _(scheduling)_ Changing an existing wage takes effect at the **start of the
+      next ISO week**, not immediately; the current rates and caps hold until then,
+      including for claims backdated to earlier weeks. A member's **first** wage is
+      the only one that applies immediately
+- [ ] _(scheduling)_ The modal states the effective date before saving
+      ("This change takes effect on Aug 17, 2026")
+- [ ] _(scheduling)_ The member row shows a badge for the pending change
+      ("Changes to SHER 10/h, 15h/wk, 8h/d on Aug 17, 2026"); it disappears once the
+      change takes effect, without a page reload
+- [ ] _(scheduling)_ Saving again before the effective date **rewrites** the pending
+      change and does **not** push its date back; the chain gains no extra version
+- [ ] _(scheduling)_ A pending change can be cancelled, leaving the current wage in
+      force (`DELETE /wage/scheduled`)
+
+> Full behaviour, edge cases and API shapes: [Wage scheduling](./wage-scheduling.md).
 - [ ] "Set Wage" is disabled with a tooltip when the current wage is disabled
       ("Resume this wage before making changes") — also blocked server-side
       (400 "Cannot set wage: the current wage is disabled")

--- a/docs/features/payroll/wage-scheduling.md
+++ b/docs/features/payroll/wage-scheduling.md
@@ -1,0 +1,294 @@
+# Wage scheduling — how a rate change lands on a week
+
+**Last updated:** 2026-08-12
+**Issue:** #2479
+**Scope:** backend wage resolution, `GET /wage`, `GET /team/:id`, member table and
+claim views.
+
+## The rule, in one line
+
+**The week worked determines the wage — never the date the claim was entered.**
+
+Everything below follows from that.
+
+---
+
+## Why the feature exists
+
+Wages are a linked list: each row points at its successor through `nextWageId`,
+and the row with `nextWageId IS NULL` is the end of the chain. Before this
+change, every lookup treated that leaf as "the current wage", and `setWage`
+appended a new leaf immediately.
+
+That broke as soon as a wage changed mid-week:
+
+1. The member had already submitted claims, so a `WeeklyClaim` existed under the
+   old wage.
+2. `setWage` appended the new wage and the old one stopped being the leaf.
+3. The next claim no longer found the existing `WeeklyClaim` — it is keyed
+   `[wageId, weekStart]` — so a **second** one was created for the same week
+   under the new wage.
+
+The consequences were the interesting part:
+
+- **Hour caps were bypassed.** The weekly and daily counters restarted from zero
+  because the hours already claimed sat on the other row.
+- **The owner saw the week twice** in the approval list.
+- **Two EIP-712 signatures** were produced for one week, at two different rates,
+  meaning two on-chain withdrawals.
+
+## The rule in practice
+
+Two mechanisms, and they only work together.
+
+### 1. Changes are anchored to a Monday
+
+`setWage` never activates a change in the middle of a week. The new row is
+created with `effectiveFrom` set to the **start of the next ISO week**
+(Monday 00:00 UTC) and the predecessor stays operative until then.
+
+The single exception is a member's **very first wage**, which takes effect
+immediately — otherwise a new joiner could not claim anything before Monday.
+
+This is unconditional. It does not depend on whether claims already exist this
+week. A conditional rule was considered and rejected: it leaves a wage boundary
+falling mid-week in some cases, and every downstream question ("which cap
+applies on Wednesday?") then has two answers.
+
+The consequence to be aware of: **a wrong rate cannot be corrected in-week.** If
+the owner saves 2.5 instead of 25 and the week already has claims, the members
+are paid at 2.5 until Sunday. This was a deliberate product decision — one
+predictable rule beat an escape hatch.
+
+### 2. Resolution is done per week, not per "now"
+
+`resolveWageForWeek(teamId, userAddress, weekStart)` walks the chain and returns
+the last wage whose effective date is at or before `weekStart`, where
+
+```text
+effective date = effectiveFrom ?? createdAt
+```
+
+`createdAt` is the fallback for rows written before `effectiveFrom` existed;
+those wages did take effect the moment they were created.
+
+Anchoring changes to Mondays is what makes this exact: a wage boundary and a
+week boundary are the same instant, so **exactly one wage covers any week**.
+Resolving on "now" instead would reintroduce the split through backdated
+claims — see [Case B](#b--backdating-into-an-earlier-week) below.
+
+### One rule, one implementation
+
+`pickWageForWeek` is the pure function that decides. Everything else calls it:
+
+| Caller | Purpose |
+| ------ | ------- |
+| `addClaim` | Wage a daily claim is priced and capped against |
+| `submitWeeklyGoals` | Wage the goals row is attached to |
+| `GET /wage` | Rates and caps the claim form validates against |
+| `GET /team/:id` | `currentWage` in the member table |
+
+This matters more than it looks. Deriving the displayed wage as "the leaf,
+unless scheduled" *seems* equivalent, and it is for rows written by this
+feature — but not for legacy rows, where `effectiveFrom` is `null` and
+`createdAt` falls mid-week. There the leaf would be shown as current while
+claims for the same week were still priced on its predecessor. The screen and
+the server would disagree about what the member earns.
+
+`splitCurrentAndScheduled` returns both halves — the wage in force and the
+change queued behind it — from that same function, so the two cannot drift.
+
+---
+
+## Cases
+
+### A — The current week
+
+| Situation | Behaviour |
+| --------- | --------- |
+| No change | The chain's only operative wage applies |
+| Change saved this week | Scheduled for next Monday; **this week keeps the current wage** |
+| Member's first wage ever | Applies immediately |
+| Wage is disabled | `setWage` refused (400); claims refused |
+
+### B — Backdating into an earlier week
+
+Only reachable when `SUBMIT_RESTRICTION` is `disabled` or `beta`. When active
+(the default, including when unconfigured) `dayWorked` is confined to the
+current ISO week, at most 4 days back, so a claim can never cross a week
+boundary.
+
+| State of the target week | Behaviour |
+| ------------------------ | --------- |
+| `WeeklyClaim` exists, pending | Joins it; caps recount against **that week's** wage |
+| `WeeklyClaim` signed | `409 Week already signed` |
+| `WeeklyClaim` withdrawn | `409 Week already withdrawn` |
+| `WeeklyClaim` disabled | `409 Week is disabled` |
+| No `WeeklyClaim` yet | A new one is created for that past week, pending |
+
+The last row is intentional. A member who simply **forgot** to submit for
+earlier weeks must be able to catch up, and that is indistinguishable from
+"reopening" a week at the data level. The catch-up follows the normal cycle:
+the owner still approves it.
+
+What makes this safe is that the claim is priced at that week's wage, so caps
+and rates are the ones that were in force, and the claim lands on the week's
+existing row instead of opening a rival one.
+
+### C — The owner made a mistake
+
+| Situation | Behaviour |
+| --------- | --------- |
+| Corrects before Monday | The scheduled row is **rewritten in place** — no new link in the chain |
+| Corrects several times | Still one rewrite each time; the chain stays two links long |
+| Effective date after a correction | **Unchanged** — fixing a typo does not push the change back a week |
+| Wants to call it off | `DELETE /wage/scheduled` removes the row and restores `nextWageId = null` on the predecessor |
+| Corrects after it took effect | Normal path: a new wage scheduled for the following Monday |
+
+Rewriting in place is safe precisely because a scheduled wage has never been
+operative — no claim, no `WeeklyClaim`, no signature references it.
+
+### D — Boundaries
+
+| Situation | Behaviour |
+| --------- | --------- |
+| Week predates the member's first wage | Falls back to the **earliest** wage in the chain |
+| Chain is broken (no predecessor found) | Falls back to the leaf rather than failing |
+| Two wages share an effective date | Highest `id` wins — ids increase along the chain |
+| Member has no wage at all | `400 No wage found for the user` |
+
+The first row deserves its reasoning. Rejecting would be more principled, but on
+existing data `createdAt` is a technical timestamp and not a business start
+date: a wage row written in June can legitimately cover weeks in May that were
+already claimed. Rejecting would break that history, so the earliest wage is
+used instead.
+
+---
+
+## What changes with the daily cap
+
+`maximumHoursPerDay` is a field on the wage like the rate, so it follows exactly
+the same rule. Changing it mid-week does **not** tighten the current week — the
+old ceiling holds until Sunday, the new one applies from Monday, and a backdated
+claim is measured against the ceiling of the week it targets.
+
+The same holds for `maximumHoursPerWeek` and the overtime settings.
+
+---
+
+## API surface
+
+### `GET /wage?teamId=`
+
+Returns the wage **in force now** per member, with any pending change attached:
+
+```jsonc
+[
+  {
+    "id": 1,
+    "ratePerHour": [{ "type": "sher", "amount": 5 }],
+    "maximumHoursPerWeek": 20,
+    "maximumHoursPerDay": 8,
+    "effectiveFrom": null,
+    "scheduledWage": {          // null when nothing is pending
+      "id": 2,
+      "ratePerHour": [{ "type": "sher", "amount": 10 }],
+      "maximumHoursPerWeek": 15,
+      "maximumHoursPerDay": 8,
+      "effectiveFrom": "2026-08-17T00:00:00.000Z"
+    }
+  }
+]
+```
+
+The top-level object is what the claim form must validate against. Returning the
+scheduled wage there would make the form accept hours the server then rejects.
+
+### `PUT /wage/setWage`
+
+- `201` with the newly scheduled wage when a change is queued
+- `200` with the rewritten wage when a scheduled change is corrected in place
+- `400` when the operative wage is disabled
+
+### `DELETE /wage/scheduled?teamId=&userAddress=`
+
+- `200` with the wage that stays in force
+- `404` when there is no scheduled change
+- `409` when the scheduled wage has no predecessor (broken chain)
+
+### `GET /team/:id`
+
+Each member carries `currentWage` and `scheduledWage`, resolved the same way.
+
+---
+
+## What the user sees
+
+| Surface | Content |
+| ------- | ------- |
+| Member table (owner) | Badge under the rate: `Changes to SHER 10/h, 15h/wk, 8h/d on Aug 17, 2026` |
+| Set-wage modal | Banner stating the effective date **before** the owner saves |
+| Claim view (member) | Same notice, **only on weeks that predate the change** |
+
+The last condition matters: on the week the change takes effect, that week
+already runs on the new wage, so announcing it as upcoming — and saying the week
+keeps the current rate — would be false.
+
+The rate label always shows the chain's ticker for `native` (via `rateSymbol`),
+never the raw `NATIVE` database value, and lists the hour ceilings alongside the
+rate, since those usually change together.
+
+### Switching over at the deadline
+
+No polling. `useScheduledWageRefresh` arms one timer for the exact moment the
+change becomes operative and invalidates the wage and team queries. Because a
+tab left open over a weekend can have its timers throttled, the queries are also
+invalidated when the document becomes visible again past the effective date.
+
+---
+
+## Data model
+
+```prisma
+model Wage {
+  effectiveFrom DateTime?   // null = took effect on creation
+  nextWageId    Int? @unique
+  // ...
+  @@index([teamId, userAddress])
+}
+```
+
+- `effectiveFrom` is nullable, so existing rows keep their exact behaviour.
+- The deferrable `Wage_active_unique` EXCLUDE constraint still guarantees one
+  leaf per `(teamId, userAddress)`; chaining runs inside a transaction so the
+  check happens at COMMIT.
+- The `(teamId, userAddress)` index backs chain resolution, which now runs on
+  every claim and every weekly-goals submission.
+
+### Migrations
+
+| Migration | Effect |
+| --------- | ------ |
+| `20260812000000_wage_effective_from` | Adds the nullable `effectiveFrom` column |
+| `20260812010000_wage_member_chain_index` | Adds the `(teamId, userAddress)` index |
+
+Both are additive and backward compatible — no backfill, no downtime. On
+deployment every existing wage has `effectiveFrom = null` and keeps behaving as
+it did.
+
+---
+
+## Known gaps
+
+- The **Overtime Wage** column shows no indicator when an overtime change is
+  scheduled, even though the badge in the Standard column already covers the
+  same wage row.
+- There is no way to schedule a change for a week **further out** than the next
+  Monday.
+- `hasPendingClaimsThisWeek` was removed with the conditional rule; if a future
+  change reintroduces conditional scheduling, note that `WeeklyClaim.status` is
+  nullable on legacy rows and a plain `status: 'pending'` filter misses them.
+
+---
+
+_[← Back to payroll user stories](./Readme.md)_


### PR DESCRIPTION
# Description

Rate changes now take effect at the **start of the next week**, so a week is never half on the old terms and half on the new. A member's first rate still applies immediately. The rate and limits used for any hours are the ones in force **during the week the work was done**, not on the day it was typed in — so hours logged late land on the week already on file instead of opening a second copy, and approved weeks stay closed. A pending change can be corrected without pushing its date back, or cancelled; owner and member both see it coming, and the switch happens on its own.

Two problems surfaced along the way and are fixed here: the screen could show a different rate than the server actually charged, and the claim calendar was silently disabling valid dates.



Fixes #2479

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)
