### PR TITLE
test: ✅ migrate remaining specs to global test mocks

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -129,7 +129,7 @@ const globalMockReMockSelectors = bannedGlobalMockPaths.map((path) => ({
   message: globalMockMessage(path)
 }))
 
-// Legacy offenders — these 34 spec files still carry at least one
+// Legacy offenders — these 26 spec files still carry at least one
 // `vi.mock(...)` call against a globally-mocked module path. The rule is
 // disabled for them so CI does not break on day one; each removal is a
 // follow-up to issue #2014.
@@ -142,12 +142,6 @@ const globalMockLegacyFiles = [
   'src/components/sections/CashRemunerationView/__tests__/CRWithdrawClaim.spec.ts',
   'src/components/sections/DashboardView/__tests__/MemberSection.spec.ts',
   'src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts',
-  'src/components/sections/SafeView/__tests__/RemoveOwnerButton.spec.ts',
-  'src/components/sections/SafeView/__tests__/SafeBalanceSection.rendering.spec.ts',
-  'src/components/sections/SafeView/__tests__/SafeBalanceSection.transfer.spec.ts',
-  'src/components/sections/SafeView/__tests__/SafeOwnersCard.spec.ts',
-  'src/components/sections/SafeView/forms/__tests__/AddSignerModal.spec.ts',
-  'src/components/sections/SafeView/forms/__tests__/UpdateThresholdModal.spec.ts',
   'src/components/sections/SherTokenView/__tests__/InvestorsTransaction.advanced.spec.ts',
   'src/components/sections/SherTokenView/__tests__/InvestorsTransaction.spec.ts',
   'src/components/sections/SherTokenView/__tests__/InvestorsTransaction.test-utils.ts',
@@ -161,8 +155,6 @@ const globalMockLegacyFiles = [
   'src/components/sections/WeeklyClaimView/__tests__/WeeklyClaimActionEnable.spec.ts',
   'src/composables/__tests__/useFileUrl.spec.ts',
   'src/composables/__tests__/useSiwe.spec.ts',
-  'src/composables/safe/__tests__/useSafeSdk.spec.ts',
-  'src/composables/safe/__tests__/useSafeTransactionActions.spec.ts',
   'src/queries/__tests__/contract.queries.spec.ts',
   'src/router/__tests__/index.spec.ts',
   'src/stores/__tests__/teamStore.spec.ts',

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -134,32 +134,12 @@ const globalMockReMockSelectors = bannedGlobalMockPaths.map((path) => ({
 // disabled for them so CI does not break on day one; each removal is a
 // follow-up to issue #2014.
 const globalMockLegacyFiles = [
-  'src/components/sections/AdministrationView/__tests__/CurrentBoDSection.spec.ts',
-  'src/components/sections/AdministrationView/__tests__/PastBoDElectionCard.spec.ts',
-  'src/components/sections/AdministrationView/__tests__/PublishResult.spec.ts',
-  'src/components/sections/CashRemunerationView/__tests__/CRSigne.migration.spec.ts',
-  'src/components/sections/CashRemunerationView/__tests__/CRSigne.spec.ts',
-  'src/components/sections/CashRemunerationView/__tests__/CRWithdrawClaim.spec.ts',
-  'src/components/sections/DashboardView/__tests__/MemberSection.spec.ts',
   'src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts',
   'src/components/sections/SherTokenView/__tests__/InvestorsTransaction.advanced.spec.ts',
   'src/components/sections/SherTokenView/__tests__/InvestorsTransaction.spec.ts',
   'src/components/sections/SherTokenView/__tests__/InvestorsTransaction.test-utils.ts',
-  'src/components/sections/SherTokenView/forms/__tests__/MintForm.spec.ts',
-  'src/components/sections/SherTokenView/forms/__tests__/MintRecapCard.spec.ts',
-  'src/components/sections/SherTokenView/forms/__tests__/MintStakeSection.spec.ts',
-  'src/components/sections/SherTokenView/forms/__tests__/TwinAmountInputs.spec.ts',
-  'src/components/sections/VestingView/__tests__/VestingFlow.spec.ts',
-  'src/components/sections/VestingView/__tests__/VestingStats.spec.ts',
-  'src/components/sections/WeeklyClaimView/__tests__/WeeklyClaimActionDropdown.spec.ts',
-  'src/components/sections/WeeklyClaimView/__tests__/WeeklyClaimActionEnable.spec.ts',
-  'src/composables/__tests__/useFileUrl.spec.ts',
   'src/composables/__tests__/useSiwe.spec.ts',
-  'src/queries/__tests__/contract.queries.spec.ts',
-  'src/router/__tests__/index.spec.ts',
-  'src/stores/__tests__/teamStore.spec.ts',
-  'src/views/team/[[]id[]]/__tests__/BankView.spec.ts',
-  'src/views/team/[[]id[]]/__tests__/BodElectionView.spec.ts'
+  'src/router/__tests__/index.spec.ts'
 ]
 
 // Contract-writes V3 enforcement (issues #1798, #1926).

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -129,19 +129,6 @@ const globalMockReMockSelectors = bannedGlobalMockPaths.map((path) => ({
   message: globalMockMessage(path)
 }))
 
-// Legacy offenders — these 26 spec files still carry at least one
-// `vi.mock(...)` call against a globally-mocked module path. The rule is
-// disabled for them so CI does not break on day one; each removal is a
-// follow-up to issue #2014.
-const globalMockLegacyFiles = [
-  'src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts',
-  'src/components/sections/SherTokenView/__tests__/InvestorsTransaction.advanced.spec.ts',
-  'src/components/sections/SherTokenView/__tests__/InvestorsTransaction.spec.ts',
-  'src/components/sections/SherTokenView/__tests__/InvestorsTransaction.test-utils.ts',
-  'src/composables/__tests__/useSiwe.spec.ts',
-  'src/router/__tests__/index.spec.ts'
-]
-
 // Contract-writes V3 enforcement (issues #1798, #1926).
 //
 // All on-chain writes must go through `useContractWritesV3` from
@@ -343,21 +330,6 @@ export default [
         tailwindClassIncludes,
         vmCast,
         ...globalMockReMockSelectors
-      ]
-    }
-  },
-  {
-    name: 'app/test-fragility-bans-global-mock-legacy',
-    files: globalMockLegacyFiles,
-    rules: {
-      // Allow local `vi.mock(...)` of globally-mocked paths in these files
-      // only — they predate issue #2014. Tailwind and wrapper.vm-cast bans still apply.
-      'no-restricted-syntax': [
-        'error',
-        tailwindClassAssertion,
-        tailwindClassAssertionOptional,
-        tailwindClassIncludes,
-        vmCast
       ]
     }
   },

--- a/app/src/components/sections/AdministrationView/__tests__/CurrentBoDSection.spec.ts
+++ b/app/src/components/sections/AdministrationView/__tests__/CurrentBoDSection.spec.ts
@@ -7,17 +7,6 @@ import { useTeamStore } from '@/stores'
 import { useReadContract } from '@wagmi/vue'
 import { log } from '@/utils'
 
-vi.mock('@/utils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/utils')>()
-  return {
-    ...actual,
-    log: {
-      ...actual.log,
-      error: vi.fn()
-    }
-  }
-})
-
 const NotFoundStub = { template: '<div data-test="not-found">no-members</div>' }
 
 // Stub for UserComponentCol to expose passed props via attributes

--- a/app/src/components/sections/AdministrationView/__tests__/PastBoDElectionCard.spec.ts
+++ b/app/src/components/sections/AdministrationView/__tests__/PastBoDElectionCard.spec.ts
@@ -3,20 +3,10 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { ref } from 'vue'
 import PastBoDElectionCard from '@/components/sections/AdministrationView/PastBoDElectionCard.vue'
-import { useReadContractFn, mockUseReadContract } from '@/tests/mocks/wagmi.vue.mock'
+import { mockTeamStore, useReadContractFn, mockUseReadContract } from '@/tests/mocks'
 
 const memberA = '0x000000000000000000000000000000000000aaaa'
 const memberB = '0x000000000000000000000000000000000000bbbb'
-
-vi.mock('@/stores', () => ({
-  useTeamStore: () => ({
-    currentTeamId: '1',
-    getContractAddressByType: () => '0x0000000000000000000000000000000000000010',
-    currentTeam: {
-      members: [{ address: memberA, name: 'Alice' }]
-    }
-  })
-}))
 
 describe('PastBoDElectionCard', () => {
   const election = {
@@ -33,6 +23,14 @@ describe('PastBoDElectionCard', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    mockTeamStore.currentTeamId = '1'
+    mockTeamStore.getContractAddressByType.mockReturnValue(
+      '0x0000000000000000000000000000000000000010'
+    )
+    mockTeamStore.currentTeam = {
+      ...mockTeamStore.currentTeam,
+      members: [{ address: memberA, name: 'Alice' }]
+    }
     useReadContractFn.mockImplementation((args: { functionName: string }) => {
       if (args.functionName === 'getVoteCount') {
         return { ...mockUseReadContract, data: ref(12n), error: ref(null) }

--- a/app/src/components/sections/AdministrationView/__tests__/PublishResult.spec.ts
+++ b/app/src/components/sections/AdministrationView/__tests__/PublishResult.spec.ts
@@ -15,14 +15,6 @@ vi.mock('@/constant', async (importOriginal) => ({
   ELECTIONS_BEACON_ADDRESS: '0x0000000000000000000000000000000000000003',
   ELECTIONS_IMPL_ADDRESS: '0x0000000000000000000000000000000000000004'
 }))
-vi.mock('viem', async () => {
-  const actual = await vi.importActual('viem')
-  return {
-    ...actual,
-    encodeFunctionData: vi.fn(() => '0xdeadbeef')
-  }
-})
-
 type PublishOptions = {
   onSuccess?: () => void
   onError?: (e: unknown) => void

--- a/app/src/components/sections/CashRemunerationView/__tests__/CRSigne.migration.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/__tests__/CRSigne.migration.spec.ts
@@ -7,7 +7,6 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import isoWeek from 'dayjs/plugin/isoWeek'
 import {
-  mockCashRemunerationWrites,
   mockTeamStore,
   mockUserStore,
   mockUseReadContract,

--- a/app/src/components/sections/CashRemunerationView/__tests__/CRSigne.migration.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/__tests__/CRSigne.migration.spec.ts
@@ -17,13 +17,6 @@ import {
 import { createMockMutationResponse } from '@/tests/mocks/query.mock'
 import { useUpdateWeeklyClaimMutation } from '@/queries'
 
-vi.mock('@/composables/cashRemuneration/writes', () => ({
-  useEnableClaim: vi.fn(() => mockCashRemunerationWrites.enableClaim),
-  useDisableClaim: vi.fn(() => mockCashRemunerationWrites.disableClaim),
-  useWithdraw: vi.fn(() => mockCashRemunerationWrites.ownerWithdrawAllToBank),
-  useOwnerWithdrawAllToBank: vi.fn(() => mockCashRemunerationWrites.ownerWithdrawAllToBank)
-}))
-
 dayjs.extend(utc)
 dayjs.extend(isoWeek)
 

--- a/app/src/components/sections/CashRemunerationView/__tests__/CRSigne.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/__tests__/CRSigne.spec.ts
@@ -19,13 +19,6 @@ import {
 import { createMockMutationResponse } from '@/tests/mocks/query.mock'
 import { useUpdateWeeklyClaimMutation } from '@/queries'
 
-vi.mock('@/composables/cashRemuneration/writes', () => ({
-  useEnableClaim: vi.fn(() => mockCashRemunerationWrites.enableClaim),
-  useDisableClaim: vi.fn(() => mockCashRemunerationWrites.disableClaim),
-  useWithdraw: vi.fn(() => mockCashRemunerationWrites.ownerWithdrawAllToBank),
-  useOwnerWithdrawAllToBank: vi.fn(() => mockCashRemunerationWrites.ownerWithdrawAllToBank)
-}))
-
 dayjs.extend(utc)
 dayjs.extend(isoWeek)
 

--- a/app/src/components/sections/CashRemunerationView/__tests__/CRWithdrawClaim.spec.ts
+++ b/app/src/components/sections/CashRemunerationView/__tests__/CRWithdrawClaim.spec.ts
@@ -9,17 +9,14 @@ import CRWithdrawClaim from '../CRWithdrawClaim.vue'
 import type { WeeklyClaim } from '@/types'
 import { USDC_ADDRESS } from '@/constant'
 import { useSyncWeeklyClaimsMutation } from '@/queries'
-import { mockTeamStore, mockGetBalance, mockUseWriteContract, mockWagmiCore } from '@/tests/mocks'
+import {
+  mockCashRemunerationWrites,
+  mockTeamStore,
+  mockGetBalance,
+  mockWagmiCore
+} from '@/tests/mocks'
 import { mockLog } from '@/tests/mocks/utils.mock'
 import * as utils from '@/utils'
-
-vi.mock('@/composables/contracts/useContractWritesV3', () => ({
-  useContractWritesV3: vi.fn(() => mockUseWriteContract)
-}))
-
-vi.mock('@/composables/cashRemuneration/writes', () => ({
-  useWithdraw: vi.fn(() => mockUseWriteContract)
-}))
 
 type WrapperProps = {
   weeklyClaim: WeeklyClaim
@@ -103,12 +100,12 @@ describe('CRWithdrawClaim', () => {
 
     // The component calls withdrawTx.mutate(variables, { onSuccess, onError })
     // By default, invoke onSuccess callback to simulate a successful mutation
-    mockUseWriteContract.mutate = vi.fn(
+    mockCashRemunerationWrites.withdraw.mutate = vi.fn(
       async (_variables: unknown, options?: { onSuccess?: () => Promise<void> | void }) => {
         await options?.onSuccess?.()
       }
     )
-    mockUseWriteContract.mutateAsync = vi.fn().mockResolvedValue('0xhash')
+    mockCashRemunerationWrites.withdraw.mutateAsync = vi.fn().mockResolvedValue('0xhash')
 
     mockGetBalance.mockResolvedValue(parseEther('100'))
 
@@ -126,7 +123,7 @@ describe('CRWithdrawClaim', () => {
     await clickWithdrawButton()
 
     // expect(mockToast.add).toHaveBeenCalledWith({ title: 'Claim withdrawn', color: 'success' })
-    expect(mockUseWriteContract.mutate).toHaveBeenCalled()
+    expect(mockCashRemunerationWrites.withdraw.mutate).toHaveBeenCalled()
   })
 
   it('withdraws and emits from dropdown when owner', async () => {
@@ -148,8 +145,8 @@ describe('CRWithdrawClaim', () => {
 
   it('skips dropdown click while loading', async () => {
     // Don't invoke onSuccess so isLoading stays true
-    mockUseWriteContract.mutate = vi.fn(() => {
-      mockUseWriteContract.isPending.value = true
+    mockCashRemunerationWrites.withdraw.mutate = vi.fn(() => {
+      mockCashRemunerationWrites.withdraw.isPending.value = true
     })
 
     createWrapper({ isDropDown: true, isClaimOwner: true })
@@ -161,8 +158,8 @@ describe('CRWithdrawClaim', () => {
     await action.trigger('click')
     await nextTick()
 
-    expect(mockUseWriteContract.mutate).toHaveBeenCalledTimes(1)
-    mockUseWriteContract.isPending.value = false
+    expect(mockCashRemunerationWrites.withdraw.mutate).toHaveBeenCalledTimes(1)
+    mockCashRemunerationWrites.withdraw.isPending.value = false
   })
 
   it('shows error when contract address is missing', async () => {
@@ -235,7 +232,7 @@ describe('CRWithdrawClaim', () => {
 
     await clickWithdrawButton()
 
-    expect(mockUseWriteContract.mutate).toHaveBeenCalledWith(
+    expect(mockCashRemunerationWrites.withdraw.mutate).toHaveBeenCalledWith(
       expect.objectContaining({
         args: [
           expect.objectContaining({
@@ -325,7 +322,7 @@ describe('CRWithdrawClaim', () => {
       raw: new Error('rejected')
     } as ReturnType<typeof utils.classifyError>)
 
-    mockUseWriteContract.mutate = vi.fn(
+    mockCashRemunerationWrites.withdraw.mutate = vi.fn(
       async (_variables: unknown, options?: { onError?: (error: unknown) => void }) => {
         options?.onError?.(new Error('rejected'))
       }
@@ -344,7 +341,7 @@ describe('CRWithdrawClaim', () => {
       raw: new Error('boom')
     } as ReturnType<typeof utils.classifyError>)
 
-    mockUseWriteContract.mutate = vi.fn(
+    mockCashRemunerationWrites.withdraw.mutate = vi.fn(
       async (_variables: unknown, options?: { onError?: (error: unknown) => void }) => {
         options?.onError?.(new Error('boom'))
       }
@@ -369,7 +366,7 @@ describe('CRWithdrawClaim', () => {
     createWrapper({ weeklyClaim: claimOnOtherContract })
     await clickWithdrawButton()
 
-    expect(mockUseWriteContract.mutate).not.toHaveBeenCalled()
+    expect(mockCashRemunerationWrites.withdraw.mutate).not.toHaveBeenCalled()
   })
 
   it('blocks withdraw when claim was signed on a different chain', async () => {
@@ -385,7 +382,7 @@ describe('CRWithdrawClaim', () => {
     createWrapper({ weeklyClaim: claimOnOtherChain })
     await clickWithdrawButton()
 
-    expect(mockUseWriteContract.mutate).not.toHaveBeenCalled()
+    expect(mockCashRemunerationWrites.withdraw.mutate).not.toHaveBeenCalled()
   })
 
   it('blocks withdraw when recovered signer does not match contract owner', async () => {
@@ -396,7 +393,7 @@ describe('CRWithdrawClaim', () => {
     createWrapper()
     await clickWithdrawButton()
 
-    expect(mockUseWriteContract.mutate).not.toHaveBeenCalled()
+    expect(mockCashRemunerationWrites.withdraw.mutate).not.toHaveBeenCalled()
   })
 
   it('allows withdraw for legacy claims with no data.contractAddress when recovery matches owner', async () => {
@@ -408,6 +405,6 @@ describe('CRWithdrawClaim', () => {
     createWrapper({ weeklyClaim: legacyClaim })
     await clickWithdrawButton()
 
-    expect(mockUseWriteContract.mutate).toHaveBeenCalled()
+    expect(mockCashRemunerationWrites.withdraw.mutate).toHaveBeenCalled()
   })
 })

--- a/app/src/components/sections/DashboardView/__tests__/MemberSection.spec.ts
+++ b/app/src/components/sections/DashboardView/__tests__/MemberSection.spec.ts
@@ -8,16 +8,6 @@ import { useUserDataStore } from '@/stores/user'
 import { useToggleWageStatusMutation } from '@/queries/wage.queries'
 import MemberSection from '../MemberSection.vue'
 
-vi.mock('@/queries/team.queries', async (importOriginal) => {
-  const actual = (await importOriginal()) as object
-  return {
-    ...actual,
-    teamKeys: {
-      detail: (id: string) => ['team', id]
-    }
-  }
-})
-
 vi.mock('@nuxt/ui/components/Table.vue', () => ({
   default: {
     name: 'UTable',

--- a/app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts
+++ b/app/src/components/sections/ExpenseAccountView/__tests__/TransferAction.spec.ts
@@ -5,24 +5,17 @@ import { nextTick, ref, toValue } from 'vue'
 import { readContract, estimateGas } from '@wagmi/core'
 import { recoverTypedDataAddress } from 'viem'
 import TransferAction from '../TransferAction.vue'
-import { mockExpenseAccountWrites, mockERC20Writes, mockTeamStore } from '@/tests/mocks'
+import {
+  mockERC20Writes,
+  mockExpenseAccountWrites,
+  mockGetTokens,
+  mockTeamStore
+} from '@/tests/mocks'
 
-// Hoisted so the module factory below can read it, and mutable so a test can
-// model the window where the contract balance has not been read yet and
-// `getTokens` therefore yields nothing.
-const { mockTokens } = vi.hoisted(() => ({
-  mockTokens: { value: [] as unknown[] }
-}))
 const DEFAULT_TOKENS = [{ symbol: 'USDC', balance: 100, spendableBalance: 100 }]
 
 // `classifyError` is left un-mocked so these tests assert the message the user
 // actually sees, rather than a stand-in string.
-vi.mock('@/utils', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  log: { error: vi.fn() },
-  getTokens: vi.fn(() => mockTokens.value)
-}))
-
 // Kept as a spy so a test can assert *what* the balance query was keyed on:
 // the address arrives with the team query, so the argument has to stay a live
 // source rather than a value read once during setup.
@@ -38,11 +31,6 @@ const useContractBalanceSpy = vi.fn(() => contractBalanceState)
 
 vi.mock('@/composables', () => ({
   useContractBalance: (address: unknown) => useContractBalanceSpy(address)
-}))
-
-vi.mock('@wagmi/core', () => ({
-  readContract: vi.fn(),
-  estimateGas: vi.fn()
 }))
 
 const MockTransferForm = {
@@ -109,7 +97,7 @@ describe('TransferAction.vue', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
-    mockTokens.value = DEFAULT_TOKENS
+    mockGetTokens.mockReturnValue(DEFAULT_TOKENS)
     contractBalanceState.isLoading.value = false
     contractBalanceState.error.value = null
     vi.mocked(estimateGas).mockResolvedValue(21000n)
@@ -142,7 +130,7 @@ describe('TransferAction.vue', () => {
     })
 
     it('explains itself while the balance is still loading', async () => {
-      mockTokens.value = []
+      mockGetTokens.mockReturnValue([])
       contractBalanceState.isLoading.value = true
 
       const wrapper = createComponent()
@@ -153,7 +141,7 @@ describe('TransferAction.vue', () => {
     })
 
     it('reports a failed balance read instead of an empty dialog', async () => {
-      mockTokens.value = []
+      mockGetTokens.mockReturnValue([])
       contractBalanceState.error.value = new Error('rpc down')
 
       const wrapper = createComponent()
@@ -175,7 +163,7 @@ describe('TransferAction.vue', () => {
     })
 
     it('omits the balance label entirely when there is no token to describe', async () => {
-      mockTokens.value = []
+      mockGetTokens.mockReturnValue([])
       contractBalanceState.isLoading.value = true
 
       const wrapper = createComponent()

--- a/app/src/components/sections/SafeView/__tests__/RemoveOwnerButton.spec.ts
+++ b/app/src/components/sections/SafeView/__tests__/RemoveOwnerButton.spec.ts
@@ -2,34 +2,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import RemoveOwnerButton from '../RemoveOwnerButton.vue'
+import { mockLog, mockUseChainId } from '@/tests/mocks'
 import { mockUserStore } from '@/tests/mocks/store.mock'
 
-const { mockChainId, mockIsPending, mockLogError, mockUpdateOwnersMutate } = vi.hoisted(() => ({
-  mockChainId: { value: 137 },
+const { mockIsPending, mockUpdateOwnersMutate } = vi.hoisted(() => ({
   mockIsPending: { value: false },
-  mockLogError: vi.fn(),
   mockUpdateOwnersMutate: vi.fn()
 }))
-
-vi.mock('@wagmi/vue', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@wagmi/vue')>()
-  return {
-    ...actual,
-    useChainId: vi.fn(() => mockChainId)
-  }
-})
 
 vi.mock('@/queries/safe.mutations', () => ({
   useUpdateSafeOwnersMutation: () => ({
     mutate: mockUpdateOwnersMutate,
     isPending: mockIsPending
   })
-}))
-
-vi.mock('@/utils', () => ({
-  log: {
-    error: mockLogError
-  }
 }))
 
 vi.mock('@iconify/vue', () => ({
@@ -67,7 +52,7 @@ const mountComponent = (props = {}) =>
 describe('RemoveOwnerButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockChainId.value = 137
+    mockUseChainId.value = 137
     mockIsPending.value = false
     mockUserStore.address = '0x1111111111111111111111111111111111111111'
     mockUpdateOwnersMutate.mockImplementation(() => undefined)
@@ -120,7 +105,7 @@ describe('RemoveOwnerButton', () => {
     callbacks?.onSuccess?.()
     await nextTick()
 
-    expect(mockLogError).not.toHaveBeenCalled()
+    expect(mockLog.error).not.toHaveBeenCalled()
   })
 
   it('shows loading state from mutation pending ref', async () => {
@@ -155,7 +140,7 @@ describe('RemoveOwnerButton', () => {
     callbacks?.onError?.(new Error('RPC failed'))
     await nextTick()
 
-    expect(mockLogError).toHaveBeenCalledWith('Failed to remove owner:', expect.any(Error))
+    expect(mockLog.error).toHaveBeenCalledWith('Failed to remove owner:', expect.any(Error))
     expect(wrapper.find('[data-test="remove-owner-button"]').attributes('data-loading')).toBe(
       'false'
     )

--- a/app/src/components/sections/SafeView/__tests__/SafeBalanceSection.rendering.spec.ts
+++ b/app/src/components/sections/SafeView/__tests__/SafeBalanceSection.rendering.spec.ts
@@ -4,7 +4,12 @@ import { nextTick, ref, defineComponent } from 'vue'
 import { useStorage } from '@vueuse/core'
 import type { Address } from 'viem'
 import SafeBalanceSection from '../SafeBalanceSection.vue'
-import { mockUseContractBalance, mockUseAccount, makeTokenBalance } from '@/tests/mocks'
+import {
+  mockUseContractBalance,
+  mockUseAccount,
+  makeTokenBalance,
+  useQueryClientFn
+} from '@/tests/mocks'
 import { mockUserStore } from '@/tests/mocks/store.mock'
 
 // Mock @iconify/vue
@@ -24,7 +29,6 @@ const {
   mockUseTeamStore,
   mockUseCurrencyStore,
   mockuseGetSafeInfoQuery,
-  mockQueryClient,
   mockUseTransferFromSafeMutation
 } = vi.hoisted(() => ({
   mockGetSafeHomeUrl: vi.fn(),
@@ -33,12 +37,6 @@ const {
   mockUseTeamStore: vi.fn(),
   mockUseCurrencyStore: vi.fn(),
   mockuseGetSafeInfoQuery: vi.fn(),
-  mockQueryClient: {
-    invalidateQueries: vi.fn(async () => undefined),
-    getQueryData: vi.fn(() => undefined),
-    setQueryData: vi.fn(() => undefined),
-    removeQueries: vi.fn(() => undefined)
-  },
   mockUseTransferFromSafeMutation: vi.fn(() => ({
     mutate: vi.fn(),
     isPending: ref(false),
@@ -56,24 +54,12 @@ vi.mock('@/composables/safe', async (importOriginal) => {
   }
 })
 
-vi.mock('@vueuse/core', async () => {
-  const actual = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core')
-  return {
-    ...actual,
-    useStorage: vi.fn()
-  }
-})
-
 vi.mock('@/queries/safe.queries', () => ({
   useGetSafeInfoQuery: mockuseGetSafeInfoQuery
 }))
 
 vi.mock('@/queries/safe.mutations', () => ({
   useTransferFromSafeMutation: mockUseTransferFromSafeMutation
-}))
-
-vi.mock('@tanstack/vue-query', () => ({
-  useQueryClient: () => mockQueryClient
 }))
 
 // Test constants
@@ -194,6 +180,12 @@ describe('SafeBalanceSection', () => {
     mockUserStore.address = MOCK_DATA.safeInfo.owners[0]!
 
     vi.mocked(useStorage).mockReturnValue(mockCurrency as never)
+    useQueryClientFn.mockReturnValue({
+      invalidateQueries: vi.fn(async () => undefined),
+      getQueryData: vi.fn(() => undefined),
+      setQueryData: vi.fn(() => undefined),
+      removeQueries: vi.fn(() => undefined)
+    })
 
     mockGetSafeHomeUrl.mockReturnValue(
       'https://app.safe.global/home?safe=polygon:0x1234567890123456789012345678901234567890'

--- a/app/src/components/sections/SafeView/__tests__/SafeBalanceSection.transfer.spec.ts
+++ b/app/src/components/sections/SafeView/__tests__/SafeBalanceSection.transfer.spec.ts
@@ -4,8 +4,9 @@ import { nextTick, ref, defineComponent } from 'vue'
 import { useStorage } from '@vueuse/core'
 import type { Address } from 'viem'
 import SafeBalanceSection from '../SafeBalanceSection.vue'
-import { mockUseContractBalance, makeTokenBalance } from '@/tests/mocks'
+import { mockUseContractBalance, makeTokenBalance, useQueryClientFn } from '@/tests/mocks'
 import { mockUserStore } from '@/tests/mocks/store.mock'
+import * as utils from '@/utils'
 
 const {
   mockGetSafeHomeUrl,
@@ -13,7 +14,6 @@ const {
   mockUseChainId,
   mockUseTeamStore,
   mockuseGetSafeInfoQuery,
-  mockQueryClient,
   mockTransferMutate,
   mockTransferReset,
   mockTransferPending,
@@ -24,12 +24,6 @@ const {
   mockUseChainId: vi.fn(),
   mockUseTeamStore: vi.fn(),
   mockuseGetSafeInfoQuery: vi.fn(),
-  mockQueryClient: {
-    invalidateQueries: vi.fn(async () => undefined),
-    getQueryData: vi.fn(() => undefined),
-    setQueryData: vi.fn(() => undefined),
-    removeQueries: vi.fn(() => undefined)
-  },
   mockTransferMutate: vi.fn(),
   mockTransferReset: vi.fn(),
   mockTransferPending: { value: false },
@@ -50,14 +44,6 @@ vi.mock('@/composables/safe', async (importOriginal) => {
   }
 })
 
-vi.mock('@vueuse/core', async () => {
-  const actual = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core')
-  return {
-    ...actual,
-    useStorage: vi.fn()
-  }
-})
-
 vi.mock('@/queries/safe.queries', () => ({
   useGetSafeInfoQuery: mockuseGetSafeInfoQuery
 }))
@@ -65,23 +51,6 @@ vi.mock('@/queries/safe.queries', () => ({
 vi.mock('@/queries/safe.mutations', () => ({
   useTransferFromSafeMutation: mockUseTransferFromSafeMutation
 }))
-
-vi.mock('@tanstack/vue-query', () => ({
-  useQueryClient: () => mockQueryClient
-}))
-
-vi.mock('@/utils', async (importOriginal) => {
-  const actual: object = await importOriginal()
-  return {
-    ...actual,
-    getTokenAddress: vi.fn((tokenId: string) => {
-      if (tokenId === 'native') return undefined
-      if (tokenId === 'usdc') return '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
-      if (tokenId === 'usdt') return '0xdAC17F958D2ee523a2206206994597C13D831ec7'
-      return undefined
-    })
-  }
-})
 
 // Test constants
 const MOCK_DATA = {
@@ -183,6 +152,18 @@ describe('SafeBalanceSection', () => {
     mockTransferReset.mockReset()
 
     vi.mocked(useStorage).mockReturnValue(mockCurrency as never)
+    useQueryClientFn.mockReturnValue({
+      invalidateQueries: vi.fn(async () => undefined),
+      getQueryData: vi.fn(() => undefined),
+      setQueryData: vi.fn(() => undefined),
+      removeQueries: vi.fn(() => undefined)
+    })
+    vi.spyOn(utils, 'getTokenAddress').mockImplementation((tokenId: string) => {
+      if (tokenId === 'native') return undefined
+      if (tokenId === 'usdc') return '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+      if (tokenId === 'usdt') return '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+      return undefined
+    })
 
     mockGetSafeHomeUrl.mockReturnValue(
       'https://app.safe.global/home?safe=polygon:0x1234567890123456789012345678901234567890'

--- a/app/src/components/sections/SafeView/__tests__/SafeOwnersCard.spec.ts
+++ b/app/src/components/sections/SafeView/__tests__/SafeOwnersCard.spec.ts
@@ -76,16 +76,6 @@ vi.mock('@/composables/safe', () => ({
   openSafeAppUrl: mockOpenSafeAppUrl
 }))
 
-// Mock utils
-vi.mock('@/utils', () => ({
-  log: {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn()
-  }
-}))
-
 // Component stubs
 const SELECTORS = {
   card: '[data-test="card-component"]',

--- a/app/src/components/sections/SafeView/forms/__tests__/AddSignerModal.spec.ts
+++ b/app/src/components/sections/SafeView/forms/__tests__/AddSignerModal.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
 import { nextTick, type ComponentPublicInstance } from 'vue'
 import type { User } from '@/types'
+import { mockUseChainId } from '@/tests/mocks'
 import { mockToast } from '@/tests/mocks/store.mock'
 
 interface AddSignerModalInstance extends ComponentPublicInstance {
@@ -24,19 +25,10 @@ interface AddSignerModalInstance extends ComponentPublicInstance {
   handleAddSigners(): Promise<void>
 }
 
-const { mockChainId, mockUpdateOwnersMutate, mockUpdateOwnersPending } = vi.hoisted(() => ({
-  mockChainId: { value: 137 },
+const { mockUpdateOwnersMutate, mockUpdateOwnersPending } = vi.hoisted(() => ({
   mockUpdateOwnersMutate: vi.fn(),
   mockUpdateOwnersPending: { value: false }
 }))
-
-vi.mock('@wagmi/vue', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@wagmi/vue')>()
-  return {
-    ...actual,
-    useChainId: vi.fn(() => mockChainId)
-  }
-})
 
 vi.mock('@/queries/safe.mutations', () => ({
   useUpdateSafeOwnersMutation: () => ({
@@ -79,6 +71,7 @@ const createWrapper = (props = {}): VueWrapper<AddSignerModalInstance> =>
 describe('AddSignerModal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseChainId.value = 137
     mockUpdateOwnersPending.value = false
     mockUpdateOwnersMutate.mockImplementation(() => undefined)
   })

--- a/app/src/components/sections/SafeView/forms/__tests__/UpdateThresholdModal.spec.ts
+++ b/app/src/components/sections/SafeView/forms/__tests__/UpdateThresholdModal.spec.ts
@@ -3,6 +3,7 @@ import UpdateThresholdModal from '@/components/sections/SafeView/forms/UpdateThr
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, type ComponentPublicInstance } from 'vue'
 import { mount } from '@vue/test-utils'
+import { mockUseChainId } from '@/tests/mocks'
 
 interface UpdateThresholdModalVm extends ComponentPublicInstance {
   formState: {
@@ -12,19 +13,10 @@ interface UpdateThresholdModalVm extends ComponentPublicInstance {
   handleUpdateThreshold: () => Promise<void>
 }
 
-const { mockChainId, mockUpdateOwnersMutate, mockUpdateOwnersPending } = vi.hoisted(() => ({
-  mockChainId: { value: 137 },
+const { mockUpdateOwnersMutate, mockUpdateOwnersPending } = vi.hoisted(() => ({
   mockUpdateOwnersMutate: vi.fn(),
   mockUpdateOwnersPending: { value: false }
 }))
-
-vi.mock('@wagmi/vue', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@wagmi/vue')>()
-  return {
-    ...actual,
-    useChainId: vi.fn(() => mockChainId)
-  }
-})
 
 vi.mock('@/queries/safe.mutations', () => ({
   useUpdateSafeOwnersMutation: () => ({
@@ -103,7 +95,7 @@ const mountComponent = (props = {}) =>
 describe('UpdateThresholdModal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockChainId.value = 137
+    mockUseChainId.value = 137
     mockUpdateOwnersPending.value = false
     mockUpdateOwnersMutate.mockImplementation(() => undefined)
     vi.spyOn(console, 'error').mockImplementation(() => undefined)

--- a/app/src/components/sections/SherTokenView/__tests__/InvestorsTransaction.advanced.spec.ts
+++ b/app/src/components/sections/SherTokenView/__tests__/InvestorsTransaction.advanced.spec.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { type VueWrapper } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import * as utils from '@/utils'
+import { useTeamStore } from '@/stores'
+import { useCurrencyStore } from '@/stores/currencyStore'
+import { mockInvestorReads } from '@/tests/mocks'
 
 // Auto-imported @nuxt/ui components bypass `config.global.stubs` because the
 // Nuxt UI Vite plugin resolves them through their file path. Mocking the
@@ -39,7 +42,6 @@ const tableData = (wrapper: VueWrapper) =>
 const {
   apolloState,
   capture,
-  mockUseQuery,
   mockGetTokenPrice,
   mockInvestorSymbolData,
   mockGetContractAddressByType
@@ -57,7 +59,6 @@ const {
     investor: null as unknown as { value: string },
     safe: null as unknown as { value: string }
   }
-  const mockUseQuery = vi.fn()
   const mockGetTokenPrice = vi.fn(() => 1)
   const mockInvestorSymbolData = { value: 'SHER' }
   const mockGetContractAddressByType = vi.fn((type: string) => {
@@ -68,22 +69,10 @@ const {
   return {
     apolloState,
     capture,
-    mockUseQuery,
     mockGetTokenPrice,
     mockInvestorSymbolData,
     mockGetContractAddressByType
   }
-})
-
-vi.mock('@vue/apollo-composable', async () => {
-  const { ref } = await import('vue')
-  apolloState.investorResult = ref()
-  apolloState.investorError = ref<Error | null>(null)
-  apolloState.investorLoading = ref(false)
-  apolloState.safeResult = ref()
-  apolloState.safeError = ref<Error | null>(null)
-  apolloState.safeLoading = ref(false)
-  return { useQuery: mockUseQuery }
 })
 
 vi.mock('@/composables/investor/useInvestorEventsViaLogs', async () => {
@@ -120,33 +109,6 @@ vi.mock('@/composables/investor/useSafeDepositRouterEventsViaLogs', async () => 
   }
 })
 
-vi.mock('@/stores', () => ({
-  useTeamStore: () => ({
-    getContractAddressByType: mockGetContractAddressByType,
-    getInvestorAddress: () =>
-      mockGetContractAddressByType('Investor') || mockGetContractAddressByType('InvestorV1')
-  }),
-  useCurrencyStore: () => ({
-    localCurrency: { code: 'USD' },
-    supportedTokens: [{ id: 'usdc', symbol: 'USDC', address: USDC_ADDRESS }],
-    getTokenPrice: mockGetTokenPrice
-  })
-}))
-
-vi.mock('@/stores/currencyStore', () => ({
-  useCurrencyStore: () => ({
-    localCurrency: { code: 'USD' },
-    supportedTokens: [{ id: 'usdc', symbol: 'USDC', address: USDC_ADDRESS }],
-    getTokenPrice: mockGetTokenPrice
-  })
-}))
-
-vi.mock('@/composables/investor/reads', () => ({
-  useInvestorSymbol: () => ({
-    data: mockInvestorSymbolData
-  })
-}))
-
 describe('InvestorsTransactions advanced', () => {
   let wrapper: VueWrapper
 
@@ -160,23 +122,22 @@ describe('InvestorsTransactions advanced', () => {
     apolloState.safeLoading.value = false
     mockGetTokenPrice.mockReturnValue(1)
     mockInvestorSymbolData.value = 'SHER'
+    mockInvestorReads.symbol.data.value = 'SHER'
     mockGetContractAddressByType.mockImplementation((type: string) => {
       if (type === 'InvestorV1') return INVESTOR_ADDRESS
       if (type === 'SafeDepositRouter') return SAFE_ROUTER_ADDRESS
       return null
     })
-    mockUseQuery.mockReset()
-    mockUseQuery
-      .mockReturnValueOnce({
-        result: apolloState.investorResult,
-        error: apolloState.investorError,
-        loading: apolloState.investorLoading
-      })
-      .mockReturnValueOnce({
-        result: apolloState.safeResult,
-        error: apolloState.safeError,
-        loading: apolloState.safeLoading
-      })
+    vi.mocked(useTeamStore).mockReturnValue({
+      getContractAddressByType: mockGetContractAddressByType,
+      getInvestorAddress: () =>
+        mockGetContractAddressByType('Investor') || mockGetContractAddressByType('InvestorV1')
+    } as never)
+    vi.mocked(useCurrencyStore).mockReturnValue({
+      localCurrency: { code: 'USD' },
+      supportedTokens: [{ id: 'usdc', symbol: 'USDC', address: USDC_ADDRESS }],
+      getTokenPrice: mockGetTokenPrice
+    } as never)
   })
 
   afterEach(() => {

--- a/app/src/components/sections/SherTokenView/__tests__/InvestorsTransaction.spec.ts
+++ b/app/src/components/sections/SherTokenView/__tests__/InvestorsTransaction.spec.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { type VueWrapper } from '@vue/test-utils'
 import { nextTick } from 'vue'
+import { useTeamStore } from '@/stores'
+import { useCurrencyStore } from '@/stores/currencyStore'
+import { mockInvestorReads } from '@/tests/mocks'
 
 // Auto-imported @nuxt/ui components bypass `config.global.stubs` because the
 // Nuxt UI Vite plugin resolves them through their file path. Mocking the
@@ -41,48 +44,30 @@ const tableColumns = (wrapper: VueWrapper) =>
 const tableLoading = (wrapper: VueWrapper) =>
   wrapper.findComponent({ name: 'UTable' }).props('loading') as boolean
 
-const {
-  apolloState,
-  mockUseQuery,
-  mockGetTokenPrice,
-  mockInvestorSymbolData,
-  mockGetContractAddressByType
-} = vi.hoisted(() => {
-  const apolloState = {
-    investorResult: null as unknown as { value: unknown },
-    investorError: null as unknown as { value: Error | null },
-    investorLoading: null as unknown as { value: boolean },
-    safeResult: null as unknown as { value: unknown },
-    safeError: null as unknown as { value: Error | null },
-    safeLoading: null as unknown as { value: boolean }
-  }
-  const mockUseQuery = vi.fn()
-  const mockGetTokenPrice = vi.fn(() => 1)
-  const mockInvestorSymbolData = { value: 'SHER' }
-  const mockGetContractAddressByType = vi.fn((type: string) => {
-    if (type === 'InvestorV1') return INVESTOR_ADDRESS
-    if (type === 'SafeDepositRouter') return SAFE_ROUTER_ADDRESS
-    return null
+const { apolloState, mockGetTokenPrice, mockInvestorSymbolData, mockGetContractAddressByType } =
+  vi.hoisted(() => {
+    const apolloState = {
+      investorResult: null as unknown as { value: unknown },
+      investorError: null as unknown as { value: Error | null },
+      investorLoading: null as unknown as { value: boolean },
+      safeResult: null as unknown as { value: unknown },
+      safeError: null as unknown as { value: Error | null },
+      safeLoading: null as unknown as { value: boolean }
+    }
+    const mockGetTokenPrice = vi.fn(() => 1)
+    const mockInvestorSymbolData = { value: 'SHER' }
+    const mockGetContractAddressByType = vi.fn((type: string) => {
+      if (type === 'InvestorV1') return INVESTOR_ADDRESS
+      if (type === 'SafeDepositRouter') return SAFE_ROUTER_ADDRESS
+      return null
+    })
+    return {
+      apolloState,
+      mockGetTokenPrice,
+      mockInvestorSymbolData,
+      mockGetContractAddressByType
+    }
   })
-  return {
-    apolloState,
-    mockUseQuery,
-    mockGetTokenPrice,
-    mockInvestorSymbolData,
-    mockGetContractAddressByType
-  }
-})
-
-vi.mock('@vue/apollo-composable', async () => {
-  const { ref } = await import('vue')
-  apolloState.investorResult = ref()
-  apolloState.investorError = ref<Error | null>(null)
-  apolloState.investorLoading = ref(false)
-  apolloState.safeResult = ref()
-  apolloState.safeError = ref<Error | null>(null)
-  apolloState.safeLoading = ref(false)
-  return { useQuery: mockUseQuery }
-})
 
 vi.mock('@/composables/investor/useInvestorEventsViaLogs', async () => {
   const { ref } = await import('vue')
@@ -112,31 +97,6 @@ vi.mock('@/composables/investor/useSafeDepositRouterEventsViaLogs', async () => 
   }
 })
 
-vi.mock('@/stores', () => ({
-  useTeamStore: () => ({
-    getContractAddressByType: mockGetContractAddressByType
-  }),
-  useCurrencyStore: () => ({
-    localCurrency: { code: 'USD' },
-    supportedTokens: [{ id: 'usdc', symbol: 'USDC', address: USDC_ADDRESS }],
-    getTokenPrice: mockGetTokenPrice
-  })
-}))
-
-vi.mock('@/stores/currencyStore', () => ({
-  useCurrencyStore: () => ({
-    localCurrency: { code: 'USD' },
-    supportedTokens: [{ id: 'usdc', symbol: 'USDC', address: USDC_ADDRESS }],
-    getTokenPrice: mockGetTokenPrice
-  })
-}))
-
-vi.mock('@/composables/investor/reads', () => ({
-  useInvestorSymbol: () => ({
-    data: mockInvestorSymbolData
-  })
-}))
-
 describe('InvestorsTransactions', () => {
   let wrapper: VueWrapper
 
@@ -150,23 +110,20 @@ describe('InvestorsTransactions', () => {
     apolloState.safeLoading.value = false
     mockGetTokenPrice.mockReturnValue(1)
     mockInvestorSymbolData.value = 'SHER'
+    mockInvestorReads.symbol.data.value = 'SHER'
     mockGetContractAddressByType.mockImplementation((type: string) => {
       if (type === 'InvestorV1') return INVESTOR_ADDRESS
       if (type === 'SafeDepositRouter') return SAFE_ROUTER_ADDRESS
       return null
     })
-    mockUseQuery.mockReset()
-    mockUseQuery
-      .mockReturnValueOnce({
-        result: apolloState.investorResult,
-        error: apolloState.investorError,
-        loading: apolloState.investorLoading
-      })
-      .mockReturnValueOnce({
-        result: apolloState.safeResult,
-        error: apolloState.safeError,
-        loading: apolloState.safeLoading
-      })
+    vi.mocked(useTeamStore).mockReturnValue({
+      getContractAddressByType: mockGetContractAddressByType
+    } as never)
+    vi.mocked(useCurrencyStore).mockReturnValue({
+      localCurrency: { code: 'USD' },
+      supportedTokens: [{ id: 'usdc', symbol: 'USDC', address: USDC_ADDRESS }],
+      getTokenPrice: mockGetTokenPrice
+    } as never)
   })
 
   afterEach(() => {

--- a/app/src/components/sections/SherTokenView/__tests__/InvestorsTransaction.test-utils.ts
+++ b/app/src/components/sections/SherTokenView/__tests__/InvestorsTransaction.test-utils.ts
@@ -42,34 +42,6 @@ export const {
   }
 })
 
-vi.mock('@vue/apollo-composable', async () => {
-  const { ref } = await import('vue')
-  apolloState.investorResult = ref()
-  apolloState.investorError = ref<Error | null>(null)
-  apolloState.investorLoading = ref(false)
-  apolloState.safeResult = ref()
-  apolloState.safeError = ref<Error | null>(null)
-  apolloState.safeLoading = ref(false)
-  return { useQuery: mockUseQuery }
-})
-
-vi.mock('@/stores', () => ({
-  useTeamStore: () => ({
-    getContractAddressByType: mockGetContractAddressByType
-  }),
-  useCurrencyStore: () => ({
-    localCurrency: { code: 'USD' },
-    supportedTokens: [{ id: 'usdc', symbol: 'USDC', address: USDC_ADDRESS }],
-    getTokenPrice: mockGetTokenPrice
-  })
-}))
-
-vi.mock('@/composables/investor/reads', () => ({
-  useInvestorSymbol: () => ({
-    data: mockInvestorSymbolData
-  })
-}))
-
 const UCardStub = defineComponent({
   name: 'UCard',
   template: '<div><slot name="header" /><slot /></div>'

--- a/app/src/components/sections/SherTokenView/forms/__tests__/MintForm.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/MintForm.spec.ts
@@ -4,7 +4,13 @@ import { createTestingPinia } from '@pinia/testing'
 import { ref } from 'vue'
 import { parseUnits } from 'viem'
 import MintForm from '../MintForm.vue'
-import { mockToast, mockTeamStore, mockInvestorWrites, useReadContractFn } from '@/tests/mocks'
+import {
+  mockToast,
+  mockTeamStore,
+  mockInvestorReads,
+  mockInvestorWrites,
+  useReadContractFn
+} from '@/tests/mocks'
 
 const VALID_ADDRESS = '0x1234567890123456789012345678901234567890'
 
@@ -13,19 +19,9 @@ type MintOptions = {
   onError?: (e: unknown) => void
 }
 
-const symbolRef = ref('SHER')
-const totalSupplyRef = ref<bigint | undefined>(undefined)
-const recipientBalanceRef = ref<bigint | undefined>(undefined)
-
-vi.mock('@/composables/investor/reads', () => ({
-  useInvestorSymbol: vi.fn(() => ({ data: symbolRef })),
-  useInvestorTotalSupply: vi.fn(() => ({ data: totalSupplyRef })),
-  useInvestorBalanceOf: vi.fn(() => ({ data: recipientBalanceRef }))
-}))
-
 const setSupplyAndBalance = (supply: bigint, balance: bigint) => {
-  totalSupplyRef.value = supply
-  recipientBalanceRef.value = balance
+  mockInvestorReads.totalSupply.data.value = supply
+  mockInvestorReads.balanceOf.data.value = balance
 }
 
 // Stake fields reach the form via an emitted payload, then UForm re-validates — let both
@@ -72,9 +68,9 @@ describe('MintForm.vue', () => {
     vi.clearAllMocks()
     vi.stubGlobal('useToast', () => mockToast)
 
-    symbolRef.value = 'SHER'
-    totalSupplyRef.value = undefined
-    recipientBalanceRef.value = undefined
+    mockInvestorReads.symbol.data.value = 'SHER'
+    mockInvestorReads.totalSupply.data.value = undefined
+    mockInvestorReads.balanceOf.data.value = undefined
 
     mockTeamStore.getContractAddressByType = vi.fn(
       () => '0x2222222222222222222222222222222222222222'
@@ -87,8 +83,8 @@ describe('MintForm.vue', () => {
     useReadContractFn
       .mockReset()
       .mockImplementation(({ functionName }: { functionName: string }) => {
-        if (functionName === 'symbol') return { data: symbolRef }
-        if (functionName === 'totalSupply') return { data: totalSupplyRef }
+        if (functionName === 'symbol') return { data: mockInvestorReads.symbol.data }
+        if (functionName === 'totalSupply') return { data: mockInvestorReads.totalSupply.data }
         return { data: ref(undefined) }
       })
   })

--- a/app/src/components/sections/SherTokenView/forms/__tests__/MintRecapCard.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/MintRecapCard.spec.ts
@@ -1,19 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { ref } from 'vue'
 import MintRecapCard from '../MintRecapCard.vue'
-import { renderWithProviders } from '@/tests/mocks'
+import { mockInvestorReads, renderWithProviders } from '@/tests/mocks'
 
 const VALID_ADDRESS = '0x1234567890123456789012345678901234567890'
-
-const symbolRef = ref<string | undefined>('SHER')
-const totalSupplyRef = ref<bigint | undefined>(100_000_000n)
-const recipientBalanceRef = ref<bigint | undefined>(20_000_000n)
-
-vi.mock('@/composables/investor/reads', () => ({
-  useInvestorSymbol: vi.fn(() => ({ data: symbolRef })),
-  useInvestorTotalSupply: vi.fn(() => ({ data: totalSupplyRef })),
-  useInvestorBalanceOf: vi.fn(() => ({ data: recipientBalanceRef }))
-}))
 
 const mountRecap = (props: Record<string, unknown> = {}) =>
   renderWithProviders(MintRecapCard, {
@@ -28,9 +17,9 @@ const mountRecap = (props: Record<string, unknown> = {}) =>
 describe('MintRecapCard.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    symbolRef.value = 'SHER'
-    totalSupplyRef.value = 100_000_000n
-    recipientBalanceRef.value = 20_000_000n
+    mockInvestorReads.symbol.data.value = 'SHER'
+    mockInvestorReads.totalSupply.data.value = 100_000_000n
+    mockInvestorReads.balanceOf.data.value = 20_000_000n
   })
 
   it('renders recap lines for valid recipient context', () => {
@@ -54,9 +43,9 @@ describe('MintRecapCard.vue', () => {
   })
 
   it('formats recap stake and supply lines with expected precision for decimal issuance', () => {
-    totalSupplyRef.value = 50_000_000n
-    recipientBalanceRef.value = 28_000_000n
-    symbolRef.value = 'shr'
+    mockInvestorReads.totalSupply.data.value = 50_000_000n
+    mockInvestorReads.balanceOf.data.value = 28_000_000n
+    mockInvestorReads.symbol.data.value = 'shr'
 
     const wrapper = mountRecap({ issuedAmount: 1.162791 })
 
@@ -70,9 +59,9 @@ describe('MintRecapCard.vue', () => {
   })
 
   it('truncates a near-100% recap stake instead of rounding it up', () => {
-    totalSupplyRef.value = 50_000_000n
-    recipientBalanceRef.value = 28_000_000n
-    symbolRef.value = 'shr'
+    mockInvestorReads.totalSupply.data.value = 50_000_000n
+    mockInvestorReads.balanceOf.data.value = 28_000_000n
+    mockInvestorReads.symbol.data.value = 'shr'
 
     const wrapper = mountRecap({ issuedAmount: 219_999_949.871549 })
 
@@ -83,9 +72,9 @@ describe('MintRecapCard.vue', () => {
   })
 
   it('shows status-only recap lines when amount is unsolvable', () => {
-    totalSupplyRef.value = 50_000_000n
-    recipientBalanceRef.value = 28_000_000n
-    symbolRef.value = 'shr'
+    mockInvestorReads.totalSupply.data.value = 50_000_000n
+    mockInvestorReads.balanceOf.data.value = 28_000_000n
+    mockInvestorReads.symbol.data.value = 'shr'
 
     const wrapper = mountRecap({
       issuedAmount: null,
@@ -104,7 +93,7 @@ describe('MintRecapCard.vue', () => {
   })
 
   it('does not render recap card when token symbol is unavailable', () => {
-    symbolRef.value = undefined
+    mockInvestorReads.symbol.data.value = undefined
     const wrapper = mountRecap()
     expect(wrapper.find('[data-test="recap-card"]').exists()).toBe(false)
   })

--- a/app/src/components/sections/SherTokenView/forms/__tests__/MintStakeSection.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/MintStakeSection.spec.ts
@@ -1,18 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
-import { ref } from 'vue'
 import MintStakeSection from '../MintStakeSection.vue'
+import { mockInvestorReads } from '@/tests/mocks'
 
 const VALID_ADDRESS = '0x1234567890123456789012345678901234567890'
-
-const totalSupplyRef = ref<bigint | undefined>(undefined)
-const recipientBalanceRef = ref<bigint | undefined>(undefined)
-
-vi.mock('@/composables/investor/reads', () => ({
-  useInvestorTotalSupply: vi.fn(() => ({ data: totalSupplyRef })),
-  useInvestorBalanceOf: vi.fn(() => ({ data: recipientBalanceRef }))
-}))
 
 const mountSection = (recipientAddress = VALID_ADDRESS) =>
   mount(MintStakeSection, {
@@ -58,8 +50,8 @@ const mountSection = (recipientAddress = VALID_ADDRESS) =>
 describe('MintStakeSection.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    totalSupplyRef.value = 100_000_000n
-    recipientBalanceRef.value = 20_000_000n
+    mockInvestorReads.totalSupply.data.value = 100_000_000n
+    mockInvestorReads.balanceOf.data.value = 20_000_000n
   })
 
   it('renders mode buttons and child sections', () => {
@@ -104,8 +96,8 @@ describe('MintStakeSection.vue', () => {
   })
 
   it('converts ending amount to final stake percentage (not amount/supply)', async () => {
-    totalSupplyRef.value = 50_000_000n
-    recipientBalanceRef.value = 28_000_000n
+    mockInvestorReads.totalSupply.data.value = 50_000_000n
+    mockInvestorReads.balanceOf.data.value = 28_000_000n
     const wrapper = mountSection()
     wrapper.findComponent({ name: 'TwinAmountInputs' }).vm.$emit('update:amount', 100)
     await flushPromises()
@@ -117,8 +109,8 @@ describe('MintStakeSection.vue', () => {
   })
 
   it('keeps add-mode percentage-to-amount sync for high percentages', async () => {
-    totalSupplyRef.value = 50_000_000n
-    recipientBalanceRef.value = undefined
+    mockInvestorReads.totalSupply.data.value = 50_000_000n
+    mockInvestorReads.balanceOf.data.value = undefined
     const wrapper = mountSection()
     await wrapper.find('[data-test="add-mode-button"]').trigger('click')
     wrapper.findComponent({ name: 'TwinAmountInputs' }).vm.$emit('update:percentage', 99)
@@ -133,8 +125,8 @@ describe('MintStakeSection.vue', () => {
   })
 
   it('disables ending mode and defaults to add mode on empty supply', async () => {
-    totalSupplyRef.value = 0n
-    recipientBalanceRef.value = 0n
+    mockInvestorReads.totalSupply.data.value = 0n
+    mockInvestorReads.balanceOf.data.value = 0n
     const wrapper = mountSection()
     await flushPromises()
 
@@ -145,8 +137,8 @@ describe('MintStakeSection.vue', () => {
   })
 
   it('disables percentage editing when recipient already owns full supply', () => {
-    totalSupplyRef.value = 100_000_000n
-    recipientBalanceRef.value = 100_000_000n
+    mockInvestorReads.totalSupply.data.value = 100_000_000n
+    mockInvestorReads.balanceOf.data.value = 100_000_000n
     const wrapper = mountSection()
 
     expect(wrapper.find('[data-test="stub-disable-percentage"]').text()).toBe('true')

--- a/app/src/components/sections/SherTokenView/forms/__tests__/TwinAmountInputs.spec.ts
+++ b/app/src/components/sections/SherTokenView/forms/__tests__/TwinAmountInputs.spec.ts
@@ -1,16 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
-import { ref } from 'vue'
 import TwinAmountInputs from '../TwinAmountInputs.vue'
-
-const totalSupplyRef = ref<bigint | undefined>(undefined)
-const symbolRef = ref<string | undefined>('SHER')
-
-vi.mock('@/composables/investor/reads', () => ({
-  useInvestorSymbol: vi.fn(() => ({ data: symbolRef })),
-  useInvestorTotalSupply: vi.fn(() => ({ data: totalSupplyRef }))
-}))
+import { mockInvestorReads } from '@/tests/mocks'
 
 const mountInputs = (props: Record<string, unknown> = {}) =>
   mount(TwinAmountInputs, {
@@ -30,8 +22,8 @@ const mountInputs = (props: Record<string, unknown> = {}) =>
 describe('TwinAmountInputs.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    totalSupplyRef.value = 100_000_000n
-    symbolRef.value = 'SHER'
+    mockInvestorReads.totalSupply.data.value = 100_000_000n
+    mockInvestorReads.symbol.data.value = 'SHER'
   })
 
   it('renders sync helper and token symbol', () => {
@@ -55,7 +47,7 @@ describe('TwinAmountInputs.vue', () => {
   })
 
   it('disables percentage input when total supply is zero', () => {
-    totalSupplyRef.value = 0n
+    mockInvestorReads.totalSupply.data.value = 0n
     const wrapper = mountInputs({ percentage: 40 })
 
     const percentageInput = wrapper.find('input[data-test="percentage-input"]')

--- a/app/src/components/sections/VestingView/__tests__/VestingFlow.spec.ts
+++ b/app/src/components/sections/VestingView/__tests__/VestingFlow.spec.ts
@@ -4,7 +4,13 @@ import VestingFlow from '@/components/sections/VestingView/VestingFlow.vue'
 import { createTestingPinia } from '@pinia/testing'
 import { ref } from 'vue'
 import VestingActions from '@/components/sections/VestingView/VestingActions.vue'
-import { mockVestingWrites, mockTeamStore, mockUserStore } from '@/tests/mocks'
+import {
+  mockInvestorReads,
+  mockVestingReads,
+  mockVestingWrites,
+  mockTeamStore,
+  mockUserStore
+} from '@/tests/mocks'
 
 const mockReloadKey = ref(0)
 const MEMBER = mockUserStore.address
@@ -12,39 +18,6 @@ const MEMBER = mockUserStore.address
 // Active vesting tuple shaped like the on-chain return: [members, indices, infos].
 // The single schedule lives at on-chain array index 3 for this member.
 const SCHEDULE_INDEX = 3n
-const activeVestings = ref([
-  [MEMBER],
-  [SCHEDULE_INDEX],
-  [
-    {
-      start: BigInt(Math.floor(Date.now() / 1000) - 3600),
-      duration: BigInt(30 * 86400),
-      cliff: 0n,
-      totalAmount: BigInt(10e18),
-      released: BigInt(2e18),
-      active: true
-    }
-  ]
-])
-
-vi.mock('@/composables/vesting/reads', () => ({
-  useVestingAddress: vi.fn(() => ref('0x1000000000000000000000000000000000000001')),
-  useVestingGetVestingsWithMembers: vi.fn(() => ({
-    data: activeVestings,
-    error: ref(null),
-    refetch: vi.fn()
-  })),
-  useVestingGetAllArchivedVestingsFlat: vi.fn(() => ({
-    data: ref(null),
-    error: ref(null),
-    refetch: vi.fn()
-  }))
-}))
-
-vi.mock('@/composables/investor/reads', () => ({
-  useInvestorSymbol: vi.fn(() => ({ data: ref('SHR') }))
-}))
-
 type MutateOptions = {
   onSuccess?: () => void | Promise<void>
   onError?: (err: Error) => void | Promise<void>
@@ -65,6 +38,22 @@ describe('VestingFlow.vue', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockInvestorReads.symbol.data.value = 'SHR'
+    mockVestingReads.vestingsWithMembers.data.value = [
+      [MEMBER],
+      [SCHEDULE_INDEX],
+      [
+        {
+          start: BigInt(Math.floor(Date.now() / 1000) - 3600),
+          duration: BigInt(30 * 86400),
+          cliff: 0n,
+          totalAmount: BigInt(10e18),
+          released: BigInt(2e18),
+          active: true
+        }
+      ]
+    ]
+    mockVestingReads.archivedVestingsFlat.data.value = [[], [], []]
     mockVestingWrites.stopVesting.mutate.mockReset()
     mockVestingWrites.release.mutate.mockReset()
     mockTeamStore.currentTeam = {

--- a/app/src/components/sections/VestingView/__tests__/VestingStats.spec.ts
+++ b/app/src/components/sections/VestingView/__tests__/VestingStats.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { type VueWrapper } from '@vue/test-utils'
-import { renderWithProviders } from '@/tests/mocks'
+import { mockInvestorReads, mockVestingReads, renderWithProviders } from '@/tests/mocks'
 
 // Auto-imported @nuxt/ui components bypass `config.global.stubs` because the
 // Nuxt UI Vite plugin resolves them through their file path. Mock the module
@@ -26,68 +26,7 @@ import { ref } from 'vue'
 
 // Constants
 const memberAddress = '0x000000000000000000000000000000000000dead'
-const mockSymbol = ref<string>('shr')
 const mockReloadKey = ref<number>(0)
-// Mocks — reads return a 3-tuple [members, indices, infos]; a member appears
-// once per schedule.
-const mockVestingInfos = ref<[string[], bigint[], { totalAmount: number; released: number }[]]>([
-  [memberAddress],
-  [0n],
-  [
-    {
-      totalAmount: 0,
-      released: 0
-    }
-  ]
-])
-
-const refetchVestingInfos = vi.fn()
-
-const mockArchivedInfos = ref([[], [], []])
-
-vi.mock('@/composables/investor/reads', () => ({
-  useInvestorSymbol: vi.fn(() => ({
-    data: mockSymbol,
-    error: ref(null),
-    refetch: vi.fn()
-  }))
-}))
-
-vi.mock('@wagmi/vue', async (importOriginal) => {
-  const actual: object = await importOriginal()
-  return {
-    ...actual,
-    useReadContract: vi.fn(({ functionName }: { functionName: string }) => {
-      if (functionName === 'getVestingsWithMembers') {
-        return {
-          data: mockVestingInfos,
-          error: ref(null),
-          refetch: refetchVestingInfos
-        }
-      }
-      if (functionName === 'getAllArchivedVestingsFlat') {
-        return {
-          data: mockArchivedInfos,
-          error: ref(null),
-          refetch: vi.fn()
-        }
-      }
-      if (functionName === 'symbol') {
-        return {
-          data: mockSymbol,
-          error: ref(null),
-          refetch: vi.fn()
-        }
-      }
-      return {
-        data: ref('TST'),
-        error: ref(null),
-        refetch: vi.fn()
-      }
-    })
-  }
-})
-
 // Test suite
 describe('VestingStats.vue', () => {
   let wrapper: VueWrapper
@@ -102,12 +41,19 @@ describe('VestingStats.vue', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockInvestorReads.symbol.data.value = 'shr'
+    mockVestingReads.vestingsWithMembers.data.value = [
+      [memberAddress],
+      [0n],
+      [{ totalAmount: 0, released: 0 }]
+    ]
+    mockVestingReads.archivedVestingsFlat.data.value = [[], [], []]
     wrapper = mountComponent()
   })
 
   it('calculates token summary correctly from vestings data', async () => {
     // Setup mock data with two schedules for the same member (one per index).
-    mockVestingInfos.value = [
+    mockVestingReads.vestingsWithMembers.data.value = [
       [memberAddress, memberAddress],
       [0n, 1n],
       [
@@ -132,14 +78,14 @@ describe('VestingStats.vue', () => {
     }>
     expect(tableData).toHaveLength(1) // Should have one row per token symbol
     expect(tableData[0]).toMatchObject({
-      symbol: mockSymbol.value,
+      symbol: mockInvestorReads.symbol.data.value,
       totalPromised: 150,
       totalReleased: 30
     })
   })
 
   it('handles empty vestings array', () => {
-    mockVestingInfos.value = [[], [], []]
+    mockVestingReads.vestingsWithMembers.data.value = [[], [], []]
     wrapper = mountComponent()
 
     const tableData = wrapper.findComponent({ name: 'UTable' }).props('data') as Array<unknown>
@@ -147,8 +93,8 @@ describe('VestingStats.vue', () => {
   })
 
   it('displays formatted token amounts with symbols', async () => {
-    mockSymbol.value = 'TEST'
-    mockVestingInfos.value = [
+    mockInvestorReads.symbol.data.value = 'TEST'
+    mockVestingReads.vestingsWithMembers.data.value = [
       [memberAddress],
       [0n],
       [

--- a/app/src/components/sections/WeeklyClaimView/__tests__/WeeklyClaimActionDropdown.spec.ts
+++ b/app/src/components/sections/WeeklyClaimView/__tests__/WeeklyClaimActionDropdown.spec.ts
@@ -15,11 +15,6 @@ import {
 import { mockLog } from '@/tests/mocks/utils.mock'
 import * as utils from '@/utils'
 
-vi.mock('@/composables/cashRemuneration/writes', () => ({
-  useEnableClaim: vi.fn(() => mockCashRemunerationWrites.enableClaim),
-  useDisableClaim: vi.fn(() => mockCashRemunerationWrites.disableClaim)
-}))
-
 describe('WeeklyClaimActionDropdown', () => {
   const weeklyClaim: WeeklyClaim = {
     id: 1,

--- a/app/src/components/sections/WeeklyClaimView/__tests__/WeeklyClaimActionEnable.spec.ts
+++ b/app/src/components/sections/WeeklyClaimView/__tests__/WeeklyClaimActionEnable.spec.ts
@@ -12,11 +12,6 @@ import {
 import { mockLog } from '@/tests/mocks/utils.mock'
 import * as utils from '@/utils'
 
-vi.mock('@/composables/cashRemuneration/writes', () => ({
-  useEnableClaim: vi.fn(() => mockCashRemunerationWrites.enableClaim),
-  useDisableClaim: vi.fn(() => mockCashRemunerationWrites.disableClaim)
-}))
-
 describe('WeeklyClaimActionEnable', () => {
   const weeklyClaim: WeeklyClaim = {
     id: 1,

--- a/app/src/composables/__tests__/useFileUrl.spec.ts
+++ b/app/src/composables/__tests__/useFileUrl.spec.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useFileUrl, getPresignedUrl } from '../useFileUrl'
-
-const mockGetFileUrlApi = vi.fn()
-
-vi.mock('@/api', () => ({
-  getFileUrlApi: (...args: unknown[]) => mockGetFileUrlApi(...args)
-}))
+import { mockGetFileUrlApi } from '@/tests/mocks'
 
 describe('useFileUrl', () => {
   beforeEach(() => {

--- a/app/src/composables/__tests__/useSiwe.spec.ts
+++ b/app/src/composables/__tests__/useSiwe.spec.ts
@@ -14,16 +14,6 @@ vi.mock('@/api/user.api', () => ({
 vi.mock('@/api/auth.api', () => ({
   siweAuth: vi.fn()
 }))
-vi.mock('@wagmi/core', async (importOriginal) => {
-  const actual: object = await importOriginal()
-  return {
-    ...actual,
-    getConnection: vi.fn(),
-    connect: vi.fn(),
-    switchChain: vi.fn(),
-    signMessage: vi.fn()
-  }
-})
 import {
   useSiweMutation,
   WalletConnectRejectedError,

--- a/app/src/composables/safe/__tests__/useSafeSdk.spec.ts
+++ b/app/src/composables/safe/__tests__/useSafeSdk.spec.ts
@@ -1,36 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useSafeSDK } from '../useSafeSdk'
+import { mockUseConnection } from '@/tests/mocks'
 
-const { mockSafeInit, mockUseConnection, mockIsAddress, mockGetInjectedProvider } = vi.hoisted(
-  () => ({
-    mockSafeInit: vi.fn(),
-    mockUseConnection: vi.fn(),
-    mockIsAddress: vi.fn(),
-    mockGetInjectedProvider: vi.fn()
-  })
-)
+const { mockSafeInit, mockGetInjectedProvider } = vi.hoisted(() => ({
+  mockSafeInit: vi.fn(),
+  mockGetInjectedProvider: vi.fn()
+}))
 
 vi.mock('@safe-global/protocol-kit', () => ({
   default: {
     init: mockSafeInit
   }
 }))
-
-vi.mock('@wagmi/vue', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@wagmi/vue')>()
-  return {
-    ...actual,
-    useConnection: mockUseConnection
-  }
-})
-
-vi.mock('viem', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('viem')>()
-  return {
-    ...actual,
-    isAddress: mockIsAddress
-  }
-})
 
 vi.mock('@/utils/safe', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/utils/safe')>()
@@ -40,28 +21,19 @@ vi.mock('@/utils/safe', async (importOriginal) => {
   }
 })
 
-const createConnection = (isConnected: boolean, address: string | null) => ({
-  isConnected: { value: isConnected },
-  address: { value: address }
-})
-
 describe('useSafeSDK', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseConnection.mockReturnValue(
-      createConnection(true, '0x1111111111111111111111111111111111111111')
-    )
+    mockUseConnection.isConnected.value = true
+    mockUseConnection.address.value = '0x1111111111111111111111111111111111111111'
     mockGetInjectedProvider.mockReturnValue('mock-provider')
-    mockIsAddress.mockImplementation(
-      (address: string) => /^0x[a-fA-F0-9]{40}$/.test(address) || address === '0xSafe'
-    )
     mockSafeInit.mockResolvedValue({ sdk: 'safe' })
     useSafeSDK().clearCache()
   })
 
   describe('createPredictedSafeSdk', () => {
     it('throws when wallet is not connected', async () => {
-      mockUseConnection.mockReturnValue(createConnection(false, null))
+      mockUseConnection.isConnected.value = false
       const { createPredictedSafeSdk } = useSafeSDK()
 
       await expect(

--- a/app/src/composables/safe/__tests__/useSafeTransactionActions.spec.ts
+++ b/app/src/composables/safe/__tests__/useSafeTransactionActions.spec.ts
@@ -3,30 +3,16 @@ import { ref } from 'vue'
 import type { Address } from 'viem'
 import type { SafeTransaction } from '@/types/safe'
 import { useSafeTransactionActions } from '../useSafeTransactionActions'
+import { mockLog, mockUseChainId } from '@/tests/mocks'
 
-const {
-  mockApproveMutate,
-  mockExecuteMutate,
-  mockApprovePending,
-  mockExecutePending,
-  mockChainId,
-  mockLogError
-} = vi.hoisted(() => ({
-  mockApproveMutate: vi.fn(),
-  mockExecuteMutate: vi.fn(),
-  mockApprovePending: { value: false },
-  mockExecutePending: { value: false },
-  mockChainId: { value: 137 },
-  mockLogError: vi.fn()
-}))
-
-vi.mock('@wagmi/vue', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@wagmi/vue')>()
-  return {
-    ...actual,
-    useChainId: vi.fn(() => mockChainId)
-  }
-})
+const { mockApproveMutate, mockExecuteMutate, mockApprovePending, mockExecutePending } = vi.hoisted(
+  () => ({
+    mockApproveMutate: vi.fn(),
+    mockExecuteMutate: vi.fn(),
+    mockApprovePending: { value: false },
+    mockExecutePending: { value: false }
+  })
+)
 
 vi.mock('@/queries/safe.mutations', () => ({
   useApproveTransactionMutation: () => ({
@@ -37,12 +23,6 @@ vi.mock('@/queries/safe.mutations', () => ({
     mutate: mockExecuteMutate,
     isPending: mockExecutePending
   })
-}))
-
-vi.mock('@/utils', () => ({
-  log: {
-    error: mockLogError
-  }
 }))
 
 const baseTransaction: SafeTransaction = {
@@ -88,6 +68,7 @@ const createActions = (options?: {
 describe('useSafeTransactionActions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseChainId.value = 137
     mockApprovePending.value = false
     mockExecutePending.value = false
   })
@@ -133,10 +114,10 @@ describe('useSafeTransactionActions', () => {
     expect(actions.isTransactionLoading(baseTransaction.safeTxHash, 'approve')).toBe(true)
 
     callbacks?.onSuccess?.()
-    expect(mockLogError).not.toHaveBeenCalled()
+    expect(mockLog.error).not.toHaveBeenCalled()
 
     callbacks?.onError?.(new Error('User rejected signature'))
-    expect(mockLogError).toHaveBeenCalledWith('Failed to approve transaction:', expect.any(Error))
+    expect(mockLog.error).toHaveBeenCalledWith('Failed to approve transaction:', expect.any(Error))
 
     mockApprovePending.value = false
     callbacks?.onSettled?.()
@@ -172,10 +153,10 @@ describe('useSafeTransactionActions', () => {
     expect(actions.isTransactionLoading(baseTransaction.safeTxHash, 'execute')).toBe(true)
 
     callbacks?.onSuccess?.()
-    expect(mockLogError).not.toHaveBeenCalled()
+    expect(mockLog.error).not.toHaveBeenCalled()
 
     callbacks?.onError?.({})
-    expect(mockLogError).toHaveBeenCalledWith('Failed to execute transaction:', {})
+    expect(mockLog.error).toHaveBeenCalledWith('Failed to execute transaction:', {})
 
     mockExecutePending.value = false
     callbacks?.onSettled?.()

--- a/app/src/queries/__tests__/contract.queries.spec.ts
+++ b/app/src/queries/__tests__/contract.queries.spec.ts
@@ -7,17 +7,6 @@ import apiClient from '@/lib/axios'
 vi.unmock('@/queries/contract.queries')
 vi.unmock('@/queries/team.queries')
 
-// Stub axios so mutationFn doesn't hit the network.
-vi.mock('@/lib/axios', () => ({
-  default: {
-    get: vi.fn(),
-    post: vi.fn(),
-    put: vi.fn(),
-    patch: vi.fn(),
-    delete: vi.fn()
-  }
-}))
-
 describe('contract.queries', () => {
   beforeEach(async () => {
     vi.clearAllMocks()

--- a/app/src/router/__tests__/index.spec.ts
+++ b/app/src/router/__tests__/index.spec.ts
@@ -17,27 +17,11 @@ import { nextTick } from 'vue'
  */
 
 // Hoist mocks to ensure they're available during module initialization
-const { mockIsAuth, mockUseStorage } = vi.hoisted(() => {
+const { mockIsAuth } = vi.hoisted(() => {
   const mockIsAuth = { value: false }
-  const mockUseStorage = vi.fn(() => mockIsAuth)
-  return { mockIsAuth, mockUseStorage }
+  globalThis.__mockUseStorageValue = mockIsAuth
+  return { mockIsAuth }
 })
-
-vi.mock('@vueuse/core', () => ({
-  useStorage: mockUseStorage,
-  // Minimal stub so composables using createFetch don't explode during dynamic imports
-  createFetch: () => {
-    const fakeJson = () => ({
-      isFetching: { value: false },
-      error: { value: null },
-      data: { value: [] },
-      statusCode: { value: 200 },
-      execute: vi.fn()
-    })
-    // Returned function signature: useCustomFetch(url, options)
-    return () => ({ json: fakeJson })
-  }
-}))
 
 // Mock all dynamic imports before importing router
 vi.mock('@/views/HomeView.vue', () => ({

--- a/app/src/tests/mocks/api.mock.ts
+++ b/app/src/tests/mocks/api.mock.ts
@@ -1,3 +1,4 @@
 import { vi } from 'vitest'
 
 export const mockUploadFileApi = vi.fn()
+export const mockGetFileUrlApi = vi.fn()

--- a/app/src/tests/mocks/contract.mock.ts
+++ b/app/src/tests/mocks/contract.mock.ts
@@ -117,6 +117,11 @@ export const mockVestingWrites = {
   release: createContractWriteV3Mock()
 }
 
+export const mockVestingReads = {
+  vestingsWithMembers: createContractReadMock<unknown>([[], [], []]),
+  archivedVestingsFlat: createContractReadMock<unknown>([[], [], []])
+}
+
 /**
  * Investor Contract Mocks
  */
@@ -194,6 +199,7 @@ export const resetContractMocks = () => {
     mockInvestorReads,
     mockCashRemunerationReads,
     mockExpenseAccountReads,
+    mockVestingReads,
     mockFixedReturnReads
   ]
 

--- a/app/src/tests/mocks/contract.mock.ts
+++ b/app/src/tests/mocks/contract.mock.ts
@@ -88,6 +88,7 @@ export const mockCashRemunerationReads = {
 }
 
 export const mockCashRemunerationWrites = {
+  withdraw: createContractWriteV3Mock(),
   ownerWithdrawAllToBank: createContractWriteV3Mock(),
   enableClaim: createContractWriteV3Mock(),
   disableClaim: createContractWriteV3Mock()

--- a/app/src/tests/mocks/utils.mock.ts
+++ b/app/src/tests/mocks/utils.mock.ts
@@ -7,9 +7,13 @@ export const mockLog = {
   debug: vi.fn()
 }
 
+export const mockGetTokens = vi.fn<() => unknown[]>(() => [])
+
 export const resetUtilsMocks = () => {
   mockLog.error.mockClear()
   mockLog.warn.mockClear()
   mockLog.info.mockClear()
   mockLog.debug.mockClear()
+  mockGetTokens.mockReset()
+  mockGetTokens.mockReturnValue([])
 }

--- a/app/src/tests/mocks/wagmi.vue.mock.ts
+++ b/app/src/tests/mocks/wagmi.vue.mock.ts
@@ -42,7 +42,11 @@ export const mockWagmiCore = {
   getWalletClient: vi.fn(),
   estimateGas: vi.fn(),
   getPublicClient: vi.fn(),
-  getConnections: vi.fn(() => [])
+  getConnections: vi.fn(() => []),
+  getConnection: vi.fn(),
+  connect: vi.fn(),
+  switchChain: vi.fn(),
+  signMessage: vi.fn()
 }
 
 // Mock useConnection composable

--- a/app/src/tests/setup/composables.setup.ts
+++ b/app/src/tests/setup/composables.setup.ts
@@ -18,7 +18,7 @@ import {
   resetComposableMocks,
   resetDeployState
 } from '@/tests/mocks/composables.mock'
-import { mockUploadFileApi } from '@/tests/mocks/api.mock'
+import { mockGetFileUrlApi, mockUploadFileApi } from '@/tests/mocks/api.mock'
 import {
   mockGetBalance,
   mockGetLogs,
@@ -71,7 +71,8 @@ vi.mock('@/api', async (importOriginal) => {
   const actual: object = await importOriginal()
   return {
     ...actual,
-    uploadFileApi: mockUploadFileApi
+    uploadFileApi: mockUploadFileApi,
+    getFileUrlApi: mockGetFileUrlApi
   }
 })
 

--- a/app/src/tests/setup/composables.setup.ts
+++ b/app/src/tests/setup/composables.setup.ts
@@ -38,7 +38,7 @@ beforeEach(() => {
 
 declare global {
   var __mockFetch: ReturnType<typeof vi.fn> | undefined
-  var __mockUseStorageValue: string | undefined
+  var __mockUseStorageValue: unknown
 }
 
 if (!globalThis.__mockFetch) {
@@ -102,7 +102,16 @@ vi.mock('@vueuse/core', async (importOriginal) => {
     useClipboard: vi.fn(() => mockUseClipboard),
     useStorage: vi.fn((key: string, initialValue: unknown, ...rest: unknown[]) => {
       if (globalThis.__mockUseStorageValue !== undefined) {
-        return ref(globalThis.__mockUseStorageValue)
+        const configuredValue = globalThis.__mockUseStorageValue
+        if (
+          typeof configuredValue === 'object' &&
+          configuredValue !== null &&
+          'value' in configuredValue
+        ) {
+          return configuredValue
+        }
+
+        return ref(configuredValue)
       }
 
       if (typeof actual.useStorage === 'function') {

--- a/app/src/tests/setup/treasury.setup.ts
+++ b/app/src/tests/setup/treasury.setup.ts
@@ -15,7 +15,10 @@ vi.mock('@/composables/expenseAccount/reads', () => ({
 }))
 
 vi.mock('@/composables/cashRemuneration/writes', () => ({
-  useOwnerWithdrawAllToBank: vi.fn(() => mockCashRemunerationWrites.ownerWithdrawAllToBank)
+  useWithdraw: vi.fn(() => mockCashRemunerationWrites.withdraw),
+  useOwnerWithdrawAllToBank: vi.fn(() => mockCashRemunerationWrites.ownerWithdrawAllToBank),
+  useEnableClaim: vi.fn(() => mockCashRemunerationWrites.enableClaim),
+  useDisableClaim: vi.fn(() => mockCashRemunerationWrites.disableClaim)
 }))
 
 vi.mock('@/composables/expenseAccount/writes', () => ({

--- a/app/src/tests/setup/utils.setup.ts
+++ b/app/src/tests/setup/utils.setup.ts
@@ -1,5 +1,5 @@
 import { beforeEach, vi } from 'vitest'
-import { mockLog, resetUtilsMocks } from '../mocks/utils.mock'
+import { mockGetTokens, mockLog, resetUtilsMocks } from '../mocks/utils.mock'
 
 // Clear the shared log spies before every test (call history only;
 // implementations are preserved).
@@ -18,6 +18,7 @@ vi.mock('@/utils', async (importOriginal) => {
     log: {
       ...actualLog,
       ...mockLog
-    }
+    },
+    getTokens: mockGetTokens
   }
 })

--- a/app/src/tests/setup/vesting.setup.ts
+++ b/app/src/tests/setup/vesting.setup.ts
@@ -1,12 +1,18 @@
 import { vi } from 'vitest'
-import { mockVestingWrites } from '../mocks/contract.mock'
+import { ref } from 'vue'
+import { mockVestingReads, mockVestingWrites } from '../mocks/contract.mock'
 
 /**
- * Mock Vesting write composables.
- * Vesting reads are mocked per-spec where needed (see CreateVesting tests).
+ * Mock Vesting composables.
  */
 vi.mock('@/composables/vesting/writes', () => ({
   useVestingAddVestingWrite: vi.fn(() => mockVestingWrites.addVesting),
   useVestingStopVestingWrite: vi.fn(() => mockVestingWrites.stopVesting),
   useVestingReleaseWrite: vi.fn(() => mockVestingWrites.release)
+}))
+
+vi.mock('@/composables/vesting/reads', () => ({
+  useVestingAddress: vi.fn(() => ref('0x1000000000000000000000000000000000000001')),
+  useVestingGetVestingsWithMembers: vi.fn(() => mockVestingReads.vestingsWithMembers),
+  useVestingGetAllArchivedVestingsFlat: vi.fn(() => mockVestingReads.archivedVestingsFlat)
 }))

--- a/app/src/views/team/[id]/__tests__/BankView.spec.ts
+++ b/app/src/views/team/[id]/__tests__/BankView.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { shallowMount } from '@vue/test-utils'
 import type { VueWrapper } from '@vue/test-utils'
 import type { ComponentPublicInstance } from 'vue'
@@ -6,14 +6,6 @@ import type { ComponentPublicInstance } from 'vue'
 import { mockTeamStore } from '@/tests/mocks/store.mock'
 
 import BankView from '../Accounts/BankView.vue'
-
-vi.mock('@/stores', async (importOriginal) => {
-  const original: object = await importOriginal()
-  return {
-    ...original,
-    useTeamStore: vi.fn(() => mockTeamStore)
-  }
-})
 
 describe('BankView', () => {
   let wrapper: VueWrapper<ComponentPublicInstance & typeof BankView>

--- a/app/src/views/team/[id]/__tests__/BodElectionView.spec.ts
+++ b/app/src/views/team/[id]/__tests__/BodElectionView.spec.ts
@@ -7,24 +7,17 @@ import CurrentBoDSection from '@/components/sections/AdministrationView/CurrentB
 import CurrentBoDElectionSection from '@/components/sections/AdministrationView/CurrentBoDElectionSection.vue'
 import PastBoDElectionsSection from '@/components/sections/AdministrationView/PastBoDElectionsSection.vue'
 import ContractOwnerCard from '@/components/ContractOwnerCard.vue'
-import { useReadContractFn, mockTeamStore } from '@/tests/mocks'
+import { mockLog, useReadContractFn, mockTeamStore } from '@/tests/mocks'
 import { useTeamStore } from '@/stores'
 
 // Test constants
 const MOCK_ELECTIONS_ADDRESS = '0x1234567890123456789012345678901234567890'
-
-const { mockLog } = vi.hoisted(() => ({
-  mockLog: { error: vi.fn() }
-}))
 
 // Reactive refs created after imports
 const mockUseReadContractData = ref<bigint | number | null>(null)
 const mockUseReadContractError = ref<Error | null>(null)
 const mockUseReadContractIsLoading = ref(false)
 
-vi.mock('@/utils', () => ({
-  log: mockLog
-}))
 vi.mock('@/artifacts/abi/elections', () => ({
   ELECTIONS_ABI: [
     {


### PR DESCRIPTION
## Summary

- migrate every former `globalMockLegacyFiles` spec to the shared test mock setup
- extend shared mocks where a supported contract/API behaviour was missing
- remove the legacy ESLint allowlist so local re-mocks are blocked in every spec

Closes #2485

## Validation

- `npm run lint` (one pre-existing warning: disabled test in `registry.spec.ts`)
- `npm run format-check`
- `npm run type-check`
- `npm run test:unit -- --run`
