### PR TITLE
docs: 📝 remove historical guidance references

### DIFF
--- a/.agents/skills/cnc-docs-governance/SKILL.md
+++ b/.agents/skills/cnc-docs-governance/SKILL.md
@@ -17,6 +17,9 @@ Keep each rule in one authoritative place and link to it from the entry points t
 Do not copy detailed guidance into a skill or `AGENTS.md`; point to its owner. Remove obsolete
 backlinks when ownership moves.
 
+Keep operating rules self-contained. Cite current code, configuration, or CI behaviour as evidence;
+do not use historical issues or pull requests as their authority or rationale.
+
 ## Change safely
 
 1. Inspect the affected source, linked guides, and the runtime or test evidence before editing.

--- a/.agents/skills/cnc-github-flow/SKILL.md
+++ b/.agents/skills/cnc-github-flow/SKILL.md
@@ -5,19 +5,23 @@ description: Manage CNC Portal GitHub issues, Sprint hierarchy, pull requests, r
 
 # CNC GitHub flow
 
-Use `gh`, not the GitHub MCP. Keep GitHub text in English, conventional-commit plus gitmoji titles, and public-repository hygiene from `AGENTS.md`.
+Use `gh`, not the GitHub MCP. Keep GitHub text in English, conventional-commit plus gitmoji titles,
+and public-repository hygiene from `AGENTS.md`.
 
 ## Create or organize an issue
 
-1. Search open issues before creating a duplicate. For audits, fetch `origin/develop` and compare delivered code before treating an item as shipped.
+1. Search open issues before creating a duplicate. For audits, fetch `origin/develop` and compare
+   delivered code before treating an item as shipped.
 2. Resolve the assignee dynamically unless the user names another owner:
 
    ```bash
    gh api user --jq .login
    ```
 
-3. Give the issue a concise problem, scope boundary, acceptance criteria, and validation evidence expected. Assign it to the current authenticated user.
-4. Place Sprint work under the right Goal. Attach a child using its database id, not its issue number:
+3. Give the issue a concise problem, scope boundary, acceptance criteria, and validation evidence
+   expected. Assign it to the current authenticated user.
+4. Place Sprint work under the right Goal. Attach a child using its database id, not its issue
+   number:
 
    ```bash
    CHILD_ID=$(gh api "repos/globe-and-citizen/cnc-portal/issues/<child-number>" --jq .id)
@@ -26,11 +30,18 @@ Use `gh`, not the GitHub MCP. Keep GitHub text in English, conventional-commit p
 
 ## Publish a branch
 
-1. Confirm the branch is `feature/<slug>` and inspect the exact diff before staging. Do not stage unrelated work.
+1. Confirm the branch is `feature/<slug>` and inspect the exact diff before staging. Do not stage
+   unrelated work.
 2. Run the validation listed in `AGENTS.md` for every touched subproject.
-3. Commit each logical change atomically, then push the feature branch. Never push directly to `main`, `master`, or `develop`; never force-push without explicit approval.
-4. Open a draft PR against `develop` unless the user asks for review-ready status. Use `.github/pull_request_template.md`, describe user or developer impact and validation, and include `Closes #N` or `Fixes #N`.
+3. Commit each logical change atomically, then push the feature branch. Never push directly to
+   `main`, `master`, or `develop`; never force-push without explicit approval.
+4. Open a draft PR against `develop` unless the user asks for review-ready status. Use
+   `.github/pull_request_template.md`, describe user or developer impact and validation, and include
+   `Closes #N` or `Fixes #N`. Write multiline Markdown to a body file and pass it through
+   `--body-file`; do not pass escaped `\n` in a shell `--body` string. Read the published body back
+   before considering the artifact complete.
 
 ## Review routing
 
