### PR TITLE
fix: 🐛 hold a wage change back only when hours are already submitted

### DIFF
--- a/app/src/components/sections/DashboardView/SetMemberWageModal.vue
+++ b/app/src/components/sections/DashboardView/SetMemberWageModal.vue
@@ -27,13 +27,18 @@
 
       <template #body>
         <div class="mt-1 space-y-4">
+          <!--
+            Shown only when the change has to wait. A change that simply takes
+            effect is not news: the new wage is what the member's week will be
+            priced at, and saying so would be noise on the common path.
+          -->
           <UAlert
-            v-if="props.wage"
+            v-if="showEffectiveDateNotice"
             icon="i-heroicons-information-circle"
-            :color="changeTiming.immediate ? 'warning' : 'info'"
+            color="info"
             variant="soft"
             data-test="wage-effective-date-notice"
-            :title="effectiveDateTitle"
+            :title="`This change takes effect on ${changeTiming.label}.`"
             :description="effectiveDateDescription"
           />
 
@@ -119,26 +124,17 @@ const wageData = ref<WageWithForm>(initialWage())
 const changeTiming = computed(() => describeWageChangeTiming(props.wage))
 const scheduledWageNotice = computed(() => formatScheduledWageNotice(props.wage?.scheduledWage))
 
-// Two genuinely different situations, and the owner has to be able to tell
-// them apart before saving. The member has not opened this week yet: the new
-// rate covers the days they have already worked but not yet submitted, which
-// is the case worth a warning. They have: this week is settled at the current
-// rate and only the next one moves.
-const effectiveDateTitle = computed(() =>
-  changeTiming.value.immediate
-    ? 'This change takes effect immediately, for the whole current week.'
-    : `This change takes effect on ${changeTiming.value.label}.`
-)
+// There is only one thing worth telling the owner before they save: that this
+// change will not apply straight away. It cannot, once the member has hours in
+// the week — those are already priced against the current wage. Everywhere
+// else the change just takes effect, and announcing it would say nothing.
+const showEffectiveDateNotice = computed(() => Boolean(props.wage) && !changeTiming.value.immediate)
 