-Use `cnc-pr-review` for a full PR review. Post genuine findings inline through the reviews API, use `REQUEST_CHANGES` for real bugs or unmet requirements, and never auto-approve.
+Use `cnc-pr-review` for a full PR review. Post genuine findings inline through the reviews API, use
+`REQUEST_CHANGES` for real bugs or unmet requirements, and never auto-approve.

--- a/.github/copilot-instructions/formatting-standards.md
+++ b/.github/copilot-instructions/formatting-standards.md
@@ -24,10 +24,9 @@ Before this module, `app/src` alone carried:
 - **five** address truncations, two using `…` where the rest used `...`, so the same address looked
   like two different values in two tables.
 
-That is not a tidiness problem. [#2376](https://github.com/globe-and-citizen/cnc-portal/pull/2376)
-shipped to production: a `maximumFractionDigits: 0` default plus raw `toLocaleString` at the call
-sites rounded every fractional Community Credit amount to a whole number, so a `0.2 USDC` position
-displayed as `0`.
+That is not a tidiness problem. A `maximumFractionDigits: 0` default plus raw `toLocaleString` at
+the call sites can round every fractional Community Credit amount to a whole number, so a `0.2 USDC`
+position displays as `0`.
 
 A formatter is a **product decision** — how much precision a user is trusted with, whether zero
 means zero or unknown, whether a figure is reconcilable against a block explorer. Decisions like
@@ -129,10 +128,9 @@ never to prepare one for a contract.
 when to reach for it. Then use it in both front-ends.
 
 Do **not** add a file to the `formattingLegacyFiles` allowlist in `eslint.config.js` /
-`eslint.config.mjs`. That list is migration debt from
-[#2383](https://github.com/globe-and-citizen/cnc-portal/issues/2383) and only ever shrinks — a
-ceiling constant fails lint at config load if it grows. A new entry means the codebase gained a
-convention in the same week it spent a PR removing them.
+`eslint.config.mjs`. That list is intentional migration debt and only ever shrinks — a ceiling
+constant fails lint at config load if it grows. A new entry means the codebase gained a convention
+in the same week it spent a PR removing them.
 
 If a one-off truly is one-off, a scoped
 `// eslint-disable-next-line no-restricted-syntax -- <reason>` on the line itself is the escape

--- a/.github/copilot-instructions/solidity-audit-checklist.md
+++ b/.github/copilot-instructions/solidity-audit-checklist.md
@@ -1,65 +1,63 @@
 # Solidity Audit Checklist
 
-Pre-merge checklist for every PR that touches `contract/`. Deployed contract bugs
-are unrecoverable post-deploy, so this list is **mandatory** — copy it into the PR
-description and tick each item. It complements the upgrade-safety rules in
-[`../../contract/UPGRADE_STRATEGY.md`](../../contract/UPGRADE_STRATEGY.md) and the
-general [`review-checklist.md`](./review-checklist.md).
+Pre-merge checklist for every PR that touches `contract/`. Deployed contract bugs are unrecoverable
+post-deploy, so this list is **mandatory** — copy it into the PR description and tick each item. It
+complements the upgrade-safety rules in
+[`../../contract/UPGRADE_STRATEGY.md`](../../contract/UPGRADE_STRATEGY.md) and the general
+[`review-checklist.md`](./review-checklist.md).
 
 ## Automated analysis (CI)
 
 [`.github/workflows/contract-slither.yml`](../workflows/contract-slither.yml) runs
 [Slither](https://github.com/crytic/slither) on every PR touching `contract/`.
 
-- [ ] **Review Slither output.** The job uploads all findings to the GitHub
-      Security tab (code scanning). It is **report-only** for now (does not fail
-      the build) because existing contracts carry a high/medium baseline tracked
-      in #1988 / #1993-1997; once that baseline is cleared the job switches to
+- [ ] **Review Slither output.** The job uploads all findings to the GitHub Security tab (code
+      scanning). It is **report-only** for now (does not fail the build) because existing contracts
+      carry a high/medium findings baseline. Once that baseline is cleared, the job switches to
       block on new high/medium findings.
 - [ ] **No silent suppressions.** Any false positive is excluded **explicitly** in
-      [`../../contract/slither.config.json`](../../contract/slither.config.json)
-      (or with an inline `// slither-disable-next-line <detector>` plus a one-line
-      justification), never by loosening the severity gate.
+      [`../../contract/slither.config.json`](../../contract/slither.config.json) (or with an inline
+      `// slither-disable-next-line <detector>` plus a one-line justification), never by loosening
+      the severity gate.
 
 ## Manual review
 
 Slither cannot catch everything. Confirm each of these by hand:
 
-- [ ] **No `hardhat/console.sol`** (or any `console.sol`) imported in production
-      contracts. It is only allowed under `contracts/mocks` and `contracts/test`.
-      A dedicated CI guard already enforces this, but check it in review too.
-- [ ] **No raw `transfer` / `transferFrom` on ERC-20.** Use OpenZeppelin
-      `SafeERC20` (`safeTransfer` / `safeTransferFrom`). Some tokens do not return
-      a bool and a raw `transfer` silently fails against them.
-- [ ] **`__gap` on every upgradeable contract.** Each upgradeable contract reserves
-      a `uint256[N] private __gap;` storage gap so future versions can add state
-      without colliding with child layouts.
-- [ ] **No `blockhash` (or `block.timestamp` / `block.prevrandao`) used as a source
-      of randomness.** These are miner/validator-influenceable. Use a commit-reveal
-      scheme or an external VRF if randomness is required.
-- [ ] **`nonReentrant` on token paths.** Any function that moves value (ETH or ERC-20
-      in/out) or performs an external call before updating state is guarded by
-      `ReentrancyGuard` / follows checks-effects-interactions.
-- [ ] **Access control reviewed.** Every state-changing entry point has an explicit
-      authorization check (`onlyOwner` / role / membership). New roles are documented.
-- [ ] **No unchecked external call return values.** `call` / `send` results are
-      checked; prefer pull-over-push for payouts.
+- [ ] **No `hardhat/console.sol`** (or any `console.sol`) imported in production contracts. It is
+      only allowed under `contracts/mocks` and `contracts/test`. A dedicated CI guard already
+      enforces this, but check it in review too.
+- [ ] **No raw `transfer` / `transferFrom` on ERC-20.** Use OpenZeppelin `SafeERC20` (`safeTransfer`
+      / `safeTransferFrom`). Some tokens do not return a bool and a raw `transfer` silently fails
+      against them.
+- [ ] **`__gap` on every upgradeable contract.** Each upgradeable contract reserves a
+      `uint256[N] private __gap;` storage gap so future versions can add state without colliding
+      with child layouts.
+- [ ] **No `blockhash` (or `block.timestamp` / `block.prevrandao`) used as a source of randomness.**
+      These are miner/validator-influenceable. Use a commit-reveal scheme or an external VRF if
+      randomness is required.
+- [ ] **`nonReentrant` on token paths.** Any function that moves value (ETH or ERC-20 in/out) or
+      performs an external call before updating state is guarded by `ReentrancyGuard` / follows
+      checks-effects-interactions.
+- [ ] **Access control reviewed.** Every state-changing entry point has an explicit authorization
+      check (`onlyOwner` / role / membership). New roles are documented.
+- [ ] **No unchecked external call return values.** `call` / `send` results are checked; prefer
+      pull-over-push for payouts.
 
 ## Upgrade safety
 
-- [ ] **Storage layout / upgrade safety checked.** Run
-      `npm run validate-upgrade:polygon` (production baseline) — see
-      [`../../contract/UPGRADE_STRATEGY.md`](../../contract/UPGRADE_STRATEGY.md).
-      A `FAIL` means **do not upgrade the proxy in place**.
+- [ ] **Storage layout / upgrade safety checked.** Run `npm run validate-upgrade:polygon`
+      (production baseline) — see
+      [`../../contract/UPGRADE_STRATEGY.md`](../../contract/UPGRADE_STRATEGY.md). A `FAIL` means
+      **do not upgrade the proxy in place**.
 - [ ] **`version()` bumped** per the semver convention when the implementation changes.
 - [ ] **Baselines updated** (`BAKE=1 ...`) only **after** a production deploy, never before.
 
 ## Outputs
 
 - [ ] **ABIs regenerated.** Run `npm run generate-abi` and commit the refreshed
-      `app/src/artifacts/abi/generated.ts`, plus the ABIs mirrored into `dashboard/`
-      and `ponder/`. A new or renamed function only reaches the frontend's types
-      through this step.
+      `app/src/artifacts/abi/generated.ts`, plus the ABIs mirrored into `dashboard/` and `ponder/`.
+      A new or renamed function only reaches the frontend's types through this step.
 - [ ] **`CHANGELOG.md` updated** for any deployed change.
 
 ## Local commands

--- a/.github/copilot-instructions/testing-anti-patterns.md
+++ b/.github/copilot-instructions/testing-anti-patterns.md
@@ -2,13 +2,23 @@
 
 ## What to Avoid in Testing
 
-This document outlines common testing anti-patterns and mistakes to avoid when writing tests for the CNC Portal project. Each anti-pattern is shown with examples of what NOT to do and the correct approach.
+This document outlines common testing anti-patterns and mistakes to avoid when writing tests for the
+CNC Portal project. Each anti-pattern is shown with examples of what NOT to do and the correct
+approach.
 
 ## ⚠️ Re-mocking globally-mocked modules
 
-`app/vitest.config.ts` loads setup files from `app/src/tests/setup/` that call `vi.mock(...)` once for every commonly used dependency (wagmi, viem, TanStack Query, Apollo, Pinia stores, the `@/composables/<domain>/{reads,writes}` modules, the stubbed Nuxt UI primitives, `@/lib/axios`, `@/utils`, `@/queries/*.queries`, …). Override hooks (`mockTeamStore`, `mockERC20Reads`, `resetERC20Mocks`, …) are re-exported from `@/tests/mocks`.
+`app/vitest.config.ts` loads setup files from `app/src/tests/setup/` that call `vi.mock(...)` once
+for every commonly used dependency (wagmi, viem, TanStack Query, Apollo, Pinia stores, the
+`@/composables/<domain>/{reads,writes}` modules, the stubbed Nuxt UI primitives, `@/lib/axios`,
+`@/utils`, `@/queries/*.queries`, …). Override hooks (`mockTeamStore`, `mockERC20Reads`,
+`resetERC20Mocks`, …) are re-exported from `@/tests/mocks`.
 
-**Do not declare a `vi.mock('<same-path>', …)` block in a spec for any of those paths.** Re-mocking shadows the global setup, duplicates `vi.hoisted` boilerplate, and drifts from the canonical mock shape. It is enforced by ESLint (`no-restricted-syntax` in `app/eslint.config.js`); the banned-path list lives in `bannedGlobalMockPaths`, and a legacy-offender allow-list seeds the migration (issue #2014).
+**Do not declare a `vi.mock('<same-path>', …)` block in a spec for any of those paths.** Re-mocking
+shadows the global setup, duplicates `vi.hoisted` boilerplate, and drifts from the canonical mock
+shape. It is enforced by ESLint (`no-restricted-syntax` in `app/eslint.config.js`); the banned-path
+list lives in `bannedGlobalMockPaths`, and the temporary `globalMockLegacyFiles` allow-list
+identifies specs still being migrated.
 
 ❌ **Bad: re-mocking `@wagmi/vue` per spec**
 
@@ -37,7 +47,9 @@ it("reads balance", () => {
 });
 ```
 
-If you need to mock a module that **isn't** yet covered, add it to `app/src/tests/setup/` and re-export the override hook from `app/src/tests/mocks/index.ts` — don't add per-spec `vi.mock` calls. See `app/src/tests/README.md` and `docs/testing/MOCK_SYSTEM.md` for the full mock system.
+If you need to mock a module that **isn't** yet covered, add it to `app/src/tests/setup/` and
+re-export the override hook from `app/src/tests/mocks/index.ts` — don't add per-spec `vi.mock`
+calls. See `app/src/tests/README.md` and `docs/testing/MOCK_SYSTEM.md` for the full mock system.
 
 ## Component Testing Anti-Patterns
 
@@ -715,4 +727,5 @@ describe("Component", () => {
 17. **Don't use flat test structure** - Organize tests logically
 18. **Don't duplicate test setup** - Create reusable helper functions
 
-Following these guidelines will help maintain high-quality, maintainable tests that provide reliable feedback about your code's behavior.
+Following these guidelines will help maintain high-quality, maintainable tests that provide reliable
+feedback about your code's behavior.

--- a/.github/workflows/contract-slither.yml
+++ b/.github/workflows/contract-slither.yml
@@ -31,10 +31,9 @@ jobs:
           slither-version: "ff1bf3ff4a5ebdfa63e4b83cb4885f682624daad"
           solc-version: "0.8.24"
           slither-config: "contract/slither.config.json"
-          # Report-only for the initial rollout: existing contracts still carry
-          # high/medium findings (tracked in #1988 and #1993-1997), so blocking
-          # now would stall every contract PR. All findings are surfaced in the
-          # GitHub Security tab via the SARIF upload below.
+          # Report-only while existing contracts carry a high/medium findings
+          # baseline. Blocking now would stall every contract PR. All findings
+          # are surfaced in the GitHub Security tab via the SARIF upload below.
           # To enforce once the baseline is triaged: set `fail-on: high` (or
           # medium) and re-add a gate step on `steps.slither.outcome`. Known
           # false positives are silenced explicitly in contract/slither.config.json.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,9 @@ addresses are mirrored into the frontend artifacts; after changing a contract in
 - Before opening a PR, search for a suitable issue or create one, assign it to the current
   authenticated GitHub user unless the task names another owner, and use `Closes #N` or `Fixes #N`
   in the PR body.
+- Create every GitHub issue and PR from its repository template. After publishing, read it back with
+  `gh issue view` or `gh pr view` and confirm its headings, Markdown spacing, links, and closing
+  keyword rendered as intended before treating the artifact as complete.
 - Treat all repository text as public. Never include infrastructure identifiers or connection
   strings in commits, issues, PRs, reviews, or committed documentation. Refer to a managed provider
   or a placeholder instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,9 @@ addresses are mirrored into the frontend artifacts; after changing a contract in
 - Create every GitHub issue and PR from its repository template. After publishing, read it back with
   `gh issue view` or `gh pr view` and confirm its headings, Markdown spacing, links, and closing
   keyword rendered as intended before treating the artifact as complete.
+- For multiline GitHub Markdown, write a body file and pass it with `gh issue|pr ... --body-file`.
+  Never pass escaped `\n` in a shell `--body` string. Verify the raw body contains real line breaks
+  before considering the rendered artifact valid.
 - Treat all repository text as public. Never include infrastructure identifiers or connection
   strings in commits, issues, PRs, reviews, or committed documentation. Refer to a managed provider
   or a placeholder instead.


### PR DESCRIPTION
## Summary

- Remove historical issue and pull-request references from Copilot guidance.
- Retain current, code-verifiable operational rules.
- Add the same current-state documentation rule to the governance skill and Slither CI comment.
- Require template-based publication and read-back verification for GitHub issues and pull requests.
- Prevent literal `\\n` sequences in future multiline GitHub Markdown.

## Validation

- `npm run lint:md`
- `npm run format:md:check`
- `bash scripts/audit-doc-drift.sh`

Closes #2481