-const effectiveDateDescription = computed(() => {
-  if (changeTiming.value.immediate) {
-    return `${props.member.name ?? 'This member'} has not submitted any hours for this week yet, so hours they have already worked will be paid at the new rate. Wait for them to submit to leave this week untouched.`
-  }
-
-  return scheduledWageNotice.value
+const effectiveDateDescription = computed(() =>
+  scheduledWageNotice.value
     ? `A change is already scheduled for that date (${scheduledWageNotice.value}). Saving replaces it without pushing the date back.`
     : 'Hours are already submitted for this week, so the current rate stays in force until then.'
-})
+)
 
 const items = computed<StepperItem[]>(() =>
   wageData.value.enableOvertimeRules

--- a/app/src/components/sections/DashboardView/SetMemberWageModal.vue
+++ b/app/src/components/sections/DashboardView/SetMemberWageModal.vue
@@ -27,19 +27,14 @@
 
       <template #body>
         <div class="mt-1 space-y-4">
-          s
           <UAlert
             v-if="props.wage"
             icon="i-heroicons-information-circle"
-            color="info"
+            :color="changeTiming.immediate ? 'warning' : 'info'"
             variant="soft"
             data-test="wage-effective-date-notice"
-            :title="`This change takes effect on ${effectiveDateLabel}.`"
-            :description="
-              scheduledWageNotice
-                ? `A change is already scheduled for that date (${scheduledWageNotice}). Saving replaces it without pushing the date back.`
-                : 'The current rate stays in force until then, including for claims backdated to earlier weeks.'
-            "
+            :title="effectiveDateTitle"
+            :description="effectiveDateDescription"
           />
 
           <UStepper :items="items" v-model="currentStep" />
@@ -77,7 +72,7 @@ import { useSetMemberWageMutation } from '@/queries/wage.queries'
 import type { Member, Wage, WageWithForm } from '@/types'
 import type { AxiosError } from 'axios'
 import { normalizeRatePerHour, buildRatePayload, DEFAULT_MAXIMUM_HOURS_PER_DAY } from '@/utils'
-import { formatScheduledWageNotice, nextEffectiveDateLabel } from '@/utils/wageUtil'
+import { describeWageChangeTiming, formatScheduledWageNotice } from '@/utils/wageUtil'
 import { useTeamWriteGuard } from '@/composables/useTeamWriteGuard'
 import { getAxiosErrorMessage } from '@/utils/httpErrorUtil'
 import type { StepperItem } from '@nuxt/ui'
@@ -121,8 +116,29 @@ const initialWage = (): WageWithForm => {
 
 const wageData = ref<WageWithForm>(initialWage())
 
-const effectiveDateLabel = computed(() => nextEffectiveDateLabel())
+const changeTiming = computed(() => describeWageChangeTiming(props.wage))
 const scheduledWageNotice = computed(() => formatScheduledWageNotice(props.wage?.scheduledWage))
+
+// Two genuinely different situations, and the owner has to be able to tell
+// them apart before saving. The member has not opened this week yet: the new
+// rate covers the days they have already worked but not yet submitted, which
+// is the case worth a warning. They have: this week is settled at the current
+// rate and only the next one moves.
+const effectiveDateTitle = computed(() =>
+  changeTiming.value.immediate
+    ? 'This change takes effect immediately, for the whole current week.'
+    : `This change takes effect on ${changeTiming.value.label}.`
+)
+
+const effectiveDateDescription = computed(() => {
+  if (changeTiming.value.immediate) {
+    return `${props.member.name ?? 'This member'} has not submitted any hours for this week yet, so hours they have already worked will be paid at the new rate. Wait for them to submit to leave this week untouched.`
+  }
+
+  return scheduledWageNotice.value
+    ? `A change is already scheduled for that date (${scheduledWageNotice.value}). Saving replaces it without pushing the date back.`
+    : 'Hours are already submitted for this week, so the current rate stays in force until then.'
+})
 
 const items = computed<StepperItem[]>(() =>
   wageData.value.enableOvertimeRules

--- a/app/src/components/sections/DashboardView/__tests__/SetMemberWageModal.spec.ts
+++ b/app/src/components/sections/DashboardView/__tests__/SetMemberWageModal.spec.ts
@@ -280,11 +280,11 @@ describe('SetMemberWageModal', () => {
   })
 
   describe('effective date notice', () => {
-    const noticeText = async (nextChangeEffectiveFrom: string | null) => {
+    const notice = async (nextChangeEffectiveFrom: string | null) => {
       const wrapper = createWrapper({ wage: { ...mockWage, nextChangeEffectiveFrom } })
       await openModal(wrapper)
 
-      return wrapper.find('[data-test="wage-effective-date-notice"]').text()
+      return wrapper.find('[data-test="wage-effective-date-notice"]')
     }
 
     /** The server only ever answers with a Monday, so the fixtures are too. */
@@ -301,20 +301,17 @@ describe('SetMemberWageModal', () => {
       ).toISOString()
     }
 
-    it('warns that an untouched week takes the change whole', async () => {
-      // The member has submitted nothing yet, so hours they have already worked
-      // are repriced. That is the case the owner has to see before saving.
-      const text = await noticeText(mondayUtc())
-
-      expect(text).toContain('immediately')
-      expect(text).toContain('Alice')
+    it('says nothing when the change simply takes effect', async () => {
+      // No hours submitted this week, so the new wage is what the week will be
+      // priced at. There is no change to announce — only a delay would be news.
+      expect((await notice(mondayUtc())).exists()).toBe(false)
     })
 
-    it('announces the date when the member has already opened this week', async () => {
-      const text = await noticeText(mondayUtc(1))
+    it('announces the date when hours are already submitted for this week', async () => {
+      const alert = await notice(mondayUtc(1))
 
-      expect(text).not.toContain('immediately')
-      expect(text).toContain('current rate stays in force')
+      expect(alert.exists()).toBe(true)
+      expect(alert.text()).toContain('current rate stays in force')
     })
   })
 })

--- a/app/src/components/sections/DashboardView/__tests__/SetMemberWageModal.spec.ts
+++ b/app/src/components/sections/DashboardView/__tests__/SetMemberWageModal.spec.ts
@@ -278,4 +278,43 @@ describe('SetMemberWageModal', () => {
     await wrapper.find('[data-test="add-wage-button"]').trigger('click')
     expect(mutateSpy.mock.calls[0]?.[0].body.userAddress).toBe('')
   })
+
+  describe('effective date notice', () => {
+    const noticeText = async (nextChangeEffectiveFrom: string | null) => {
+      const wrapper = createWrapper({ wage: { ...mockWage, nextChangeEffectiveFrom } })
+      await openModal(wrapper)
+
+      return wrapper.find('[data-test="wage-effective-date-notice"]').text()
+    }
+
+    /** The server only ever answers with a Monday, so the fixtures are too. */
+    const mondayUtc = (weeksAhead = 0) => {
+      const today = new Date()
+      const daysSinceMonday = (today.getUTCDay() + 6) % 7
+
+      return new Date(
+        Date.UTC(
+          today.getUTCFullYear(),
+          today.getUTCMonth(),
+          today.getUTCDate() - daysSinceMonday + weeksAhead * 7
+        )
+      ).toISOString()
+    }
+
+    it('warns that an untouched week takes the change whole', async () => {
+      // The member has submitted nothing yet, so hours they have already worked
+      // are repriced. That is the case the owner has to see before saving.
+      const text = await noticeText(mondayUtc())
+
+      expect(text).toContain('immediately')
+      expect(text).toContain('Alice')
+    })
+
+    it('announces the date when the member has already opened this week', async () => {
+      const text = await noticeText(mondayUtc(1))
+
+      expect(text).not.toContain('immediately')
+      expect(text).toContain('current rate stays in force')
+    })
+  })
 })

--- a/app/src/types/cash-remuneration.ts
+++ b/app/src/types/cash-remuneration.ts
@@ -29,6 +29,10 @@ export interface Wage {
   nextWageId: number | null
   effectiveFrom?: string | null // ISO date string
   scheduledWage?: Wage | null
+  // The Monday a change saved right now would take effect on: this week's when
+  // the member has not opened it yet, next week's when they have. Computed by
+  // the server so the owner is never shown a date the server would not honour.
+  nextChangeEffectiveFrom?: string | null // ISO date string
   createdAt: string // ISO date string
   updatedAt: string // ISO date string
   user?: User

--- a/app/src/utils/__tests__/wageScheduling.spec.ts
+++ b/app/src/utils/__tests__/wageScheduling.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  describeWageChangeTiming,
   formatScheduledWageNotice,
-  msUntilWageEffective,
-  nextEffectiveDateLabel
+  msUntilWageEffective
 } from '@/utils/wageUtil'
 import type { Wage } from '@/types'
 import { NETWORK } from '@/constant'
@@ -137,19 +137,42 @@ describe('msUntilWageEffective', () => {
   })
 })
 
-describe('nextEffectiveDateLabel', () => {
-  it('points at the next Monday when called mid-week', () => {
-    // Wednesday 12 Aug 2026 -> Monday 17 Aug
-    expect(nextEffectiveDateLabel(new Date('2026-08-12T15:00:00.000Z'))).toContain('17')
+describe('describeWageChangeTiming', () => {
+  // Wednesday 12 Aug 2026, in the week starting Monday 10 Aug.
+  const now = new Date('2026-08-12T15:00:00.000Z')
+
+  it('reads the date from the server rather than recomputing it', () => {
+    const timing = describeWageChangeTiming(
+      wage({ nextChangeEffectiveFrom: '2026-08-17T00:00:00.000Z' }),
+      now
+    )
+
+    expect(timing.immediate).toBe(false)
+    expect(timing.label).toContain('17')
   })
 
-  it('points at the following Monday when called on a Monday', () => {
-    // A change made on Monday still lands on the *next* week's Monday, matching
-    // the server so the two never disagree.
-    expect(nextEffectiveDateLabel(new Date('2026-08-17T09:00:00.000Z'))).toContain('24')
+  it('reports a change landing on the current week as immediate', () => {
+    const timing = describeWageChangeTiming(
+      wage({ nextChangeEffectiveFrom: '2026-08-10T00:00:00.000Z' }),
+      now
+    )
+
+    expect(timing.immediate).toBe(true)
   })
 
-  it('points at the next day when called on a Sunday', () => {
-    expect(nextEffectiveDateLabel(new Date('2026-08-16T09:00:00.000Z'))).toContain('17')
+  it('falls back to next Monday when the server said nothing', () => {
+    // Older payloads carry no date. Announcing a later change than the server
+    // applies is a smaller mistake than promising an immediate one.
+    const timing = describeWageChangeTiming(wage({}), now)
+
+    expect(timing.immediate).toBe(false)
+    expect(timing.label).toContain('17')
+  })
+
+  it('ignores an unparseable date', () => {
+    const timing = describeWageChangeTiming(wage({ nextChangeEffectiveFrom: 'not-a-date' }), now)
+
+    expect(timing.immediate).toBe(false)
+    expect(timing.label).toContain('17')
   })
 })

--- a/app/src/utils/wageUtil.ts
+++ b/app/src/utils/wageUtil.ts
@@ -76,12 +76,31 @@ export const formatScheduledWageNotice = (scheduledWage?: Wage | null): string |
 }
 
 /**
- * The Monday a change made now would take effect on, formatted for display.
- * Mirrors the server's `nextMondayUtc`, which anchors every wage change to the
- * start of the next ISO week so a wage boundary never falls mid-week.
+ * When a change saved right now would take effect, for the set-wage modal.
+ *
+ * A change only waits for next Monday when the member has already opened the
+ * current week; otherwise it applies to this week whole. Only the server knows
+ * which, so the date is read from `nextChangeEffectiveFrom` rather than
+ * recomputed here — a rule implemented twice is a rule that drifts.
+ *
+ * The fallback to next Monday covers payloads that predate the field. It errs
+ * the cautious way: announcing a later date than the server applies is a
+ * smaller mistake than promising an immediate change that never happens.
  */
-export const nextEffectiveDateLabel = (now: DateInput = new Date()): string =>
-  formatDate(dayjs(now).utc().add(1, 'week').startOf('isoWeek'))
+export const describeWageChangeTiming = (
+  wage?: Wage | null,
+  now: DateInput = new Date()
+): { immediate: boolean; label: string } => {
+  const weekStart = dayjs(now).utc().startOf('isoWeek')
+  const announced = wage?.nextChangeEffectiveFrom ? dayjs(wage.nextChangeEffectiveFrom).utc() : null
+
+  const effective = announced?.isValid() ? announced : weekStart.add(1, 'week')
+
+  return {
+    immediate: !effective.isAfter(weekStart),
+    label: formatDate(effective)
+  }
+}
 
 /**
  * Milliseconds until a scheduled wage takes effect, or null when there is

--- a/backend/src/controllers/__tests__/claimController.test.ts
+++ b/backend/src/controllers/__tests__/claimController.test.ts
@@ -151,6 +151,9 @@ const createMockWeeklyClaim = (overrides: Partial<WeeklyClaim> = {}): WeeklyClai
     signature: null,
     claims: [{ hoursWorked: 30, minutesWorked: 1800 }],
     wageId: 1,
+    // addClaim always loads the week with its wage: once a week holds hours,
+    // that wage is what prices and caps them.
+    wage: createMockWage(),
 
     status: 'pending',
     ...overrides,
@@ -258,20 +261,20 @@ describe('Claim Controller', () => {
       expect(response.body.message).toBe('No wage found for the user');
     });
 
-    it('should price an open week with the wage it was opened with', async () => {
-      // The owner raised the cap mid-week. The week is already open, so it
-      // stays on its own wage: repricing it would mean a second WeeklyClaim
-      // for the same week, with the hour counters restarting from zero.
+    it('should price a week that already holds hours with their own wage', async () => {
+      // The owner raised the cap mid-week. Hours are already priced against the
+      // old wage, so the week keeps it: repricing would mean a second
+      // WeeklyClaim for the same week, hour counters restarting from zero.
       const testDate = dayjs.utc().startOf('day').toDate();
-      const openWeek = createMockWeeklyClaim({
+      const submittedWeek = createMockWeeklyClaim({
         wageId: 1,
         wage: createMockWage({ id: 1, maximumHoursPerDay: 6 }),
       } as Partial<WeeklyClaim>);
-      (openWeek as any).claims = [
+      (submittedWeek as any).claims = [
         { id: 1, dayWorked: testDate, hoursWorked: 5, minutesWorked: 300 },
       ];
 
-      vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(openWeek);
+      vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(submittedWeek);
       mockResolveWageForWeek.mockResolvedValue(createMockWage({ id: 2, maximumHoursPerDay: 12 }));
 
       const response = await request(app).post('/').send({
@@ -286,14 +289,49 @@ describe('Claim Controller', () => {
       expect(mockResolveWageForWeek).not.toHaveBeenCalled();
     });
 
+    it('should move a goals-only week onto the wage in force when hours arrive', async () => {
+      // Goals commit nothing: the member had not submitted their hours when the
+      // wage changed, so the first hours are priced at the new wage and the
+      // week's row follows them instead of pointing at the superseded one.
+      const testDate = dayjs.utc().startOf('day').toDate();
+      const goalsOnlyWeek = createMockWeeklyClaim({
+        id: 7,
+        wageId: 1,
+        wage: createMockWage({ id: 1, maximumHoursPerDay: 6 }),
+        weeklyGoals: 'ship the thing',
+      } as Partial<WeeklyClaim>);
+      (goalsOnlyWeek as any).claims = [];
+
+      vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(goalsOnlyWeek);
+      const updateSpy = vi
+        .spyOn(prisma.weeklyClaim, 'update')
+        .mockResolvedValue(createMockWeeklyClaim({ id: 7, wageId: 2 }));
+      vi.spyOn(prisma.claim, 'create').mockResolvedValue(createMockClaim());
+      mockResolveWageForWeek.mockResolvedValue(createMockWage({ id: 2, maximumHoursPerDay: 12 }));
+
+      const response = await request(app).post('/').send({
+        teamId: 1,
+        minutesWorked: 600, // 10h: over the old 6h cap, within the new 12h one
+        memo: 'memo',
+        dayWorked: testDate.toISOString(),
+      });
+
+      expect(response.status).toBe(201);
+      expect(prisma.weeklyClaim.create).not.toHaveBeenCalled();
+      expect(updateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 7 }, data: { wageId: 2 } })
+      );
+    });
+
     it('should return 409 if the day total exceeds the wage daily cap', async () => {
       const testDate = dayjs.utc().startOf('day').toDate();
-      const modifiedWeeklyClaims = createMockWeeklyClaim();
+      const modifiedWeeklyClaims = createMockWeeklyClaim({
+        wage: createMockWage({ maximumHoursPerDay: 6 }),
+      } as Partial<WeeklyClaim>);
       (modifiedWeeklyClaims as any).claims = [
         { id: 1, dayWorked: testDate, hoursWorked: 5, minutesWorked: 300 },
       ];
 
-      mockResolveWageForWeek.mockResolvedValue(createMockWage({ maximumHoursPerDay: 6 }));
       vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(modifiedWeeklyClaims);
 
       const response = await request(app).post('/').send({
@@ -316,7 +354,6 @@ describe('Claim Controller', () => {
         { id: 1, dayWorked: testDate, hoursWorked: 7, minutesWorked: 420 },
       ];
 
-      mockResolveWageForWeek.mockResolvedValue(createMockWage());
       vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(modifiedWeeklyClaims);
 
       const response = await request(app).post('/').send({
@@ -332,12 +369,13 @@ describe('Claim Controller', () => {
 
     it('should allow a claim that stays within the daily cap', async () => {
       const testDate = dayjs.utc().startOf('day').toDate();
-      const modifiedWeeklyClaims = createMockWeeklyClaim();
+      const modifiedWeeklyClaims = createMockWeeklyClaim({
+        wage: createMockWage({ maximumHoursPerDay: 8 }),
+      } as Partial<WeeklyClaim>);
       (modifiedWeeklyClaims as any).claims = [
         { id: 1, dayWorked: testDate, hoursWorked: 4, minutesWorked: 240 },
       ];
 
-      mockResolveWageForWeek.mockResolvedValue(createMockWage({ maximumHoursPerDay: 8 }));
       vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(modifiedWeeklyClaims);
       vi.spyOn(prisma.claim, 'create').mockResolvedValue(createMockClaim());
 
@@ -488,6 +526,8 @@ describe('Claim Controller', () => {
     });
 
     it('should return 500 if internal server error occurs', async () => {
+      // An untouched week, so the wage is resolved — and that is what fails.
+      vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(null);
       mockResolveWageForWeek.mockRejectedValue(new Error('DB error'));
 
       const response = await request(app)

--- a/backend/src/controllers/__tests__/claimController.test.ts
+++ b/backend/src/controllers/__tests__/claimController.test.ts
@@ -258,6 +258,34 @@ describe('Claim Controller', () => {
       expect(response.body.message).toBe('No wage found for the user');
     });
 
+    it('should price an open week with the wage it was opened with', async () => {
+      // The owner raised the cap mid-week. The week is already open, so it
+      // stays on its own wage: repricing it would mean a second WeeklyClaim
+      // for the same week, with the hour counters restarting from zero.
+      const testDate = dayjs.utc().startOf('day').toDate();
+      const openWeek = createMockWeeklyClaim({
+        wageId: 1,
+        wage: createMockWage({ id: 1, maximumHoursPerDay: 6 }),
+      } as Partial<WeeklyClaim>);
+      (openWeek as any).claims = [
+        { id: 1, dayWorked: testDate, hoursWorked: 5, minutesWorked: 300 },
+      ];
+
+      vi.spyOn(prisma.weeklyClaim, 'findFirst').mockResolvedValue(openWeek);
+      mockResolveWageForWeek.mockResolvedValue(createMockWage({ id: 2, maximumHoursPerDay: 12 }));
+
+      const response = await request(app).post('/').send({
+        teamId: 1,
+        minutesWorked: 120, // 5h + 2h is under the new 12h cap, over the old 6h one
+        memo: 'memo',
+        dayWorked: testDate.toISOString(),
+      });
+
+      expect(response.status).toBe(409);
+      expect(response.body.message).toContain('Daily allowance: 6h');
+      expect(mockResolveWageForWeek).not.toHaveBeenCalled();
+    });
+
     it('should return 409 if the day total exceeds the wage daily cap', async () => {
       const testDate = dayjs.utc().startOf('day').toDate();
       const modifiedWeeklyClaims = createMockWeeklyClaim();

--- a/backend/src/controllers/__tests__/wageController.test.ts
+++ b/backend/src/controllers/__tests__/wageController.test.ts
@@ -575,22 +575,45 @@ describe('Wage Controller', () => {
       expect(effectiveFrom.getTime()).toBeLessThanOrEqual(Date.now());
     });
 
-    it('should rewrite a scheduled wage in place without moving its effective date', async () => {
-      // Correcting a typo before Monday must not push the change back a week,
-      // nor leave a dead link in the chain.
+    /** Arranges a correction on top of a change that is still waiting. */
+    const arrangeRewrite = (weekIsSubmitted: boolean) => {
       vi.spyOn(prisma.team, 'findFirst').mockResolvedValue(mockTeam);
       vi.spyOn(prisma.wage, 'findFirst')
         .mockResolvedValueOnce({ ...mockWage, id: 2, effectiveFrom: futureDate() } as Wage)
         .mockResolvedValueOnce({ ...mockWage, id: 1, nextWageId: 2 } as Wage);
-      const updateSpy = vi.spyOn(prisma.wage, 'update').mockResolvedValue(mockWage);
-      const createSpy = vi.spyOn(prisma.wage, 'create');
+      mockWeekHasClaims.mockResolvedValue(weekIsSubmitted);
+      vi.spyOn(prisma.wage, 'create');
+
+      return vi.spyOn(prisma.wage, 'update').mockResolvedValue(mockWage);
+    };
+
+    it('should rewrite a scheduled wage in place without pushing its date back', async () => {
+      // Correcting a typo before Monday must not push the change back a week,
+      // nor leave a dead link in the chain.
+      const updateSpy = arrangeRewrite(true);
 
       const response = await request(app).put('/setWage').send(validBody);
 
       expect(response.status).toBe(200);
-      expect(createSpy).not.toHaveBeenCalled();
+      expect(prisma.wage.create).not.toHaveBeenCalled();
       expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 2 } }));
-      expect(updateSpy.mock.calls[0][0].data).not.toHaveProperty('effectiveFrom');
+      const effectiveFrom = updateSpy.mock.calls[0][0].data.effectiveFrom as Date;
+      expect(effectiveFrom.getUTCDay()).toBe(1);
+      expect(effectiveFrom.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('should stop a queued change from waiting once the week holds no hours', async () => {
+      // The wait outlives its reason when the hours that justified it are gone
+      // — a withdrawn week, or a change queued under the old always-defer rule.
+      // Saving again has to release it, otherwise nothing can.
+      const updateSpy = arrangeRewrite(false);
+
+      const response = await request(app).put('/setWage').send(validBody);
+
+      expect(response.status).toBe(200);
+      const effectiveFrom = updateSpy.mock.calls[0][0].data.effectiveFrom as Date;
+      expect(effectiveFrom.getUTCDay()).toBe(1);
+      expect(effectiveFrom.getTime()).toBeLessThanOrEqual(Date.now());
     });
 
     it('should refuse to rewrite a scheduled wage when the active one is disabled', async () => {

--- a/backend/src/controllers/__tests__/wageController.test.ts
+++ b/backend/src/controllers/__tests__/wageController.test.ts
@@ -29,6 +29,25 @@ vi.mock('../../utils', async () => {
 });
 vi.mock('../../utils/viem.config');
 
+// Only the two helpers that read WeeklyClaim rows are stubbed; the rule that
+// turns "has this member opened the week?" into an effective date stays real,
+// so these tests exercise it rather than restate it.
+const { mockIsWeekOpen, mockMembersWithOpenWeek } = vi.hoisted(() => ({
+  mockIsWeekOpen: vi.fn(),
+  mockMembersWithOpenWeek: vi.fn(),
+}));
+
+vi.mock('../../utils/wageResolution', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/wageResolution')>(
+    '../../utils/wageResolution'
+  );
+  return {
+    ...actual,
+    isWeekOpen: mockIsWeekOpen,
+    membersWithOpenWeek: mockMembersWithOpenWeek,
+  };
+});
+
 // Mock the authorization middleware with proper hoisting
 vi.mock('../../middleware/authMiddleware', () => ({
   authorizeUser: vi.fn((req: Request, res: Response, next: NextFunction) => {
@@ -90,6 +109,8 @@ describe('Wage Controller', () => {
         ...mockTeam,
         isArchived: false,
       });
+      // Default: the member has not opened the current week.
+      mockIsWeekOpen.mockResolvedValue(false);
     });
 
     it('should return 400 if required parameters are missing', async () => {
@@ -489,16 +510,20 @@ describe('Wage Controller', () => {
       maximumHoursPerWeek: 40,
     };
 
-    it('should defer a change to an existing wage to the next Monday', async () => {
-      // A wage boundary must never fall mid-week, otherwise two WeeklyClaims can
-      // cover the same week under different wages (issue #2479).
+    /** Arranges a change on top of an existing wage, week open or not. */
+    const arrangeChange = (weekIsOpen: boolean) => {
       vi.spyOn(prisma.team, 'findFirst').mockResolvedValue(mockTeam);
       vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(mockWage);
-      const createSpy = vi.spyOn(prisma.wage, 'create').mockResolvedValue({
-        ...mockWage,
-        id: 2,
-      } as Wage);
+      mockIsWeekOpen.mockResolvedValue(weekIsOpen);
       vi.spyOn(prisma.wage, 'update').mockResolvedValue(mockWage);
+
+      return vi.spyOn(prisma.wage, 'create').mockResolvedValue({ ...mockWage, id: 2 } as Wage);
+    };
+
+    it('should defer a change to the next Monday when the member has already opened this week', async () => {
+      // That week is priced by the wage it was opened with and cannot be
+      // repriced without splitting it across two WeeklyClaims (issue #2479).
+      const createSpy = arrangeChange(true);
 
       const response = await request(app).put('/setWage').send(validBody);
 
@@ -509,7 +534,34 @@ describe('Wage Controller', () => {
       expect(effectiveFrom.getTime()).toBeGreaterThan(Date.now());
     });
 
-    it('should apply the very first wage immediately', async () => {
+    it('should apply a change to the current week when the member has not opened it', async () => {
+      // Nothing is submitted yet, so the whole week can take the new terms —
+      // the owner chose not to wait for their member to submit.
+      const createSpy = arrangeChange(false);
+
+      const response = await request(app).put('/setWage').send(validBody);
+
+      expect(response.status).toBe(201);
+      const effectiveFrom = createSpy.mock.calls[0][0].data.effectiveFrom as Date;
+      expect(effectiveFrom.getUTCDay()).toBe(1);
+      expect(effectiveFrom.getTime()).toBeLessThanOrEqual(Date.now());
+    });
+
+    it('should anchor the effective date to a Monday even when applied immediately', async () => {
+      // Resolution compares the effective date against the *start* of the week,
+      // so a mid-week timestamp would exclude the new wage from the very week
+      // it is meant to cover.
+      const createSpy = arrangeChange(false);
+
+      await request(app).put('/setWage').send(validBody);
+
+      const effectiveFrom = createSpy.mock.calls[0][0].data.effectiveFrom as Date;
+      expect(effectiveFrom.getUTCHours()).toBe(0);
+      expect(effectiveFrom.getUTCMinutes()).toBe(0);
+      expect(effectiveFrom.getUTCSeconds()).toBe(0);
+    });
+
+    it('should apply the very first wage from the current Monday', async () => {
       vi.spyOn(prisma.team, 'findFirst').mockResolvedValue(mockTeam);
       vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(null);
       vi.spyOn(prisma.wage, 'findMany').mockResolvedValue([]);
@@ -518,7 +570,9 @@ describe('Wage Controller', () => {
       const response = await request(app).put('/setWage').send(validBody);
 
       expect(response.status).toBe(201);
-      expect(createSpy.mock.calls[0][0].data).not.toHaveProperty('effectiveFrom');
+      const effectiveFrom = createSpy.mock.calls[0][0].data.effectiveFrom as Date;
+      expect(effectiveFrom.getUTCDay()).toBe(1);
+      expect(effectiveFrom.getTime()).toBeLessThanOrEqual(Date.now());
     });
 
     it('should rewrite a scheduled wage in place without moving its effective date', async () => {
@@ -611,6 +665,8 @@ describe('Wage Controller', () => {
         req.address = '0x1234567890123456789012345678901234567890';
         next();
       });
+      // Default: nobody has opened the current week yet.
+      mockMembersWithOpenWeek.mockResolvedValue(new Set<string>());
     });
 
     it('should return 400 if teamId is invalid', async () => {
@@ -690,6 +746,37 @@ describe('Wage Controller', () => {
       expect(response.status).toBe(200);
       expect(response.body[0]).toMatchObject({ id: 1, maximumHoursPerWeek: 40 });
       expect(response.body[0].scheduledWage).toMatchObject({ id: 2, maximumHoursPerWeek: 45 });
+    });
+
+    it('should tell the caller when a change saved now would take effect', async () => {
+      // The set-wage modal announces this date, so it has to come from the same
+      // rule the server applies rather than being recomputed on the front end.
+      vi.spyOn(prisma.team, 'findFirst').mockResolvedValue(mockTeam);
+      vi.spyOn(prisma.wage, 'findMany').mockResolvedValue([
+        { ...mockWage, effectiveFrom: new Date('2026-01-05T00:00:00.000Z') } as never,
+      ]);
+      mockMembersWithOpenWeek.mockResolvedValue(new Set([mockWage.userAddress]));
+
+      const response = await request(app).get('/').query({ teamId: 1 });
+
+      expect(response.status).toBe(200);
+      const announced = new Date(response.body[0].nextChangeEffectiveFrom);
+      expect(announced.getUTCDay()).toBe(1);
+      expect(announced.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('should announce an immediate change for a member who has not opened the week', async () => {
+      vi.spyOn(prisma.team, 'findFirst').mockResolvedValue(mockTeam);
+      vi.spyOn(prisma.wage, 'findMany').mockResolvedValue([
+        { ...mockWage, effectiveFrom: new Date('2026-01-05T00:00:00.000Z') } as never,
+      ]);
+
+      const response = await request(app).get('/').query({ teamId: 1 });
+
+      expect(response.status).toBe(200);
+      const announced = new Date(response.body[0].nextChangeEffectiveFrom);
+      expect(announced.getUTCDay()).toBe(1);
+      expect(announced.getTime()).toBeLessThanOrEqual(Date.now());
     });
 
     it('should return the leaf with a null scheduledWage when no change is pending', async () => {

--- a/backend/src/controllers/__tests__/wageController.test.ts
+++ b/backend/src/controllers/__tests__/wageController.test.ts
@@ -30,11 +30,11 @@ vi.mock('../../utils', async () => {
 vi.mock('../../utils/viem.config');
 
 // Only the two helpers that read WeeklyClaim rows are stubbed; the rule that
-// turns "has this member opened the week?" into an effective date stays real,
+// turns "has this member submitted hours?" into an effective date stays real,
 // so these tests exercise it rather than restate it.
-const { mockIsWeekOpen, mockMembersWithOpenWeek } = vi.hoisted(() => ({
-  mockIsWeekOpen: vi.fn(),
-  mockMembersWithOpenWeek: vi.fn(),
+const { mockWeekHasClaims, mockMembersWithClaimsThisWeek } = vi.hoisted(() => ({
+  mockWeekHasClaims: vi.fn(),
+  mockMembersWithClaimsThisWeek: vi.fn(),
 }));
 
 vi.mock('../../utils/wageResolution', async () => {
@@ -43,8 +43,8 @@ vi.mock('../../utils/wageResolution', async () => {
   );
   return {
     ...actual,
-    isWeekOpen: mockIsWeekOpen,
-    membersWithOpenWeek: mockMembersWithOpenWeek,
+    weekHasClaims: mockWeekHasClaims,
+    membersWithClaimsThisWeek: mockMembersWithClaimsThisWeek,
   };
 });
 
@@ -110,7 +110,7 @@ describe('Wage Controller', () => {
         isArchived: false,
       });
       // Default: the member has not opened the current week.
-      mockIsWeekOpen.mockResolvedValue(false);
+      mockWeekHasClaims.mockResolvedValue(false);
     });
 
     it('should return 400 if required parameters are missing', async () => {
@@ -510,19 +510,19 @@ describe('Wage Controller', () => {
       maximumHoursPerWeek: 40,
     };
 
-    /** Arranges a change on top of an existing wage, week open or not. */
-    const arrangeChange = (weekIsOpen: boolean) => {
+    /** Arranges a change on top of an existing wage, hours submitted or not. */
+    const arrangeChange = (weekIsSubmitted: boolean) => {
       vi.spyOn(prisma.team, 'findFirst').mockResolvedValue(mockTeam);
       vi.spyOn(prisma.wage, 'findFirst').mockResolvedValue(mockWage);
-      mockIsWeekOpen.mockResolvedValue(weekIsOpen);
+      mockWeekHasClaims.mockResolvedValue(weekIsSubmitted);
       vi.spyOn(prisma.wage, 'update').mockResolvedValue(mockWage);
 
       return vi.spyOn(prisma.wage, 'create').mockResolvedValue({ ...mockWage, id: 2 } as Wage);
     };
 
-    it('should defer a change to the next Monday when the member has already opened this week', async () => {
-      // That week is priced by the wage it was opened with and cannot be
-      // repriced without splitting it across two WeeklyClaims (issue #2479).
+    it('should defer a change to the next Monday when hours are already submitted', async () => {
+      // Those hours are priced against the current wage and cannot be repriced
+      // without splitting the week across two WeeklyClaims (issue #2479).
       const createSpy = arrangeChange(true);
 
       const response = await request(app).put('/setWage').send(validBody);
@@ -534,7 +534,7 @@ describe('Wage Controller', () => {
       expect(effectiveFrom.getTime()).toBeGreaterThan(Date.now());
     });
 
-    it('should apply a change to the current week when the member has not opened it', async () => {
+    it('should apply a change to the current week when no hours are submitted', async () => {
       // Nothing is submitted yet, so the whole week can take the new terms —
       // the owner chose not to wait for their member to submit.
       const createSpy = arrangeChange(false);
@@ -666,7 +666,7 @@ describe('Wage Controller', () => {
         next();
       });
       // Default: nobody has opened the current week yet.
-      mockMembersWithOpenWeek.mockResolvedValue(new Set<string>());
+      mockMembersWithClaimsThisWeek.mockResolvedValue(new Set<string>());
     });
 
     it('should return 400 if teamId is invalid', async () => {
@@ -755,7 +755,7 @@ describe('Wage Controller', () => {
       vi.spyOn(prisma.wage, 'findMany').mockResolvedValue([
         { ...mockWage, effectiveFrom: new Date('2026-01-05T00:00:00.000Z') } as never,
       ]);
-      mockMembersWithOpenWeek.mockResolvedValue(new Set([mockWage.userAddress]));
+      mockMembersWithClaimsThisWeek.mockResolvedValue(new Set([mockWage.userAddress]));
 
       const response = await request(app).get('/').query({ teamId: 1 });
 
@@ -765,7 +765,7 @@ describe('Wage Controller', () => {
       expect(announced.getTime()).toBeGreaterThan(Date.now());
     });
 
-    it('should announce an immediate change for a member who has not opened the week', async () => {
+    it('should date an immediate change to this week for a member with no hours in', async () => {
       vi.spyOn(prisma.team, 'findFirst').mockResolvedValue(mockTeam);
       vi.spyOn(prisma.wage, 'findMany').mockResolvedValue([
         { ...mockWage, effectiveFrom: new Date('2026-01-05T00:00:00.000Z') } as never,

--- a/backend/src/controllers/__tests__/weeklyClaimController.test.ts
+++ b/backend/src/controllers/__tests__/weeklyClaimController.test.ts
@@ -1092,6 +1092,9 @@ describe('Weekly Claim Controller', () => {
     });
 
     it('returns 400 when the caller has no current wage', async () => {
+      // Only reachable on a week nobody has opened: an open week already
+      // carries the wage that prices it, so no resolution is needed.
+      vi.mocked(prisma.weeklyClaim.findFirst).mockResolvedValue(null);
       mockResolveWageForWeek.mockResolvedValue(null);
 
       const response = await request(app).put('/goals').send(GOALS_BODY);

--- a/backend/src/controllers/claimController.ts
+++ b/backend/src/controllers/claimController.ts
@@ -115,11 +115,9 @@ export const addClaim = async (req: Request, res: Response) => {
   const weekStart = dayjs.utc(dayWorked).startOf('isoWeek').toDate(); // Monday 00:00 UTC
 
   try {
-    // The week's own row decides which wage prices it. A week the member has
-    // already opened keeps the wage it was opened with, whatever the owner has
-    // saved since, so a mid-week change can never split one week across two
-    // rows — the failure that let hour caps restart from zero (issue #2479).
-    // Resolution only speaks for weeks nobody has opened yet.
+    // A week is found by member and week, never by wage, so one week always has
+    // one row — the split that let hour caps restart from zero (issue #2479)
+    // has nowhere to happen.
     let weeklyClaim = await prisma.weeklyClaim.findFirst({
       where: {
         teamId: teamId,
@@ -129,7 +127,15 @@ export const addClaim = async (req: Request, res: Response) => {
       include: { claims: true, wage: true },
     });
 
-    const wage = weeklyClaim?.wage ?? (await resolveWageForWeek(teamId, callerAddress, weekStart));
+    // Hours are what commit a week to a wage. Once the week holds claims it
+    // keeps the wage they were priced against, whatever the owner has saved
+    // since. A week holding only goals has committed to nothing, so it follows
+    // the change like an empty week would — the member had not submitted their
+    // hours, which is precisely the case the rule leaves to them.
+    const weekIsSubmitted = (weeklyClaim?.claims.length ?? 0) > 0;
+    const wage = weekIsSubmitted
+      ? weeklyClaim!.wage
+      : await resolveWageForWeek(teamId, callerAddress, weekStart);
 
     if (!wage) {
       return errorResponse(400, 'No wage found for the user', res);
@@ -209,6 +215,15 @@ export const addClaim = async (req: Request, res: Response) => {
           data: {},
           status: 'pending',
         },
+        include: { claims: true, wage: true },
+      });
+    } else if (weeklyClaim.wageId !== wage.id) {
+      // Only reachable on a goals-only week whose wage changed since: these are
+      // the first hours in it, so the row moves to the wage that prices them
+      // instead of leaving the week pointing at the superseded one.
+      weeklyClaim = await prisma.weeklyClaim.update({
+        where: { id: weeklyClaim.id },
+        data: { wageId: wage.id },
         include: { claims: true, wage: true },
       });
     }

--- a/backend/src/controllers/claimController.ts
+++ b/backend/src/controllers/claimController.ts
@@ -115,7 +115,21 @@ export const addClaim = async (req: Request, res: Response) => {
   const weekStart = dayjs.utc(dayWorked).startOf('isoWeek').toDate(); // Monday 00:00 UTC
 
   try {
-    const wage = await resolveWageForWeek(teamId, callerAddress, weekStart);
+    // The week's own row decides which wage prices it. A week the member has
+    // already opened keeps the wage it was opened with, whatever the owner has
+    // saved since, so a mid-week change can never split one week across two
+    // rows — the failure that let hour caps restart from zero (issue #2479).
+    // Resolution only speaks for weeks nobody has opened yet.
+    let weeklyClaim = await prisma.weeklyClaim.findFirst({
+      where: {
+        teamId: teamId,
+        memberAddress: callerAddress,
+        weekStart: weekStart,
+      },
+      include: { claims: true, wage: true },
+    });
+
+    const wage = weeklyClaim?.wage ?? (await resolveWageForWeek(teamId, callerAddress, weekStart));
 
     if (!wage) {
       return errorResponse(400, 'No wage found for the user', res);
@@ -136,17 +150,6 @@ export const addClaim = async (req: Request, res: Response) => {
         res
       );
     }
-
-    // Find the weekly claim for the active wage and current week.
-    let weeklyClaim = await prisma.weeklyClaim.findFirst({
-      where: {
-        wageId: wage.id,
-        weekStart: weekStart,
-        memberAddress: callerAddress,
-        teamId: teamId,
-      },
-      include: { claims: true },
-    });
 
     if (weeklyClaim) {
       if (weeklyClaim.status === 'disabled') {
@@ -206,9 +209,7 @@ export const addClaim = async (req: Request, res: Response) => {
           data: {},
           status: 'pending',
         },
-        include: {
-          claims: true,
-        },
+        include: { claims: true, wage: true },
       });
     }
 

--- a/backend/src/controllers/wageController.ts
+++ b/backend/src/controllers/wageController.ts
@@ -61,6 +61,13 @@ export const setWage = async (req: Request, res: Response) => {
     });
 
     if (leafWage) {
+      // A change only waits for next Monday when the member has already
+      // submitted hours for this week — those hours are priced against the
+      // current wage and cannot be repriced without splitting the week. A week
+      // with no hours in it takes the change whole, from its own Monday.
+      const weekIsSubmitted = await weekHasClaims(teamId, userAddress, currentWeekStart());
+      const effectiveFrom = effectiveFromForChange(weekIsSubmitted);
+
       if (isScheduledWage(leafWage)) {
         const activePredecessor = await prisma.wage.findFirst({
           where: { teamId, userAddress, nextWageId: leafWage.id },
@@ -70,9 +77,15 @@ export const setWage = async (req: Request, res: Response) => {
           return errorResponse(400, 'Cannot set wage: the current wage is disabled', res);
         }
 
+        // The date is recomputed, not preserved. A change queued while the week
+        // held hours must stop waiting once it no longer does — otherwise the
+        // wait outlives its reason and there is no way to call it off. This can
+        // only pull the date forward to the current Monday: for a week that
+        // still holds hours the rule returns the same next Monday it did
+        // before, so a correction never pushes the change back a week.
         const updatedWage = await prisma.wage.update({
           where: { id: leafWage.id },
-          data: wagePayload,
+          data: { ...wagePayload, effectiveFrom },
         });
         return res.status(200).json(updatedWage);
       }
@@ -83,13 +96,6 @@ export const setWage = async (req: Request, res: Response) => {
       if (activeWage.disabled) {
         return errorResponse(400, 'Cannot set wage: the current wage is disabled', res);
       }
-
-      // A change only waits for next Monday when the member has already
-      // submitted hours for this week — those hours are priced against the
-      // current wage and cannot be repriced without splitting the week. A week
-      // with no hours in it takes the change whole, from its own Monday.
-      const weekIsSubmitted = await weekHasClaims(teamId, userAddress, currentWeekStart());
-      const effectiveFrom = effectiveFromForChange(weekIsSubmitted);
 
       // Create wage and chain it to the previous wage. Done in a transaction
       // so the deferrable Wage_active_unique constraint is checked at COMMIT,

--- a/backend/src/controllers/wageController.ts
+++ b/backend/src/controllers/wageController.ts
@@ -7,9 +7,9 @@ import {
   currentWeekStart,
   effectiveFromForChange,
   isScheduledWage,
-  isWeekOpen,
-  membersWithOpenWeek,
+  membersWithClaimsThisWeek,
   splitCurrentAndScheduled,
+  weekHasClaims,
 } from '../utils/wageResolution';
 import {
   cancelScheduledWageQuerySchema,
@@ -84,12 +84,12 @@ export const setWage = async (req: Request, res: Response) => {
         return errorResponse(400, 'Cannot set wage: the current wage is disabled', res);
       }
 
-      // A change only waits for next Monday when the member has already opened
-      // this week — that week is priced by the wage it was opened with and
-      // cannot be repriced without splitting it. When the week is still
-      // untouched the change applies to it whole, from its own Monday.
-      const weekIsOpen = await isWeekOpen(teamId, userAddress, currentWeekStart());
-      const effectiveFrom = effectiveFromForChange(weekIsOpen);
+      // A change only waits for next Monday when the member has already
+      // submitted hours for this week — those hours are priced against the
+      // current wage and cannot be repriced without splitting the week. A week
+      // with no hours in it takes the change whole, from its own Monday.
+      const weekIsSubmitted = await weekHasClaims(teamId, userAddress, currentWeekStart());
+      const effectiveFrom = effectiveFromForChange(weekIsSubmitted);
 
       // Create wage and chain it to the previous wage. Done in a transaction
       // so the deferrable Wage_active_unique constraint is checked at COMMIT,
@@ -156,11 +156,12 @@ export const getWages = async (req: Request, res: Response) => {
       else chainsByMember.set(wage.userAddress, [wage]);
     }
 
-    // Which members have already opened this week decides when a change saved
-    // now would take effect, so the owner is told the real date instead of the
-    // front end guessing it — the two would drift the moment the rule changes.
+    // Which members have already submitted this week decides when a change
+    // saved now would take effect, so the owner is told the real date instead
+    // of the front end guessing it — the two would drift the moment the rule
+    // changes.
     const now = new Date();
-    const openWeeks = await membersWithOpenWeek(teamId, now);
+    const submittedThisWeek = await membersWithClaimsThisWeek(teamId, now);
 
     const wages = Array.from(chainsByMember.values()).flatMap((chain) => {
       const { current, scheduled } = splitCurrentAndScheduled(chain, now);
@@ -170,7 +171,10 @@ export const getWages = async (req: Request, res: Response) => {
         {
           ...current,
           scheduledWage: scheduled,
-          nextChangeEffectiveFrom: effectiveFromForChange(openWeeks.has(current.userAddress), now),
+          nextChangeEffectiveFrom: effectiveFromForChange(
+            submittedThisWeek.has(current.userAddress),
+            now
+          ),
         },
       ];
     });

--- a/backend/src/controllers/wageController.ts
+++ b/backend/src/controllers/wageController.ts
@@ -3,7 +3,14 @@ import { Request, Response } from 'express';
 import { Prisma } from '@prisma/client';
 import { prisma } from '../utils';
 import { errorResponse } from '../utils/utils';
-import { isScheduledWage, nextMondayUtc, splitCurrentAndScheduled } from '../utils/wageResolution';
+import {
+  currentWeekStart,
+  effectiveFromForChange,
+  isScheduledWage,
+  isWeekOpen,
+  membersWithOpenWeek,
+  splitCurrentAndScheduled,
+} from '../utils/wageResolution';
 import {
   cancelScheduledWageQuerySchema,
   getWagesQuerySchema,
@@ -77,7 +84,12 @@ export const setWage = async (req: Request, res: Response) => {
         return errorResponse(400, 'Cannot set wage: the current wage is disabled', res);
       }
 
-      const effectiveFrom = nextMondayUtc();
+      // A change only waits for next Monday when the member has already opened
+      // this week — that week is priced by the wage it was opened with and
+      // cannot be repriced without splitting it. When the week is still
+      // untouched the change applies to it whole, from its own Monday.
+      const weekIsOpen = await isWeekOpen(teamId, userAddress, currentWeekStart());
+      const effectiveFrom = effectiveFromForChange(weekIsOpen);
 
       // Create wage and chain it to the previous wage. Done in a transaction
       // so the deferrable Wage_active_unique constraint is checked at COMMIT,
@@ -105,9 +117,11 @@ export const setWage = async (req: Request, res: Response) => {
       return errorResponse(500, 'User has a wage not chained', res);
     }
 
-    // Create first wage
+    // Create first wage. Anchored to the current Monday like every other
+    // change, so that every effective date in the chain is a week boundary
+    // rather than the mid-week timestamp `createdAt` would provide.
     const createdWage = await prisma.wage.create({
-      data: wagePayload,
+      data: { ...wagePayload, effectiveFrom: currentWeekStart() },
     });
 
     return res.status(201).json(createdWage);
@@ -142,10 +156,23 @@ export const getWages = async (req: Request, res: Response) => {
       else chainsByMember.set(wage.userAddress, [wage]);
     }
 
+    // Which members have already opened this week decides when a change saved
+    // now would take effect, so the owner is told the real date instead of the
+    // front end guessing it — the two would drift the moment the rule changes.
     const now = new Date();
+    const openWeeks = await membersWithOpenWeek(teamId, now);
+
     const wages = Array.from(chainsByMember.values()).flatMap((chain) => {
       const { current, scheduled } = splitCurrentAndScheduled(chain, now);
-      return current ? [{ ...current, scheduledWage: scheduled }] : [];
+      if (!current) return [];
+
+      return [
+        {
+          ...current,
+          scheduledWage: scheduled,
+          nextChangeEffectiveFrom: effectiveFromForChange(openWeeks.has(current.userAddress), now),
+        },
+      ];
     });
 
     return res.status(200).json(wages);

--- a/backend/src/controllers/weeklyClaimController.ts
+++ b/backend/src/controllers/weeklyClaimController.ts
@@ -597,9 +597,10 @@ export const submitWeeklyGoals = async (req: Request, res: Response) => {
   const weekStart = dayjs.utc(weekStartInput).startOf('isoWeek').toDate();
 
   try {
-    // Looked up by week rather than by wage, exactly as addClaim does: an open
-    // week keeps the wage it was opened with, so goals never open a second row
-    // for a week whose wage has changed since.
+    // Looked up by week rather than by wage, exactly as addClaim does, so goals
+    // never open a second row for a week whose wage has changed since. When the
+    // week holds no hours yet, the first claim moves the row onto the wage that
+    // prices it; goals alone never commit a week to a wage.
     const existing = await prisma.weeklyClaim.findFirst({
       where: {
         teamId,

--- a/backend/src/controllers/weeklyClaimController.ts
+++ b/backend/src/controllers/weeklyClaimController.ts
@@ -592,26 +592,19 @@ export const submitWeeklyGoals = async (req: Request, res: Response) => {
     weeklyGoals: string;
   };
 
-  // Normalize to Monday 00:00 UTC the same way addClaim does, so the row lines
-  // up with the [wageId, weekStart] uniqueness used by daily claims.
+  // Normalize to Monday 00:00 UTC the same way addClaim does, so goals and
+  // daily claims land on the same row for a given week.
   const weekStart = dayjs.utc(weekStartInput).startOf('isoWeek').toDate();
 
   try {
-    // A WeeklyClaim requires a wageId, so the member needs a wage before any
-    // goals can be recorded. Resolved against the target week so goals land on
-    // the same row as that week's claims (mirrors addClaim).
-    const wage = await resolveWageForWeek(teamId, callerAddress, weekStart);
-
-    if (!wage) {
-      return errorResponse(400, 'No wage found for the user', res);
-    }
-
+    // Looked up by week rather than by wage, exactly as addClaim does: an open
+    // week keeps the wage it was opened with, so goals never open a second row
+    // for a week whose wage has changed since.
     const existing = await prisma.weeklyClaim.findFirst({
       where: {
-        wageId: wage.id,
-        weekStart,
-        memberAddress: callerAddress,
         teamId,
+        memberAddress: callerAddress,
+        weekStart,
       },
     });
 
@@ -631,6 +624,15 @@ export const submitWeeklyGoals = async (req: Request, res: Response) => {
         data: { weeklyGoals },
       });
       return res.status(200).json(updated);
+    }
+
+    // A WeeklyClaim requires a wageId, so the member needs a wage before any
+    // goals can be recorded. Only reached for a week nobody has opened yet,
+    // which is priced by resolution like a first claim would be.
+    const wage = await resolveWageForWeek(teamId, callerAddress, weekStart);
+
+    if (!wage) {
+      return errorResponse(400, 'No wage found for the user', res);
     }
 
     const created = await prisma.weeklyClaim.create({

--- a/backend/src/utils/__tests__/wageResolution.test.ts
+++ b/backend/src/utils/__tests__/wageResolution.test.ts
@@ -7,6 +7,9 @@ import {
   resolveCurrentWage,
   nextMondayUtc,
   isScheduledWage,
+  isWeekOpen,
+  effectiveFromForChange,
+  membersWithOpenWeek,
   pickWageForWeek,
   splitCurrentAndScheduled,
 } from '../wageResolution';
@@ -17,6 +20,10 @@ dayjs.extend(isoWeek);
 vi.mock('../dependenciesUtil', () => ({
   prisma: {
     wage: {
+      findMany: vi.fn(),
+    },
+    weeklyClaim: {
+      count: vi.fn(),
       findMany: vi.fn(),
     },
   },
@@ -160,6 +167,67 @@ describe('wageResolution', () => {
 
     it('is false for a missing wage', () => {
       expect(isScheduledWage(null, now)).toBe(false);
+    });
+  });
+
+  describe('isWeekOpen', () => {
+    it('counts a week with goals but no claims as open', async () => {
+      // A goals-only row is keyed by wage like any other, so a change landing
+      // on that week would split it in two exactly as claims would.
+      vi.mocked(prisma.weeklyClaim.count).mockResolvedValue(1);
+
+      expect(await isWeekOpen(1, '0xabc', week('2026-08-12'))).toBe(true);
+    });
+
+    it('is false when the member has not touched the week', async () => {
+      vi.mocked(prisma.weeklyClaim.count).mockResolvedValue(0);
+
+      expect(await isWeekOpen(1, '0xabc', week('2026-08-12'))).toBe(false);
+    });
+  });
+
+  describe('effectiveFromForChange', () => {
+    // Wednesday.
+    const now = at('2026-08-12T15:00:00.000Z');
+
+    it('waits for next Monday when the week is already open', () => {
+      expect(effectiveFromForChange(true, now).toISOString()).toBe('2026-08-17T00:00:00.000Z');
+    });
+
+    it('covers the current week whole when nothing is submitted yet', () => {
+      // Not "now": resolution compares the effective date against the start of
+      // the week, so a mid-week timestamp would skip the week it targets.
+      expect(effectiveFromForChange(false, now).toISOString()).toBe('2026-08-10T00:00:00.000Z');
+    });
+
+    it('always lands on a Monday, so a wage boundary is always a week boundary', () => {
+      expect(effectiveFromForChange(true, now).getUTCDay()).toBe(1);
+      expect(effectiveFromForChange(false, now).getUTCDay()).toBe(1);
+    });
+
+    it('applies to the week just worked when saved on a Sunday', () => {
+      const sunday = at('2026-08-16T22:00:00.000Z');
+
+      expect(effectiveFromForChange(false, sunday).toISOString()).toBe('2026-08-10T00:00:00.000Z');
+    });
+  });
+
+  describe('membersWithOpenWeek', () => {
+    it('returns the members who have already opened the current week', async () => {
+      vi.mocked(prisma.weeklyClaim.findMany).mockResolvedValue([
+        { memberAddress: '0xabc' },
+        { memberAddress: '0xdef' },
+      ] as never);
+
+      const members = await membersWithOpenWeek(1, at('2026-08-12T15:00:00.000Z'));
+
+      expect(members).toEqual(new Set(['0xabc', '0xdef']));
+    });
+
+    it('is empty when nobody has submitted anything', async () => {
+      vi.mocked(prisma.weeklyClaim.findMany).mockResolvedValue([]);
+
+      expect((await membersWithOpenWeek(1)).size).toBe(0);
     });
   });
 });

--- a/backend/src/utils/__tests__/wageResolution.test.ts
+++ b/backend/src/utils/__tests__/wageResolution.test.ts
@@ -7,9 +7,9 @@ import {
   resolveCurrentWage,
   nextMondayUtc,
   isScheduledWage,
-  isWeekOpen,
+  weekHasClaims,
   effectiveFromForChange,
-  membersWithOpenWeek,
+  membersWithClaimsThisWeek,
   pickWageForWeek,
   splitCurrentAndScheduled,
 } from '../wageResolution';
@@ -170,19 +170,22 @@ describe('wageResolution', () => {
     });
   });
 
-  describe('isWeekOpen', () => {
-    it('counts a week with goals but no claims as open', async () => {
-      // A goals-only row is keyed by wage like any other, so a change landing
-      // on that week would split it in two exactly as claims would.
-      vi.mocked(prisma.weeklyClaim.count).mockResolvedValue(1);
-
-      expect(await isWeekOpen(1, '0xabc', week('2026-08-12'))).toBe(true);
-    });
-
-    it('is false when the member has not touched the week', async () => {
+  describe('weekHasClaims', () => {
+    it('only counts weeks that hold claims', async () => {
+      // A goals-only row must not count: nothing has been priced against it, so
+      // a change still applies to that week.
       vi.mocked(prisma.weeklyClaim.count).mockResolvedValue(0);
 
-      expect(await isWeekOpen(1, '0xabc', week('2026-08-12'))).toBe(false);
+      expect(await weekHasClaims(1, '0xabc', week('2026-08-12'))).toBe(false);
+      expect(vi.mocked(prisma.weeklyClaim.count).mock.calls[0][0]).toMatchObject({
+        where: { claims: { some: {} } },
+      });
+    });
+
+    it('is true once the member has submitted hours', async () => {
+      vi.mocked(prisma.weeklyClaim.count).mockResolvedValue(1);
+
+      expect(await weekHasClaims(1, '0xabc', week('2026-08-12'))).toBe(true);
     });
   });
 
@@ -190,7 +193,7 @@ describe('wageResolution', () => {
     // Wednesday.
     const now = at('2026-08-12T15:00:00.000Z');
 
-    it('waits for next Monday when the week is already open', () => {
+    it('waits for next Monday when hours are already submitted', () => {
       expect(effectiveFromForChange(true, now).toISOString()).toBe('2026-08-17T00:00:00.000Z');
     });
 
@@ -212,22 +215,25 @@ describe('wageResolution', () => {
     });
   });
 
-  describe('membersWithOpenWeek', () => {
-    it('returns the members who have already opened the current week', async () => {
+  describe('membersWithClaimsThisWeek', () => {
+    it('returns the members who have submitted hours this week', async () => {
       vi.mocked(prisma.weeklyClaim.findMany).mockResolvedValue([
         { memberAddress: '0xabc' },
         { memberAddress: '0xdef' },
       ] as never);
 
-      const members = await membersWithOpenWeek(1, at('2026-08-12T15:00:00.000Z'));
+      const members = await membersWithClaimsThisWeek(1, at('2026-08-12T15:00:00.000Z'));
 
       expect(members).toEqual(new Set(['0xabc', '0xdef']));
+      expect(vi.mocked(prisma.weeklyClaim.findMany).mock.calls[0][0]).toMatchObject({
+        where: { claims: { some: {} } },
+      });
     });
 
     it('is empty when nobody has submitted anything', async () => {
       vi.mocked(prisma.weeklyClaim.findMany).mockResolvedValue([]);
 
-      expect((await membersWithOpenWeek(1)).size).toBe(0);
+      expect((await membersWithClaimsThisWeek(1)).size).toBe(0);
     });
   });
 });

--- a/backend/src/utils/wageResolution.ts
+++ b/backend/src/utils/wageResolution.ts
@@ -136,56 +136,54 @@ export function isScheduledWage(
 }
 
 /**
- * Has the member already opened the given week?
+ * Has the member submitted hours for the given week?
  *
- * "Opened" means a `WeeklyClaim` row exists for that member and week — whether
- * it holds daily claims or only weekly goals. Goals count: a goals-only row is
- * keyed `[wageId, weekStart]` like any other, so letting a wage change land on
- * a week that already carries one would split that week in two exactly as
- * claims would.
+ * Claims are what commits a week to a wage. A `WeeklyClaim` row holding only
+ * weekly goals does not: nothing has been priced against it yet, so a change
+ * still applies to that week — the member had not submitted their hours, which
+ * is exactly the case the rule leaves to them.
  */
-export async function isWeekOpen(
+export async function weekHasClaims(
   teamId: number,
   userAddress: string,
   weekStart: Date
 ): Promise<boolean> {
-  const opened = await prisma.weeklyClaim.count({
-    where: { teamId, memberAddress: userAddress, weekStart },
+  const submitted = await prisma.weeklyClaim.count({
+    where: { teamId, memberAddress: userAddress, weekStart, claims: { some: {} } },
   });
 
-  return opened > 0;
+  return submitted > 0;
 }
 
 /**
  * The date a wage change saved now takes effect on.
  *
- * A week the member has already opened keeps the wage it was opened with, so
- * the change is anchored to next Monday. A week nobody has touched yet takes
- * the change whole, from its own Monday: days already worked but not yet
- * submitted are then paid at the new rate. That is the trade-off the owner
- * makes by not waiting for their members to submit, and it is deliberate.
+ * A week the member has already submitted hours for keeps the wage those hours
+ * were priced against, so the change is anchored to next Monday. A week with no
+ * hours in it takes the change whole, from its own Monday: days already worked
+ * but not yet submitted are then paid at the new rate. That is the trade-off
+ * the owner makes by not waiting for their members to submit.
  *
  * Both branches return a Monday. That is what keeps a wage boundary and a week
- * boundary the same instant, so exactly one wage still covers any week and two
- * `WeeklyClaim` rows for one week remain impossible.
+ * boundary the same instant, so exactly one wage still covers any week.
  *
  * Returning "now" for the immediate case would be wrong: resolution compares
  * the effective date against the *start* of the week, so a mid-week timestamp
  * would exclude the new wage from the very week it is meant to apply to.
  */
-export function effectiveFromForChange(weekIsOpen: boolean, now?: Date): Date {
-  return weekIsOpen ? nextMondayUtc(now) : currentWeekStart(now);
+export function effectiveFromForChange(weekIsSubmitted: boolean, now?: Date): Date {
+  return weekIsSubmitted ? nextMondayUtc(now) : currentWeekStart(now);
 }
 
 /**
- * Members of a team who have already opened the current week, in one query.
+ * Members of a team who have submitted hours for the current week, in one query.
  *
  * Used to tell the owner, per member, when a change would take effect, without
  * issuing a query per row.
  */
-export async function membersWithOpenWeek(teamId: number, now?: Date): Promise<Set<string>> {
+export async function membersWithClaimsThisWeek(teamId: number, now?: Date): Promise<Set<string>> {
   const rows = await prisma.weeklyClaim.findMany({
-    where: { teamId, weekStart: currentWeekStart(now) },
+    where: { teamId, weekStart: currentWeekStart(now), claims: { some: {} } },
     select: { memberAddress: true },
     distinct: ['memberAddress'],
   });

--- a/backend/src/utils/wageResolution.ts
+++ b/backend/src/utils/wageResolution.ts
@@ -134,3 +134,61 @@ export function isScheduledWage(
   if (!wage?.effectiveFrom) return false;
   return wage.effectiveFrom > (now ?? new Date());
 }
+
+/**
+ * Has the member already opened the given week?
+ *
+ * "Opened" means a `WeeklyClaim` row exists for that member and week — whether
+ * it holds daily claims or only weekly goals. Goals count: a goals-only row is
+ * keyed `[wageId, weekStart]` like any other, so letting a wage change land on
+ * a week that already carries one would split that week in two exactly as
+ * claims would.
+ */
+export async function isWeekOpen(
+  teamId: number,
+  userAddress: string,
+  weekStart: Date
+): Promise<boolean> {
+  const opened = await prisma.weeklyClaim.count({
+    where: { teamId, memberAddress: userAddress, weekStart },
+  });
+
+  return opened > 0;
+}
+
+/**
+ * The date a wage change saved now takes effect on.
+ *
+ * A week the member has already opened keeps the wage it was opened with, so
+ * the change is anchored to next Monday. A week nobody has touched yet takes
+ * the change whole, from its own Monday: days already worked but not yet
+ * submitted are then paid at the new rate. That is the trade-off the owner
+ * makes by not waiting for their members to submit, and it is deliberate.
+ *
+ * Both branches return a Monday. That is what keeps a wage boundary and a week
+ * boundary the same instant, so exactly one wage still covers any week and two
+ * `WeeklyClaim` rows for one week remain impossible.
+ *
+ * Returning "now" for the immediate case would be wrong: resolution compares
+ * the effective date against the *start* of the week, so a mid-week timestamp
+ * would exclude the new wage from the very week it is meant to apply to.
+ */
+export function effectiveFromForChange(weekIsOpen: boolean, now?: Date): Date {
+  return weekIsOpen ? nextMondayUtc(now) : currentWeekStart(now);
+}
+
+/**
+ * Members of a team who have already opened the current week, in one query.
+ *
+ * Used to tell the owner, per member, when a change would take effect, without
+ * issuing a query per row.
+ */
+export async function membersWithOpenWeek(teamId: number, now?: Date): Promise<Set<string>> {
+  const rows = await prisma.weeklyClaim.findMany({
+    where: { teamId, weekStart: currentWeekStart(now) },
+    select: { memberAddress: true },
+    distinct: ['memberAddress'],
+  });
+
+  return new Set(rows.map((row) => row.memberAddress));
+}

--- a/docs/features/payroll/Readme.md
+++ b/docs/features/payroll/Readme.md
@@ -94,7 +94,8 @@ submit claims for fair, bounded compensation
       15h/wk, 8h/d on Aug 17, 2026"); it disappears once the change takes effect, without a page
       reload
 - [ ] _(scheduling)_ Saving again before the effective date **rewrites** the pending change and does
-      **not** push its date back; the chain gains no extra version
+      **not** push its date back; the chain gains no extra version. If the week no longer holds any
+      hours, saving again releases the change and it applies straight away
 - [ ] _(scheduling)_ A pending change can be cancelled, leaving the current wage in force
       (`DELETE /wage/scheduled`)
 - [ ] _(scheduling)_ A week that is already open never gains a second `WeeklyClaim`: a claim finds

--- a/docs/features/payroll/Readme.md
+++ b/docs/features/payroll/Readme.md
@@ -80,15 +80,16 @@ submit claims for fair, bounded compensation
       "8h/d" (tooltip "Daily limit: N hours"); the cell shows "—" when the member has no wage
 - [ ] Editing a member with an existing wage pre-fills the current values; saving creates a new wage
       **version** (one active wage per member)
-- [ ] _(scheduling)_ Changing a wage for a member who has **already submitted** something this week
-      (hours or goals) takes effect at the **start of the next ISO week**: that week is already
-      priced by the wage it was opened with and keeps it
-- [ ] _(scheduling)_ Changing a wage for a member who has **submitted nothing** this week applies
+- [ ] _(scheduling)_ Changing a wage for a member who has **already submitted hours** this week
+      takes effect at the **start of the next ISO week**: those hours are priced against the current
+      wage and the week keeps it
+- [ ] _(scheduling)_ Changing a wage for a member who has **submitted no hours** this week applies
       **immediately, to the whole week** — including the days they have already worked but not yet
-      submitted. Waiting for them to submit is how the owner avoids that
-- [ ] _(scheduling)_ The modal says which of the two is about to happen, before saving ("This change
-      takes effect immediately, for the whole current week." / "This change takes effect on Aug 17,
-      2026.")
+      submitted. Nothing is announced in that case: the week is simply priced at the new wage.
+      Waiting for the member to submit is how the owner avoids it
+- [ ] _(scheduling)_ Weekly goals alone do not hold a week to its wage — only submitted hours do
+- [ ] _(scheduling)_ The modal warns **only** when the change has to wait ("This change takes effect
+      on Aug 17, 2026."), and says nothing when it applies straight away
 - [ ] _(scheduling)_ The member row shows a badge for a change that waits ("Changes to SHER 10/h,
       15h/wk, 8h/d on Aug 17, 2026"); it disappears once the change takes effect, without a page
       reload

--- a/docs/features/payroll/Readme.md
+++ b/docs/features/payroll/Readme.md
@@ -80,18 +80,24 @@ submit claims for fair, bounded compensation
       "8h/d" (tooltip "Daily limit: N hours"); the cell shows "—" when the member has no wage
 - [ ] Editing a member with an existing wage pre-fills the current values; saving creates a new wage
       **version** (one active wage per member)
-- [ ] _(scheduling)_ Changing an existing wage takes effect at the **start of the next ISO week**,
-      not immediately; the current rates and caps hold until then, including for claims backdated to
-      earlier weeks. A member's **first** wage is the only one that applies immediately
-- [ ] _(scheduling)_ The modal states the effective date before saving ("This change takes effect on
-      Aug 17, 2026")
-- [ ] _(scheduling)_ The member row shows a badge for the pending change ("Changes to SHER 10/h,
+- [ ] _(scheduling)_ Changing a wage for a member who has **already submitted** something this week
+      (hours or goals) takes effect at the **start of the next ISO week**: that week is already
+      priced by the wage it was opened with and keeps it
+- [ ] _(scheduling)_ Changing a wage for a member who has **submitted nothing** this week applies
+      **immediately, to the whole week** — including the days they have already worked but not yet
+      submitted. Waiting for them to submit is how the owner avoids that
+- [ ] _(scheduling)_ The modal says which of the two is about to happen, before saving ("This change
+      takes effect immediately, for the whole current week." / "This change takes effect on Aug 17,
+      2026.")
+- [ ] _(scheduling)_ The member row shows a badge for a change that waits ("Changes to SHER 10/h,
       15h/wk, 8h/d on Aug 17, 2026"); it disappears once the change takes effect, without a page
       reload
 - [ ] _(scheduling)_ Saving again before the effective date **rewrites** the pending change and does
       **not** push its date back; the chain gains no extra version
 - [ ] _(scheduling)_ A pending change can be cancelled, leaving the current wage in force
       (`DELETE /wage/scheduled`)
+- [ ] _(scheduling)_ A week that is already open never gains a second `WeeklyClaim`: a claim finds
+      its week by member and week, so hour caps keep counting on the same row
 
 > Full behaviour, edge cases and API shapes: [Wage scheduling](./wage-scheduling.md).
 

--- a/docs/features/payroll/wage-scheduling.md
+++ b/docs/features/payroll/wage-scheduling.md
@@ -1,11 +1,12 @@
 # Wage scheduling — how a rate change lands on a week
 
-**Last updated:** 2026-08-12 **Issue:** #2479 **Scope:** backend wage resolution, `GET /wage`,
+**Last updated:** 2026-08-15 **Issue:** #2479 **Scope:** backend wage resolution, `GET /wage`,
 `GET /team/:id`, member table and claim views.
 
 ## The rule, in one line
 
-**The week worked determines the wage — never the date the claim was entered.**
+**A week that has been opened keeps the wage it was opened with; a week nobody has touched takes the
+change whole.**
 
 Everything below follows from that.
 
@@ -34,26 +35,45 @@ The consequences were the interesting part:
 
 ## The rule in practice
 
-Two mechanisms, and they only work together.
+Three mechanisms, and they only work together.
 
-### 1. Changes are anchored to a Monday
+### 1. The week's own row decides which wage prices it
 
-`setWage` never activates a change in the middle of a week. The new row is created with
-`effectiveFrom` set to the **start of the next ISO week** (Monday 00:00 UTC) and the predecessor
-stays operative until then.
+A claim finds its week by `[teamId, memberAddress, weekStart]` — not by wage. When that row exists
+it already carries a `wageId`, and that is the wage the claim is priced and capped against, whatever
+the owner has saved since.
 
-The single exception is a member's **very first wage**, which takes effect immediately — otherwise a
-new joiner could not claim anything before Monday.
+This is what makes a second `WeeklyClaim` for one week impossible, and it holds on its own: no
+invariant about Mondays is needed for it to be true. Weekly goals follow the same lookup, because a
+goals-only row opens a week just as claims do.
 
-This is unconditional. It does not depend on whether claims already exist this week. A conditional
-rule was considered and rejected: it leaves a wage boundary falling mid-week in some cases, and
-every downstream question ("which cap applies on Wednesday?") then has two answers.
+Resolution is only consulted for a week nobody has opened yet.
 
-The consequence to be aware of: **a wrong rate cannot be corrected in-week.** If the owner saves 2.5
-instead of 25 and the week already has claims, the members are paid at 2.5 until Sunday. This was a
-deliberate product decision — one predictable rule beat an escape hatch.
+### 2. A change waits only when it has to
 
-### 2. Resolution is done per week, not per "now"
+`setWage` looks at the member's current week:
+
+| State of the current week            | `effectiveFrom`                  |
+| ------------------------------------ | -------------------------------- |
+| Already opened (claims **or** goals) | Next Monday 00:00 UTC            |
+| Untouched                            | **This** week's Monday 00:00 UTC |
+
+The second branch is the one that matters: the change covers the whole current week, including days
+the member has worked but not yet submitted. That is deliberate — the owner who does not want it
+waits for their members to submit first, and the modal says which of the two is about to happen.
+
+Note what `effectiveFrom` is **not** in the immediate case: it is not "now". Resolution compares the
+effective date against the _start_ of the week (below), so a mid-week timestamp would exclude the
+new wage from the very week it is meant to cover.
+
+Both branches return a Monday, so a wage boundary is always a week boundary and exactly one wage
+covers any week. A member's **first** wage follows the same rule and lands on the current Monday.
+
+The consequence to be aware of: **a wrong rate cannot be corrected in-week once the week is open.**
+If the owner saves 2.5 instead of 25 and someone has already submitted, that member is paid at 2.5
+until Sunday. Members who have submitted nothing are corrected right away.
+
+### 3. Resolution is done per week, not per "now"
 
 `resolveWageForWeek(teamId, userAddress, weekStart)` walks the chain and returns the last wage whose
 effective date is at or before `weekStart`, where
@@ -66,19 +86,20 @@ effective date = effectiveFrom ?? createdAt
 effect the moment they were created.
 
 Anchoring changes to Mondays is what makes this exact: a wage boundary and a week boundary are the
-same instant, so **exactly one wage covers any week**. Resolving on "now" instead would reintroduce
-the split through backdated claims — see [Case B](#b--backdating-into-an-earlier-week) below.
+same instant, so **exactly one wage covers any week**. Resolving on "now" instead would price a
+backdated claim at today's rate — see [Case B](#b--backdating-into-an-earlier-week) below.
 
 ### One rule, one implementation
 
-`pickWageForWeek` is the pure function that decides. Everything else calls it:
+`pickWageForWeek` is the pure function that decides, for weeks that are not open yet. Everything
+else calls it:
 
-| Caller              | Purpose                                         |
-| ------------------- | ----------------------------------------------- |
-| `addClaim`          | Wage a daily claim is priced and capped against |
-| `submitWeeklyGoals` | Wage the goals row is attached to               |
-| `GET /wage`         | Rates and caps the claim form validates against |
-| `GET /team/:id`     | `currentWage` in the member table               |
+| Caller              | Purpose                                                                              |
+| ------------------- | ------------------------------------------------------------------------------------ |
+| `addClaim`          | Wage a daily claim is priced and capped against, **if the week is not already open** |
+| `submitWeeklyGoals` | Wage the goals row is attached to, under the same condition                          |
+| `GET /wage`         | Rates and caps the claim form validates against                                      |
+| `GET /team/:id`     | `currentWage` in the member table                                                    |
 
 This matters more than it looks. Deriving the displayed wage as "the leaf, unless scheduled" _seems_
 equivalent, and it is for rows written by this feature — but not for legacy rows, where
@@ -95,12 +116,18 @@ from that same function, so the two cannot drift.
 
 ### A — The current week
 
-| Situation                | Behaviour                                                       |
-| ------------------------ | --------------------------------------------------------------- |
-| No change                | The chain's only operative wage applies                         |
-| Change saved this week   | Scheduled for next Monday; **this week keeps the current wage** |
-| Member's first wage ever | Applies immediately                                             |
-| Wage is disabled         | `setWage` refused (400); claims refused                         |
+| Situation                                    | Behaviour                                                       |
+| -------------------------------------------- | --------------------------------------------------------------- |
+| No change                                    | The chain's only operative wage applies                         |
+| Change saved, member has already submitted   | Scheduled for next Monday; **this week keeps the current wage** |
+| Change saved, member has submitted nothing   | Applies from this week's Monday, to the whole week              |
+| Member submits **after** an immediate change | Their week opens on the new wage, days already worked included  |
+| Member's first wage ever                     | Applies from this week's Monday                                 |
+| Wage is disabled                             | `setWage` refused (400); claims refused                         |
+
+The third and fourth rows are the same event seen from each side, and they are the deliberate cost
+of the rule: the owner who changes a wage before their member submits repriced that member's week.
+Waiting for the submission is the way out, and the modal says so before the owner saves.
 
 ### B — Backdating into an earlier week
 
@@ -108,20 +135,21 @@ Only reachable when `SUBMIT_RESTRICTION` is `disabled` or `beta`. When active (t
 including when unconfigured) `dayWorked` is confined to the current ISO week, at most 4 days back,
 so a claim can never cross a week boundary.
 
-| State of the target week      | Behaviour                                           |
-| ----------------------------- | --------------------------------------------------- |
-| `WeeklyClaim` exists, pending | Joins it; caps recount against **that week's** wage |
-| `WeeklyClaim` signed          | `409 Week already signed`                           |
-| `WeeklyClaim` withdrawn       | `409 Week already withdrawn`                        |
-| `WeeklyClaim` disabled        | `409 Week is disabled`                              |
-| No `WeeklyClaim` yet          | A new one is created for that past week, pending    |
+| State of the target week      | Behaviour                                                       |
+| ----------------------------- | --------------------------------------------------------------- |
+| `WeeklyClaim` exists, pending | Joins it; caps recount against **that row's** wage              |
+| `WeeklyClaim` signed          | `409 Week already signed`                                       |
+| `WeeklyClaim` withdrawn       | `409 Week already withdrawn`                                    |
+| `WeeklyClaim` disabled        | `409 Week is disabled`                                          |
+| No `WeeklyClaim` yet          | A new one is created, priced at the wage that covered that week |
 
 The last row is intentional. A member who simply **forgot** to submit for earlier weeks must be able
 to catch up, and that is indistinguishable from "reopening" a week at the data level. The catch-up
 follows the normal cycle: the owner still approves it.
 
-What makes this safe is that the claim is priced at that week's wage, so caps and rates are the ones
-that were in force, and the claim lands on the week's existing row instead of opening a rival one.
+What makes this safe is that the claim lands on the week's existing row instead of opening a rival
+one, and is priced by that row — so caps and rates are the ones that were in force when the week was
+opened.
 
 ### C — The owner made a mistake
 
@@ -155,9 +183,10 @@ the earliest wage is used instead.
 ## What changes with the daily cap
 
 `maximumHoursPerDay` is a field on the wage like the rate, so it follows exactly the same rule.
-Changing it mid-week does **not** tighten the current week — the old ceiling holds until Sunday, the
-new one applies from Monday, and a backdated claim is measured against the ceiling of the week it
-targets.
+Tightening it does **not** touch a week the member has already opened — the old ceiling holds until
+Sunday and the new one applies from Monday — while a week they have not opened is measured against
+the new ceiling from its own Monday. A backdated claim is measured against the ceiling carried by
+the week it targets.
 
 The same holds for `maximumHoursPerWeek` and the overtime settings.
 
@@ -177,23 +206,32 @@ Returns the wage **in force now** per member, with any pending change attached:
     "maximumHoursPerWeek": 20,
     "maximumHoursPerDay": 8,
     "effectiveFrom": null,
-    "scheduledWage": {          // null when nothing is pending
+    // The Monday a change saved right now would take effect on. This week's
+    // when the member has not opened it, next week's when they have.
+    "nextChangeEffectiveFrom": "2026-08-17T00:00:00.000Z",
+    "scheduledWage": {
+      // null when nothing is pending
       "id": 2,
       "ratePerHour": [{ "type": "sher", "amount": 10 }],
       "maximumHoursPerWeek": 15,
       "maximumHoursPerDay": 8,
-      "effectiveFrom": "2026-08-17T00:00:00.000Z"
-    }
-  }
+      "effectiveFrom": "2026-08-17T00:00:00.000Z",
+    },
+  },
 ]
 ```
 
 The top-level object is what the claim form must validate against. Returning the scheduled wage
 there would make the form accept hours the server then rejects.
 
+`nextChangeEffectiveFrom` exists so the set-wage modal never announces a date the server would not
+honour: the front end cannot know whether a member has opened their week, and a rule implemented
+twice is a rule that drifts.
+
 ### `PUT /wage/setWage`
 
-- `201` with the newly scheduled wage when a change is queued
+- `201` with the new wage — scheduled for next Monday, or effective from this week's Monday when the
+  member has not opened the week; `effectiveFrom` on the response says which
 - `200` with the rewritten wage when a scheduled change is corrected in place
 - `400` when the operative wage is disabled
 
@@ -211,11 +249,17 @@ Each member carries `currentWage` and `scheduledWage`, resolved the same way.
 
 ## What the user sees
 
-| Surface              | Content                                                                    |
-| -------------------- | -------------------------------------------------------------------------- |
-| Member table (owner) | Badge under the rate: `Changes to SHER 10/h, 15h/wk, 8h/d on Aug 17, 2026` |
-| Set-wage modal       | Banner stating the effective date **before** the owner saves               |
-| Claim view (member)  | Same notice, **only on weeks that predate the change**                     |
+| Surface              | Content                                                                      |
+| -------------------- | ---------------------------------------------------------------------------- |
+| Member table (owner) | Badge under the rate: `Changes to SHER 10/h, 15h/wk, 8h/d on Aug 17, 2026`   |
+| Set-wage modal       | Banner stating **which** of the two outcomes applies, before the owner saves |
+| Claim view (member)  | Same notice, **only on weeks that predate the change**                       |
+
+The modal has two states, and the distinction is the point of it:
+
+- the member has not opened the week — an amber banner naming them: the change is immediate and
+  covers hours they have already worked, so the owner can still choose to wait
+- the member has opened it — the date, and the fact that this week keeps the current rate
 
 The last condition matters: on the week the change takes effect, that week already runs on the new
 wage, so announcing it as upcoming — and saying the week keeps the current rate — would be false.
@@ -267,9 +311,15 @@ wage has `effectiveFrom = null` and keeps behaving as it did.
 - The **Overtime Wage** column shows no indicator when an overtime change is scheduled, even though
   the badge in the Standard column already covers the same wage row.
 - There is no way to schedule a change for a week **further out** than the next Monday.
-- `hasPendingClaimsThisWeek` was removed with the conditional rule; if a future change reintroduces
-  conditional scheduling, note that `WeeklyClaim.status` is nullable on legacy rows and a plain
-  `status: 'pending'` filter misses them.
+- Nothing at the database level forbids two `WeeklyClaim` rows for one member-week: the uniqueness
+  is `[wageId, weekStart]`, and it is the lookup in `addClaim` that makes a second row unreachable.
+  A `[teamId, memberAddress, weekStart]` unique index would make it structural, but the migration
+  has to dedupe rows the original bug may already have created in production.
+- A week the member never opened is priced by resolution, so a forgotten past week is paid at the
+  wage that covered it — not at the wage in force when they finally submit. That is the intended
+  reading of "the week worked determines the wage", but it is worth knowing it is a choice.
+- `WeeklyClaim.status` is nullable on legacy rows. `isWeekOpen` counts rows rather than filtering on
+  `status: 'pending'` for that reason; a status filter added later would silently miss them.
 
 ---
 

--- a/docs/features/payroll/wage-scheduling.md
+++ b/docs/features/payroll/wage-scheduling.md
@@ -161,12 +161,19 @@ measured against.
 | --------------------------------- | -------------------------------------------------------------------------------------------- |
 | Corrects before Monday            | The scheduled row is **rewritten in place** — no new link in the chain                       |
 | Corrects several times            | Still one rewrite each time; the chain stays two links long                                  |
-| Effective date after a correction | **Unchanged** — fixing a typo does not push the change back a week                           |
+| Effective date after a correction | **Recomputed** — see below                                                                   |
 | Wants to call it off              | `DELETE /wage/scheduled` removes the row and restores `nextWageId = null` on the predecessor |
 | Corrects after it took effect     | Normal path: a new wage scheduled for the following Monday                                   |
 
 Rewriting in place is safe precisely because a scheduled wage has never been operative — no claim,
 no `WeeklyClaim`, no signature references it.
+
+The effective date is recomputed on every save rather than preserved, because the reason a change
+waits can disappear: the week's hours can be withdrawn, or the change can have been queued under an
+older rule. A wait that outlives its reason cannot be released by any other route, since the change
+is not visible as an editable row anywhere. Recomputing can only pull the date **forward** to the
+current Monday — a week that still holds hours yields the same next Monday it did before — so a
+correction never pushes the change back a week.
 
 ### D — Boundaries
 

--- a/docs/features/payroll/wage-scheduling.md
+++ b/docs/features/payroll/wage-scheduling.md
@@ -5,8 +5,8 @@
 
 ## The rule, in one line
 
-**A week that has been opened keeps the wage it was opened with; a week nobody has touched takes the
-change whole.**
+**A week that holds submitted hours keeps the wage they were priced against; a week with no hours in
+it takes the change whole.**
 
 Everything below follows from that.
 
@@ -35,32 +35,34 @@ The consequences were the interesting part:
 
 ## The rule in practice
 
-Three mechanisms, and they only work together.
+Four mechanisms, and they only work together.
 
-### 1. The week's own row decides which wage prices it
+### 1. One week, one row
 
-A claim finds its week by `[teamId, memberAddress, weekStart]` — not by wage. When that row exists
-it already carries a `wageId`, and that is the wage the claim is priced and capped against, whatever
-the owner has saved since.
+A claim finds its week by `[teamId, memberAddress, weekStart]` — never by wage. One week therefore
+always has one row, and the split that produced this issue has nowhere to happen. No invariant about
+Mondays is needed for that to hold. Weekly goals use the same lookup.
 
-This is what makes a second `WeeklyClaim` for one week impossible, and it holds on its own: no
-invariant about Mondays is needed for it to be true. Weekly goals follow the same lookup, because a
-goals-only row opens a week just as claims do.
+### 2. Submitted hours commit a week to a wage; nothing else does
 
-Resolution is only consulted for a week nobody has opened yet.
+When the row already holds claims, the wage recorded on it is what prices and caps the week,
+whatever the owner has saved since.
 
-### 2. A change waits only when it has to
+When it holds no claims — an empty week, or a row carrying only weekly goals — nothing has been
+priced yet, so the week follows the change like any untouched week: the first hours are priced at
+the wage in force and the row moves onto it. Goals are a note to self, not a commitment.
+
+This is the whole of the reviewed rule: a member who had not submitted their hours before the change
+is impacted by it, and that is left to them and the owner to sort out.
+
+### 3. A change waits only when it has to
 
 `setWage` looks at the member's current week:
 
-| State of the current week            | `effectiveFrom`                  |
-| ------------------------------------ | -------------------------------- |
-| Already opened (claims **or** goals) | Next Monday 00:00 UTC            |
-| Untouched                            | **This** week's Monday 00:00 UTC |
-
-The second branch is the one that matters: the change covers the whole current week, including days
-the member has worked but not yet submitted. That is deliberate — the owner who does not want it
-waits for their members to submit first, and the modal says which of the two is about to happen.
+| State of the current week | `effectiveFrom`                  |
+| ------------------------- | -------------------------------- |
+| Holds submitted hours     | Next Monday 00:00 UTC            |
+| No hours in it            | **This** week's Monday 00:00 UTC |
 
 Note what `effectiveFrom` is **not** in the immediate case: it is not "now". Resolution compares the
 effective date against the _start_ of the week (below), so a mid-week timestamp would exclude the
@@ -69,11 +71,11 @@ new wage from the very week it is meant to cover.
 Both branches return a Monday, so a wage boundary is always a week boundary and exactly one wage
 covers any week. A member's **first** wage follows the same rule and lands on the current Monday.
 
-The consequence to be aware of: **a wrong rate cannot be corrected in-week once the week is open.**
-If the owner saves 2.5 instead of 25 and someone has already submitted, that member is paid at 2.5
+The consequence to be aware of: **a wrong rate cannot be corrected in-week once hours are in.** If
+the owner saves 2.5 instead of 25 and someone has already submitted, that member is paid at 2.5
 until Sunday. Members who have submitted nothing are corrected right away.
 
-### 3. Resolution is done per week, not per "now"
+### 4. Resolution is done per week, not per "now"
 
 `resolveWageForWeek(teamId, userAddress, weekStart)` walks the chain and returns the last wage whose
 effective date is at or before `weekStart`, where
@@ -91,15 +93,15 @@ backdated claim at today's rate — see [Case B](#b--backdating-into-an-earlier-
 
 ### One rule, one implementation
 
-`pickWageForWeek` is the pure function that decides, for weeks that are not open yet. Everything
+`pickWageForWeek` is the pure function that decides, for weeks with no hours in them yet. Everything
 else calls it:
 
-| Caller              | Purpose                                                                              |
-| ------------------- | ------------------------------------------------------------------------------------ |
-| `addClaim`          | Wage a daily claim is priced and capped against, **if the week is not already open** |
-| `submitWeeklyGoals` | Wage the goals row is attached to, under the same condition                          |
-| `GET /wage`         | Rates and caps the claim form validates against                                      |
-| `GET /team/:id`     | `currentWage` in the member table                                                    |
+| Caller              | Purpose                                                                                  |
+| ------------------- | ---------------------------------------------------------------------------------------- |
+| `addClaim`          | Wage a daily claim is priced and capped against, **unless the week already holds hours** |
+| `submitWeeklyGoals` | Wage a goals row is created with, when the week does not exist yet                       |
+| `GET /wage`         | Rates and caps the claim form validates against                                          |
+| `GET /team/:id`     | `currentWage` in the member table                                                        |
 
 This matters more than it looks. Deriving the displayed wage as "the leaf, unless scheduled" _seems_
 equivalent, and it is for rows written by this feature — but not for legacy rows, where
@@ -116,18 +118,20 @@ from that same function, so the two cannot drift.
 
 ### A — The current week
 
-| Situation                                    | Behaviour                                                       |
-| -------------------------------------------- | --------------------------------------------------------------- |
-| No change                                    | The chain's only operative wage applies                         |
-| Change saved, member has already submitted   | Scheduled for next Monday; **this week keeps the current wage** |
-| Change saved, member has submitted nothing   | Applies from this week's Monday, to the whole week              |
-| Member submits **after** an immediate change | Their week opens on the new wage, days already worked included  |
-| Member's first wage ever                     | Applies from this week's Monday                                 |
-| Wage is disabled                             | `setWage` refused (400); claims refused                         |
+| Situation                                     | Behaviour                                                          |
+| --------------------------------------------- | ------------------------------------------------------------------ |
+| No change                                     | The chain's only operative wage applies                            |
+| Change saved, member has submitted hours      | Scheduled for next Monday; **this week keeps the current wage**    |
+| Change saved, member has submitted no hours   | Applies from this week's Monday, to the whole week                 |
+| Change saved, member has only set their goals | Same: goals commit nothing, the week takes the change              |
+| Member submits **after** an immediate change  | Their week is priced at the new wage, days already worked included |
+| Member's first wage ever                      | Applies from this week's Monday                                    |
+| Wage is disabled                              | `setWage` refused (400); claims refused                            |
 
-The third and fourth rows are the same event seen from each side, and they are the deliberate cost
-of the rule: the owner who changes a wage before their member submits repriced that member's week.
-Waiting for the submission is the way out, and the modal says so before the owner saves.
+Rows three to five are the deliberate cost of the rule: the owner who changes a wage before their
+member submits repriced that member's week. Waiting for the submission is the way out. Nothing is
+announced when it happens — the week is simply priced at the new wage, and there is no pending state
+to describe.
 
 ### B — Backdating into an earlier week
 
@@ -148,8 +152,8 @@ to catch up, and that is indistinguishable from "reopening" a week at the data l
 follows the normal cycle: the owner still approves it.
 
 What makes this safe is that the claim lands on the week's existing row instead of opening a rival
-one, and is priced by that row — so caps and rates are the ones that were in force when the week was
-opened.
+one, and is priced by that row — so caps and rates are the ones the hours already in it were
+measured against.
 
 ### C — The owner made a mistake
 
@@ -183,10 +187,10 @@ the earliest wage is used instead.
 ## What changes with the daily cap
 
 `maximumHoursPerDay` is a field on the wage like the rate, so it follows exactly the same rule.
-Tightening it does **not** touch a week the member has already opened — the old ceiling holds until
-Sunday and the new one applies from Monday — while a week they have not opened is measured against
-the new ceiling from its own Monday. A backdated claim is measured against the ceiling carried by
-the week it targets.
+Tightening it does **not** touch a week the member has already submitted hours for — the old ceiling
+holds until Sunday and the new one applies from Monday — while a week with no hours in it is
+measured against the new ceiling from its own Monday. A backdated claim is measured against the
+ceiling carried by the week it targets.
 
 The same holds for `maximumHoursPerWeek` and the overtime settings.
 
@@ -207,7 +211,7 @@ Returns the wage **in force now** per member, with any pending change attached:
     "maximumHoursPerDay": 8,
     "effectiveFrom": null,
     // The Monday a change saved right now would take effect on. This week's
-    // when the member has not opened it, next week's when they have.
+    // when the member has submitted no hours, next week's when they have.
     "nextChangeEffectiveFrom": "2026-08-17T00:00:00.000Z",
     "scheduledWage": {
       // null when nothing is pending
@@ -224,14 +228,14 @@ Returns the wage **in force now** per member, with any pending change attached:
 The top-level object is what the claim form must validate against. Returning the scheduled wage
 there would make the form accept hours the server then rejects.
 
-`nextChangeEffectiveFrom` exists so the set-wage modal never announces a date the server would not
-honour: the front end cannot know whether a member has opened their week, and a rule implemented
-twice is a rule that drifts.
+`nextChangeEffectiveFrom` is what tells the modal whether to warn at all, and with which date. The
+front end cannot know whether a member has submitted hours, and a rule implemented twice is a rule
+that drifts.
 
 ### `PUT /wage/setWage`
 
 - `201` with the new wage — scheduled for next Monday, or effective from this week's Monday when the
-  member has not opened the week; `effectiveFrom` on the response says which
+  member has submitted no hours; `effectiveFrom` on the response says which
 - `200` with the rewritten wage when a scheduled change is corrected in place
 - `400` when the operative wage is disabled
 
@@ -249,17 +253,18 @@ Each member carries `currentWage` and `scheduledWage`, resolved the same way.
 
 ## What the user sees
 
-| Surface              | Content                                                                      |
-| -------------------- | ---------------------------------------------------------------------------- |
-| Member table (owner) | Badge under the rate: `Changes to SHER 10/h, 15h/wk, 8h/d on Aug 17, 2026`   |
-| Set-wage modal       | Banner stating **which** of the two outcomes applies, before the owner saves |
-| Claim view (member)  | Same notice, **only on weeks that predate the change**                       |
+| Surface              | Content                                                                    |
+| -------------------- | -------------------------------------------------------------------------- |
+| Member table (owner) | Badge under the rate: `Changes to SHER 10/h, 15h/wk, 8h/d on Aug 17, 2026` |
+| Set-wage modal       | Banner **only when the change has to wait**, stating the date              |
+| Claim view (member)  | Same notice, **only on weeks that predate the change**                     |
 
-The modal has two states, and the distinction is the point of it:
+Nothing is shown when the change takes effect straight away, and that is on purpose. There is no
+pending state to describe: the member's week is simply priced at the new wage. Announcing it would
+put a notice on the common path to say that saving a wage saved the wage.
 
-- the member has not opened the week — an amber banner naming them: the change is immediate and
-  covers hours they have already worked, so the owner can still choose to wait
-- the member has opened it — the date, and the fact that this week keeps the current rate
+Every surface here therefore describes the same single thing — a change that is waiting — which is
+also why they all key off `scheduledWage` being present.
 
 The last condition matters: on the week the change takes effect, that week already runs on the new
 wage, so announcing it as upcoming — and saying the week keeps the current rate — would be false.
@@ -315,11 +320,14 @@ wage has `effectiveFrom = null` and keeps behaving as it did.
   is `[wageId, weekStart]`, and it is the lookup in `addClaim` that makes a second row unreachable.
   A `[teamId, memberAddress, weekStart]` unique index would make it structural, but the migration
   has to dedupe rows the original bug may already have created in production.
-- A week the member never opened is priced by resolution, so a forgotten past week is paid at the
-  wage that covered it — not at the wage in force when they finally submit. That is the intended
-  reading of "the week worked determines the wage", but it is worth knowing it is a choice.
-- `WeeklyClaim.status` is nullable on legacy rows. `isWeekOpen` counts rows rather than filtering on
-  `status: 'pending'` for that reason; a status filter added later would silently miss them.
+- A week with no hours in it is priced by resolution, so a forgotten past week is paid at the wage
+  that covered it — not at the wage in force when they finally submit. That is the intended reading
+  of "the week worked determines the wage", but it is worth knowing it is a choice.
+- `WeeklyClaim.status` is nullable on legacy rows. `weekHasClaims` counts rows holding claims rather
+  than filtering on `status: 'pending'`; a status filter added later would silently miss them.
+- A goals-only row keeps pointing at its original wage until the first hours arrive. Nothing is
+  priced against it in the meantime, so this is invisible — but a screen reading the wage off a
+  goals-only week would show a superseded one.
 
 ---
 


### PR DESCRIPTION
# Description


- **Submitted hours hold a week to its wage** — nothing else does. A week with no hours in it, even
  one carrying weekly goals, takes the change whole from its own Monday, days already worked
  included.
- **A week is found by member and week, never by wage**, so it always has one row and cannot split.
  When the first hours land on a goals-only week, the row moves onto the wage that prices them.
- **Nothing is displayed when a change just takes effect.** The set-wage window warns only when the
  change has to wait.
- **A wait ends when its reason does.** The effective date is recomputed on each save, so a change
  queued while the week held hours stops waiting once it no longer does. It can only move forward,
  never back a week.

Left open, and noted in the feature notes: no database constraint forbids two rows for one
member-week — the lookup does. Making it structural needs a migration that first cleans up rows the
original bug may have left behind.

Fixed  #2479
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

- **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

## Validation

`backend`: lint clean, 778 unit tests. `app`: lint clean, 202 tests across the affected views. Docs:
markdown lint and format clean.
